### PR TITLE
[FE] 로그인 페이지 UI 구현 및 인증 API 연동

### DIFF
--- a/features/auth/LoginPage.tsx
+++ b/features/auth/LoginPage.tsx
@@ -1,13 +1,14 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '../../shared/components/Button';
 import { Input } from '../../shared/components/Input';
 import { LogoWithSubtitle } from '../../shared/components/Logo';
+import type { AxiosError } from 'axios';
 import { useLogin } from '../../src/hooks/useAuth';
 import { useAuthStore } from '../../src/store/authStore';
 import { loginSchema, type LoginFormData } from '../../src/validation/auth';
+import type { ErrorResponse } from '../../src/types/api.types';
 import svgPaths from "../../imports/svg-1z9x9otd1u";
 import { imgGroup } from "../../imports/svg-cdk78";
 
@@ -99,15 +100,19 @@ function LoginLeftPanel() {
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const { isAuthenticated } = useAuthStore();
   const loginMutation = useLogin();
-  const [formError, setFormError] = useState('');
 
   const { register, handleSubmit, formState: { errors } } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
   });
 
+  // 이미 인증된 사용자는 대시보드로 리다이렉트
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
   const onSubmit = (data: LoginFormData) => {
-    setFormError('');
     loginMutation.mutate(data);
   };
 
@@ -220,8 +225,10 @@ export default function LoginPage() {
                         <p className="text-red-500 font-detail-small mt-1">{errors.password.message}</p>
                       )}
                     </div>
-                    {formError && (
-                      <p className="text-red-500 font-body-small">{formError}</p>
+                    {loginMutation.isError && (
+                      <p className="text-red-500 font-body-small">
+                        {(loginMutation.error as AxiosError<ErrorResponse>)?.response?.data?.message || '로그인에 실패했습니다. 다시 시도해주세요.'}
+                      </p>
                     )}
                     <p className="font-detail-medium leading-none text-[var(--color-text-tertiary)] text-right w-full cursor-pointer hover:text-[var(--color-primary-main)]">
                         아이디 찾기 / 비밀번호 초기화

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -16,7 +16,7 @@ export const useLogin = () => {
     mutationFn: authApi.login,
     onSuccess: (data) => {
       const user = data.user;
-      // Redirect based on role
+      toast.success(`${user.name}님, 환영합니다.`);
       if (!user.role || user.role.code === 'GUEST') {
         navigate('/permission/request');
       } else {


### PR DESCRIPTION
## 작업 내용
- 로그인 폼 Zod 유효성 검사 + react-hook-form 연동
- `POST /api/v1/auth/login` API 연동 (useLogin hook)
- `GET /api/v1/auth/me` 를 통한 사용자 정보 조회
- 역할 기반 리다이렉트 (GUEST → 권한요청, 그 외 → 대시보드)
- 인증된 사용자 자동 리다이렉트 처리
- 서버 에러 메시지 폼 인라인 표시
- 에러 코드별 처리: `A003` (자격증명 오류), `U010` (Rate limit)

## 변경 파일
- `features/auth/LoginPage.tsx` — 인증 리다이렉트, 에러 인라인 표시
- `src/hooks/useAuth.ts` — 로그인 성공 toast 메시지 추가

## 테스트
- [x] 이메일/비밀번호 유효성 검사 동작 확인
- [x] 로그인 API 호출 및 토큰 저장 확인
- [x] 에러 시 인라인 메시지 표시 확인
- [x] 인증 사용자 대시보드 리다이렉트 확인

Closes #33