### PR TITLE
[FE] 알림 페이지 UI 구현 및 API 연동

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import DocumentReviewPage from './features/documents/DocumentReviewPage';
 import PermissionRequestPage from './features/permission/PermissionRequestPage';
 import PermissionStatusPage from './features/permission/PermissionStatusPage';
 import PermissionManagementPage from './features/permission/PermissionManagementPage';
+import NotificationsPage from './features/notifications/NotificationsPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -85,6 +86,16 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <PermissionManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Notifications */}
+      <Route
+        path="/notifications"
+        element={
+          <ProtectedRoute>
+            <NotificationsPage />
           </ProtectedRoute>
         }
       />

--- a/features/notifications/NotificationsPage.tsx
+++ b/features/notifications/NotificationsPage.tsx
@@ -1,0 +1,226 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotifications, useMarkAsRead, useMarkAllAsRead } from '../../src/hooks/useNotifications';
+import type { NotificationItem } from '../../src/api/notifications';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+function formatRelativeTime(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHour = Math.floor(diffMs / 3_600_000);
+  const diffDay = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return '방금 전';
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  if (diffDay < 7) return `${diffDay}일 전`;
+  return date.toLocaleDateString('ko-KR');
+}
+
+const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
+  ROLE_REQUEST: '권한 요청',
+  ROLE_APPROVED: '권한 승인',
+  ROLE_REJECTED: '권한 반려',
+  DIAGNOSTIC_SUBMITTED: '진단 제출',
+  DIAGNOSTIC_RETURNED: '진단 반려',
+  APPROVAL_REQUESTED: '결재 요청',
+  APPROVAL_COMPLETED: '결재 완료',
+  REVIEW_REQUESTED: '심사 요청',
+  REVIEW_COMPLETED: '심사 완료',
+  SYSTEM: '시스템',
+};
+
+type FilterTab = 'all' | 'unread' | 'read';
+
+function NotificationCard({
+  notification,
+  onMarkRead,
+  onNavigate,
+}: {
+  notification: NotificationItem;
+  onMarkRead: (id: number) => void;
+  onNavigate: (link: string) => void;
+}) {
+  const handleClick = () => {
+    if (!notification.read) {
+      onMarkRead(notification.notificationId);
+    }
+    if (notification.link) {
+      onNavigate(notification.link);
+    }
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className={`flex items-start gap-[16px] p-[20px] rounded-[12px] border transition-colors cursor-pointer ${
+        notification.read
+          ? 'bg-white border-[var(--color-border-default)] hover:bg-gray-50'
+          : 'bg-[var(--color-primary-light)] border-[var(--color-primary-border)] hover:bg-blue-50'
+      }`}
+    >
+      {/* 읽음 상태 인디케이터 */}
+      <div className="pt-[6px] shrink-0">
+        <div
+          className={`w-[8px] h-[8px] rounded-full ${
+            notification.read ? 'bg-transparent' : 'bg-[var(--color-primary-main)]'
+          }`}
+        />
+      </div>
+
+      {/* 내용 */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-[8px] mb-[4px]">
+          <span className="font-title-xsmall text-[var(--color-primary-main)]">
+            {NOTIFICATION_TYPE_LABELS[notification.type] || notification.type}
+          </span>
+          <span className="font-detail-small text-[var(--color-text-tertiary)]">
+            {formatRelativeTime(notification.createdAt)}
+          </span>
+        </div>
+        <p className="font-title-small text-[var(--color-text-primary)] mb-[4px]">
+          {notification.title}
+        </p>
+        <p className="font-body-medium text-[var(--color-text-secondary)] truncate">
+          {notification.message}
+        </p>
+      </div>
+
+      {/* 링크 화살표 */}
+      {notification.link && (
+        <div className="shrink-0 pt-[4px] text-[var(--color-text-tertiary)]">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path d="M7.5 15L12.5 10L7.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function NotificationsPage() {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<FilterTab>('all');
+  const [page, setPage] = useState(0);
+
+  const isReadParam = activeTab === 'unread' ? false : activeTab === 'read' ? true : undefined;
+  const { data, isLoading, isError } = useNotifications({ isRead: isReadParam, page, size: 20 });
+  const markAsReadMutation = useMarkAsRead();
+  const markAllAsReadMutation = useMarkAllAsRead();
+
+  const notifications = data?.content || [];
+  const pageInfo = data?.page;
+  const totalPages = pageInfo?.totalPages || 0;
+
+  const handleMarkRead = (id: number) => {
+    markAsReadMutation.mutate([id]);
+  };
+
+  const handleMarkAllRead = () => {
+    markAllAsReadMutation.mutate();
+  };
+
+  const handleNavigate = (link: string) => {
+    navigate(link);
+  };
+
+  const tabs: { key: FilterTab; label: string }[] = [
+    { key: 'all', label: '전체' },
+    { key: 'unread', label: '안읽음' },
+    { key: 'read', label: '읽음' },
+  ];
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[800px] mx-auto w-full">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between">
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">알림</h1>
+          <button
+            onClick={handleMarkAllRead}
+            disabled={markAllAsReadMutation.isPending}
+            className="font-title-xsmall text-[var(--color-primary-main)] hover:underline disabled:opacity-50"
+          >
+            {markAllAsReadMutation.isPending ? '처리 중...' : '모두 읽음'}
+          </button>
+        </div>
+
+        {/* 필터 탭 */}
+        <div className="flex gap-[8px]">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => { setActiveTab(tab.key); setPage(0); }}
+              className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+                activeTab === tab.key
+                  ? 'bg-[var(--color-primary-main)] text-white'
+                  : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 알림 목록 */}
+        <div className="flex flex-col gap-[12px]">
+          {isLoading && (
+            <div className="flex items-center justify-center py-[60px]">
+              <div className="w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+
+          {isError && (
+            <div className="text-center py-[60px]">
+              <p className="font-body-medium text-[var(--color-state-error-text)]">
+                알림을 불러오는 데 실패했습니다.
+              </p>
+            </div>
+          )}
+
+          {!isLoading && !isError && notifications.length === 0 && (
+            <div className="text-center py-[60px]">
+              <p className="font-body-medium text-[var(--color-text-tertiary)]">
+                {activeTab === 'unread' ? '읽지 않은 알림이 없습니다.' : '알림이 없습니다.'}
+              </p>
+            </div>
+          )}
+
+          {notifications.map((notification) => (
+            <NotificationCard
+              key={notification.notificationId}
+              notification={notification}
+              onMarkRead={handleMarkRead}
+              onNavigate={handleNavigate}
+            />
+          ))}
+        </div>
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-[8px] pt-[16px]">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              이전
+            </button>
+            <span className="font-body-medium text-[var(--color-text-primary)]">
+              {page + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -1,5 +1,8 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import svgPaths from '../../imports/svg-h10djjhihc';
 import { useLogout } from '../../src/hooks/useAuth';
+import { useNotifications, useUnreadCount, useMarkAsRead } from '../../src/hooks/useNotifications';
 
 interface HeaderProps {
   userName: string;
@@ -13,12 +16,118 @@ const roleLabels = {
   guest: '게스트',
 };
 
+function formatShortTime(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHour = Math.floor(diffMs / 3_600_000);
+  const diffDay = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return '방금';
+  if (diffMin < 60) return `${diffMin}분`;
+  if (diffHour < 24) return `${diffHour}시간`;
+  if (diffDay < 7) return `${diffDay}일`;
+  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+}
+
+function NotificationDropdown({ onClose }: { onClose: () => void }) {
+  const navigate = useNavigate();
+  const { data, isLoading } = useNotifications({ page: 0, size: 5 });
+  const markAsReadMutation = useMarkAsRead();
+  const notifications = data?.content || [];
+
+  const handleClickItem = (notificationId: number, read: boolean, link?: string) => {
+    if (!read) {
+      markAsReadMutation.mutate([notificationId]);
+    }
+    onClose();
+    if (link) {
+      navigate(link);
+    }
+  };
+
+  const handleViewAll = () => {
+    onClose();
+    navigate('/notifications');
+  };
+
+  return (
+    <div className="absolute right-0 top-[calc(100%+8px)] w-[360px] bg-white rounded-[12px] shadow-lg border border-gray-200 z-[100] overflow-hidden">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between px-[16px] py-[12px] border-b border-gray-100">
+        <span className="font-title-small text-[var(--color-text-primary)]">알림</span>
+        <button
+          onClick={handleViewAll}
+          className="font-detail-medium text-[var(--color-primary-main)] hover:underline"
+        >
+          전체보기
+        </button>
+      </div>
+
+      {/* 목록 */}
+      <div className="max-h-[320px] overflow-y-auto">
+        {isLoading && (
+          <div className="flex items-center justify-center py-[32px]">
+            <div className="w-[24px] h-[24px] border-[2px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+
+        {!isLoading && notifications.length === 0 && (
+          <div className="text-center py-[32px]">
+            <p className="font-body-medium text-[var(--color-text-tertiary)]">알림이 없습니다.</p>
+          </div>
+        )}
+
+        {notifications.map((n) => (
+          <div
+            key={n.notificationId}
+            onClick={() => handleClickItem(n.notificationId, n.read, n.link)}
+            className={`flex items-start gap-[12px] px-[16px] py-[12px] cursor-pointer transition-colors ${
+              n.read ? 'bg-white hover:bg-gray-50' : 'bg-blue-50/50 hover:bg-blue-50'
+            }`}
+          >
+            {!n.read && (
+              <div className="pt-[6px] shrink-0">
+                <div className="w-[6px] h-[6px] rounded-full bg-[var(--color-primary-main)]" />
+              </div>
+            )}
+            <div className={`flex-1 min-w-0 ${n.read ? 'pl-[18px]' : ''}`}>
+              <p className="font-title-xsmall text-[var(--color-text-primary)] truncate">{n.title}</p>
+              <p className="font-detail-small text-[var(--color-text-secondary)] truncate">{n.message}</p>
+            </div>
+            <span className="font-detail-small text-[var(--color-text-tertiary)] shrink-0 pt-[2px]">
+              {formatShortTime(n.createdAt)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function Header({ userName, userRole }: HeaderProps) {
   const logoutMutation = useLogout();
+  const { data: unreadCount } = useUnreadCount();
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const handleLogout = () => {
     logoutMutation.mutate();
   };
+
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+    if (showDropdown) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showDropdown]);
 
   return (
     <div className="bg-[#002554] h-[85px] w-full flex items-center justify-between px-[30px] shadow-md z-50 relative">
@@ -54,18 +163,35 @@ export default function Header({ userName, userRole }: HeaderProps) {
           </div>
         </div>
 
-        {/* Notification Icon */}
-        <div className="size-[24px] cursor-pointer">
-          <svg className="block size-full" fill="none" preserveAspectRatio="none" viewBox="0 0 24 24">
-            <g>
-              <mask height="24" id="mask0_1_2929" maskUnits="userSpaceOnUse" style={{ maskType: 'alpha' }} width="24" x="0" y="0">
-                <rect fill="#D9D9D9" height="24" width="24" />
-              </mask>
-              <g mask="url(#mask0_1_2929)">
-                <path d={svgPaths.p22390780} fill="white" />
+        {/* Notification Icon with Badge */}
+        <div className="relative" ref={dropdownRef}>
+          <button
+            onClick={() => setShowDropdown((prev) => !prev)}
+            className="size-[24px] cursor-pointer relative"
+            aria-label="알림"
+          >
+            <svg className="block size-full" fill="none" preserveAspectRatio="none" viewBox="0 0 24 24">
+              <g>
+                <mask height="24" id="mask0_1_2929" maskUnits="userSpaceOnUse" style={{ maskType: 'alpha' }} width="24" x="0" y="0">
+                  <rect fill="#D9D9D9" height="24" width="24" />
+                </mask>
+                <g mask="url(#mask0_1_2929)">
+                  <path d={svgPaths.p22390780} fill="white" />
+                </g>
               </g>
-            </g>
-          </svg>
+            </svg>
+            {/* 뱃지 */}
+            {typeof unreadCount === 'number' && unreadCount > 0 && (
+              <span className="absolute -top-[6px] -right-[6px] min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold px-[4px]">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )}
+          </button>
+
+          {/* 드롭다운 */}
+          {showDropdown && (
+            <NotificationDropdown onClose={() => setShowDropdown(false)} />
+          )}
         </div>
 
         {/* Divider */}

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -11,8 +11,14 @@ export interface NotificationItem {
   link?: string;
 }
 
+export interface NotificationListParams {
+  isRead?: boolean;
+  page?: number;
+  size?: number;
+}
+
 export const getNotifications = async (
-  params: { page?: number; size?: number } = {}
+  params: NotificationListParams = {}
 ): Promise<PagedData<NotificationItem>> => {
   const response = await apiClient.get<BaseResponse<PagedData<NotificationItem>>>('/v1/notifications', {
     params: { page: 0, size: 20, ...params },
@@ -22,4 +28,8 @@ export const getNotifications = async (
 
 export const markAsRead = async (ids: number[]): Promise<void> => {
   await apiClient.patch('/v1/notifications/read', { notificationIds: ids });
+};
+
+export const markAllAsRead = async (): Promise<void> => {
+  await apiClient.patch('/v1/notifications/read', { readAll: true });
 };

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,11 +1,31 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import * as notificationsApi from '../api/notifications';
+import type { NotificationListParams } from '../api/notifications';
 import { QUERY_KEYS } from '../constants/queryKeys';
+import { useAuthStore } from '../store/authStore';
 
-export const useNotifications = (params?: { page?: number; size?: number }) => {
+export const useNotifications = (params?: NotificationListParams) => {
+  const { isAuthenticated } = useAuthStore();
+
   return useQuery({
     queryKey: QUERY_KEYS.NOTIFICATIONS.LIST(params),
     queryFn: () => notificationsApi.getNotifications(params),
+    enabled: isAuthenticated,
+  });
+};
+
+export const useUnreadCount = () => {
+  const { isAuthenticated } = useAuthStore();
+
+  return useQuery({
+    queryKey: [...QUERY_KEYS.NOTIFICATIONS.LIST({ isRead: false }), 'count'],
+    queryFn: async () => {
+      const data = await notificationsApi.getNotifications({ isRead: false, page: 0, size: 1 });
+      return data.page.totalElements;
+    },
+    enabled: isAuthenticated,
+    refetchInterval: 60_000, // 1분마다 갱신
   });
 };
 
@@ -15,6 +35,18 @@ export const useMarkAsRead = () => {
   return useMutation({
     mutationFn: notificationsApi.markAsRead,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+};
+
+export const useMarkAllAsRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: notificationsApi.markAllAsRead,
+    onSuccess: () => {
+      toast.success('모든 알림을 읽음 처리했습니다.');
       queryClient.invalidateQueries({ queryKey: ['notifications'] });
     },
   });


### PR DESCRIPTION
## 작업 내용

### 알림 목록 페이지 (`/notifications`)
- 전체/안읽음/읽음 필터 탭으로 알림 분류 조회
- 알림 카드: 타입 뱃지, 제목, 내용, 상대 시간 표시
- 안읽은 알림 클릭 시 자동 읽음 처리 + 링크 이동
- "모두 읽음" 버튼으로 전체 읽음 처리
- 페이지네이션 (이전/다음)
- 로딩/에러/빈 상태 처리

### Header 알림 기능
- 알림 아이콘에 안읽은 개수 뱃지 (99+ 처리, 1분 주기 자동 갱신)
- 클릭 시 최근 5건 드롭다운 미리보기
- "전체보기" → `/notifications` 페이지 이동
- 외부 클릭 시 드롭다운 자동 닫힘

### API/Hook 보강
- `src/api/notifications.ts`: `isRead` 필터, `markAllAsRead` 추가
- `src/hooks/useNotifications.ts`: `useUnreadCount`, `useMarkAllAsRead` 추가

## 연동 API
- `GET /api/v1/notifications` — 알림 목록 (isRead, page, size)
- `PATCH /api/v1/notifications/read` — 개별/전체 읽음 처리

## 변경 파일
- `features/notifications/NotificationsPage.tsx` (신규)
- `shared/layout/Header.tsx`
- `src/api/notifications.ts`
- `src/hooks/useNotifications.ts`
- `App.tsx`

## 테스트
- [x] 알림 목록 전체/안읽음/읽음 필터 동작 확인
- [x] 개별 읽음 처리 후 뱃지 갱신 확인
- [x] 전체 읽음 처리 동작 확인
- [x] Header 드롭다운 열림/닫힘 확인
- [x] TypeScript 에러 없음

Closes #46