### PR TITLE
[FE] 회원가입 페이지 UI 구현 및 API 연동

### DIFF
--- a/features/auth/SignupStep1Page.tsx
+++ b/features/auth/SignupStep1Page.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import { Logo } from '../../shared/components/Logo';
 import { Checkbox, RadioButton } from '../../shared/components/FormControls';
 
@@ -10,44 +11,43 @@ export default function SignupStep1Page() {
 
   const handleNext = () => {
     if (agreeTerms === true) {
-      navigate('/signup/step2');
+      navigate('/signup/step2', { state: { termsAgreed: true } });
     } else {
-      alert('개인정보 수집 및 이용에 동의해주세요.');
+      toast.error('개인정보 수집 및 이용에 동의해주세요.');
     }
   };
 
   return (
-    <div className="absolute bg-[var(--color-page-bg)] content-stretch flex flex-col h-[1080px] items-start left-0 overflow-clip p-[70px] top-0 w-[1920px]">
-      <div className="content-stretch flex flex-col items-start relative shadow-[var(--shadow-card)] shrink-0 w-full">
-        <div className="bg-white relative rounded-[var(--radius-card)] shrink-0 w-full">
+    <div className="bg-[var(--color-page-bg)] min-h-screen w-full flex items-center justify-center p-4 lg:p-[70px]">
+      <div className="w-full max-w-[1776px] shadow-[var(--shadow-card)]">
+        <div className="bg-white rounded-[var(--radius-card)] w-full">
           <div className="overflow-clip rounded-[inherit] size-full">
-            <div className="content-stretch flex items-start p-[24px] relative w-full">
-              {/* Content */}
-              <div className="flex-[1_0_0] min-h-px min-w-px relative rounded-[var(--radius-card)]">
+            <div className="flex items-start p-[24px] relative w-full">
+              <div className="flex-1 min-h-px min-w-px rounded-[var(--radius-card)]">
                 <div className="overflow-clip rounded-[inherit] size-full">
-                  <div className="content-stretch flex flex-col gap-[24px] items-start p-[24px] relative w-full">
+                  <div className="flex flex-col gap-[24px] items-start p-[24px] relative w-full">
                     {/* Logo */}
-                    <div className="content-stretch flex items-center py-[24px] relative shrink-0 w-full">
+                    <div className="flex items-center py-[24px] shrink-0 w-full">
                       <Logo size="small" />
                     </div>
-                    
+
                     {/* Step Title */}
-                    <div className="content-stretch flex flex-col gap-[12px] items-start not-italic relative shrink-0 text-[var(--color-text-primary)]">
-                      <p className="css-ew64yg font-title-xxlarge leading-[0]">
+                    <div className="flex flex-col gap-[12px] items-start shrink-0 text-[var(--color-text-primary)]">
+                      <p className="font-title-xxlarge leading-[0]">
                         <span className="leading-[1.4] text-[var(--color-primary-main)]">1단계</span>
                         <span className="leading-[1.4]">/2단계</span>
                       </p>
-                      <p className="css-ew64yg font-heading-small leading-[1.35]">개인정보 활용동의</p>
+                      <p className="font-heading-small leading-[1.35]">개인정보 활용동의</p>
                     </div>
-                    
+
                     {/* Agreement Section */}
-                    <div className="content-stretch flex flex-col gap-[12px] items-start relative shrink-0 w-full">
-                      <p className="css-4hzbpn font-title-medium leading-[1.4] not-italic relative shrink-0 text-[var(--color-text-primary)] w-full">
+                    <div className="flex flex-col gap-[12px] items-start shrink-0 w-full">
+                      <p className="font-title-medium leading-[1.4] text-[var(--color-text-primary)] w-full">
                         약관 동의
                       </p>
                       <div className="bg-[var(--color-surface-primary)] relative rounded-[24px] shrink-0 w-full">
                         <div className="overflow-clip rounded-[inherit] size-full">
-                          <div className="content-stretch flex flex-col gap-[12px] items-start p-[24px] relative w-full">
+                          <div className="flex flex-col gap-[12px] items-start p-[24px] relative w-full">
                             <Checkbox
                               label="모두 동의합니다"
                               checked={agreeAll}
@@ -56,52 +56,46 @@ export default function SignupStep1Page() {
                                 setAgreeTerms(checked ? true : null);
                               }}
                             />
-                            <div className="css-g0mm18 font-body-medium leading-[1.5] not-italic relative shrink-0 text-[var(--color-state-info-text)]">
-                              <p className="css-ew64yg mb-0">0000, 0000, 0000 항목에 모두 동의합니다.</p>
-                              <p className="css-ew64yg">선택 사항은 ....</p>
+                            <div className="font-body-medium leading-[1.5] text-[var(--color-state-info-text)]">
+                              <p className="mb-0">서비스 이용약관, 개인정보 수집 및 이용 항목에 모두 동의합니다.</p>
+                              <p>선택 사항은 동의하지 않아도 서비스 이용이 가능합니다.</p>
                             </div>
                           </div>
                         </div>
                         <div aria-hidden="true" className="absolute border border-[var(--color-primary-border)] border-solid inset-0 pointer-events-none rounded-[24px]" />
                       </div>
                     </div>
-                    
+
                     {/* Terms Detail */}
-                    <div className="content-stretch flex flex-col gap-[12px] items-start relative shrink-0 w-full">
-                      <p className="css-4hzbpn font-title-medium leading-[1.4] not-italic relative shrink-0 text-[var(--color-text-primary)] w-full">
+                    <div className="flex flex-col gap-[12px] items-start shrink-0 w-full">
+                      <p className="font-title-medium leading-[1.4] text-[var(--color-text-primary)] w-full">
                         [필수] 개인정보수집 및 이용
                       </p>
                       <div className="bg-white relative rounded-[24px] shrink-0 w-full max-h-[200px] overflow-y-auto">
                         <div className="overflow-clip rounded-[inherit] size-full">
-                          <div className="content-stretch flex flex-col gap-[12px] items-start not-italic p-[24px] relative text-[var(--color-text-primary)] w-full">
-                            <p className="css-ew64yg font-title-medium leading-[1.4]">약관동의 및 개인정보수집이용동의</p>
-                            <div className="css-g0mm18 font-body-medium leading-[0]">
-                              <ol className="css-8097nc mb-0" start={1}>
-                                <li className="css-4hzbpn mb-0 ms-[24px]">
-                                  <span className="leading-[1.5]">수집하는 기간은 ...</span>
-                                </li>
-                                <li className="css-4hzbpn ms-[24px]">
-                                  <span className="leading-[1.5]">보유 기간은 ...</span>
-                                </li>
+                          <div className="flex flex-col gap-[12px] items-start p-[24px] text-[var(--color-text-primary)] w-full">
+                            <p className="font-title-medium leading-[1.4]">약관동의 및 개인정보수집이용동의</p>
+                            <div className="font-body-medium leading-[1.5]">
+                              <ol className="list-decimal pl-[24px]">
+                                <li>수집하는 개인정보 항목: 이름, 이메일, 비밀번호</li>
+                                <li>수집 목적: 서비스 제공 및 회원 관리</li>
+                                <li>보유 기간: 회원 탈퇴 시까지</li>
                               </ol>
-                              <p className="css-ew64yg leading-[1.5] mb-0">&nbsp;</p>
-                              <p className="css-ew64yg leading-[1.5] mb-0">&nbsp;</p>
-                              <p className="css-ew64yg leading-[1.5]">&nbsp;</p>
                             </div>
                           </div>
                         </div>
                         <div aria-hidden="true" className="absolute border border-[var(--color-border-default)] border-solid inset-0 pointer-events-none rounded-[24px]" />
                       </div>
                     </div>
-                    
+
                     {/* Agreement Buttons */}
                     <div className="bg-[var(--color-surface-primary)] relative rounded-[24px] shrink-0 w-full">
                       <div className="overflow-clip rounded-[inherit] size-full">
-                        <div className="content-stretch flex gap-[10px] items-start p-[24px] relative w-full">
-                          <p className="css-4hzbpn flex-[1_0_0] font-body-medium leading-[1.5] min-h-px min-w-px not-italic relative text-[var(--color-state-info-text)]">
+                        <div className="flex flex-wrap gap-[10px] items-center p-[24px] relative w-full">
+                          <p className="flex-1 font-body-medium leading-[1.5] min-w-[200px] text-[var(--color-state-info-text)]">
                             개인정보수집 및 이용에 대한 안내 사항을 읽고 동의합니다.
                           </p>
-                          <div className="content-stretch flex gap-[10px] items-center relative shrink-0">
+                          <div className="flex gap-[10px] items-center shrink-0">
                             <RadioButton
                               label="동의안함"
                               checked={agreeTerms === false}


### PR DESCRIPTION
## 작업 내용

### Step1 (약관 동의)
- `navigate`의 `state`를 통해 약관 동의 상태를 Step2로 전달
- `alert()` → `toast.error()` 변경
- 고정 크기(1920x1080) 레이아웃을 반응형(`min-h-screen`, `max-w`)으로 변경

### Step2 (개인정보 입력)
- `react-hook-form` + `zod` validation 적용 (기존 수동 state 관리 제거)
- 약관 미동의로 직접 접근 시 Step1으로 리다이렉트 처리
- 이메일 인증 플로우: 중복확인 → 인증코드 발송 → 타이머(3분) → 인증 확인
- 인증코드 만료 시 재발송 링크 제공
- 비밀번호 Zod 검증: 영문/숫자/특수문자 포함 8자 이상
- 이전/회원가입 버튼, 이메일 미인증 시 가입 버튼 비활성화

## 연동 API
- `POST /api/v1/auth/check-email` — 이메일 중복 확인
- `POST /api/v1/auth/send-verification` — 인증코드 발송
- `POST /api/v1/auth/verify-email` — 인증코드 검증
- `POST /api/v1/auth/register` — 회원가입

## 변경 파일
- `features/auth/SignupStep1Page.tsx`
- `features/auth/SignupStep2Page.tsx`

## 테스트
- [x] Step1에서 동의 후 Step2 진입 확인
- [x] Step2 직접 접근 시 Step1 리다이렉트 확인
- [x] 이메일 중복확인 → 인증코드 발송 → 타이머 표시 확인
- [x] Zod validation 에러 메시지 표시 확인
- [x] 이메일 미인증 시 가입 버튼 비활성화 확인
- [x] TypeScript 에러 없음

Closes #34