### PR TITLE
권한 요청 상태 페이지 UI 개선 및 API 연동

### DIFF
--- a/features/permission/PermissionStatusPage.tsx
+++ b/features/permission/PermissionStatusPage.tsx
@@ -1,17 +1,101 @@
-import { AlertCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { AlertCircle, Clock, CheckCircle, XCircle, RefreshCw, ArrowLeft, User, Building2, Shield, Calendar, FileText } from 'lucide-react';
+import { Button } from '../../shared/components/Button';
 import GuestLayout from '../../shared/layout/GuestLayout';
 import { useMyRoleRequests } from '../../src/hooks/useRoles';
 import { useAuthStore } from '../../src/store/authStore';
-import { REQUEST_STATUS_LABELS } from '../../src/types/api.types';
+import type { RequestStatus } from '../../src/types/api.types';
+
+const STATUS_CONFIG: Record<RequestStatus, {
+  label: string;
+  bgColor: string;
+  textColor: string;
+  borderColor: string;
+  icon: React.ReactNode;
+  description: string;
+}> = {
+  PENDING: {
+    label: '승인 대기중',
+    bgColor: 'bg-[#fff8e1]',
+    textColor: 'text-[#f57c00]',
+    borderColor: 'border-[#ffb74d]',
+    icon: <Clock className="w-5 h-5" />,
+    description: '관리자가 요청을 검토 중입니다. 승인까지 1-2일 정도 소요될 수 있습니다.',
+  },
+  APPROVED: {
+    label: '승인 완료',
+    bgColor: 'bg-[#e8f5e9]',
+    textColor: 'text-[#2e7d32]',
+    borderColor: 'border-[#81c784]',
+    icon: <CheckCircle className="w-5 h-5" />,
+    description: '권한이 승인되었습니다. 이제 해당 기능을 사용할 수 있습니다.',
+  },
+  REJECTED: {
+    label: '승인 반려',
+    bgColor: 'bg-[#ffebee]',
+    textColor: 'text-[#c62828]',
+    borderColor: 'border-[#e57373]',
+    icon: <XCircle className="w-5 h-5" />,
+    description: '요청이 반려되었습니다. 반려 사유를 확인하고 다시 요청해 주세요.',
+  },
+};
+
+function formatDate(dateString: string): string {
+  try {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  } catch {
+    return dateString;
+  }
+}
+
+function StatusBadge({ status }: { status: RequestStatus }) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium ${config.bgColor} ${config.textColor}`}>
+      {config.icon}
+      {config.label}
+    </span>
+  );
+}
 
 export default function PermissionStatusPage() {
-  const { data: requestStatus, isLoading } = useMyRoleRequests();
+  const navigate = useNavigate();
+  const { data: requestStatus, isLoading, isError, refetch } = useMyRoleRequests();
   const { user } = useAuthStore();
 
   if (isLoading) {
     return (
       <GuestLayout>
-        <div className="flex justify-center items-center h-[500px]">Loading...</div>
+        <div className="flex justify-center items-center h-[500px]">
+          <div className="flex flex-col items-center gap-4">
+            <div className="w-10 h-10 border-4 border-[#003087] border-t-transparent rounded-full animate-spin" />
+            <p className="font-body-medium text-[#868e96]">요청 상태를 불러오는 중...</p>
+          </div>
+        </div>
+      </GuestLayout>
+    );
+  }
+
+  if (isError) {
+    return (
+      <GuestLayout>
+        <div className="flex justify-center items-center h-[500px]">
+          <div className="flex flex-col items-center gap-4">
+            <AlertCircle className="w-12 h-12 text-[#c62828]" />
+            <p className="font-body-medium text-[#868e96]">요청 상태를 불러오는데 실패했습니다.</p>
+            <Button variant="secondary" onClick={() => refetch()}>
+              <RefreshCw className="w-4 h-4 mr-2" />
+              다시 시도
+            </Button>
+          </div>
+        </div>
       </GuestLayout>
     );
   }
@@ -19,63 +103,197 @@ export default function PermissionStatusPage() {
   if (!requestStatus) {
     return (
       <GuestLayout>
-        <div className="flex justify-center items-center h-[500px]">
-          <p className="font-body-medium text-[#868e96]">권한 요청 내역이 없습니다.</p>
+        <div className="flex justify-center w-full py-[48px] px-4">
+          <div className="bg-white rounded-[32px] p-[48px] w-full max-w-[800px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)] border border-[#b0cbef]">
+            <div className="flex flex-col items-center gap-6">
+              <div className="w-20 h-20 bg-[#f8f9fa] rounded-full flex items-center justify-center">
+                <FileText className="w-10 h-10 text-[#adb5bd]" />
+              </div>
+              <div className="text-center">
+                <h2 className="font-title-large text-[#212529] mb-2">권한 요청 내역이 없습니다</h2>
+                <p className="font-body-medium text-[#868e96]">
+                  시스템 기능을 사용하려면 먼저 권한을 요청해 주세요.
+                </p>
+              </div>
+              <Button
+                variant="primary"
+                size="large"
+                className="mt-4"
+                onClick={() => navigate('/permission/request')}
+              >
+                권한 요청하기
+              </Button>
+            </div>
+          </div>
         </div>
       </GuestLayout>
     );
   }
 
+  const statusConfig = STATUS_CONFIG[requestStatus.status];
+
   return (
     <GuestLayout>
       <div className="flex justify-center w-full py-[48px] px-4">
-        <div className="bg-white rounded-[32px] p-[48px] w-full max-w-[1392px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)] border border-[#b0cbef]">
-            <div className="flex flex-col gap-[24px]">
-                <h1 className="font-heading-medium text-[#212529]">시스템 권한요청</h1>
-
-                 {/* Info Box */}
-                 <div className="bg-[#eff4fc] rounded-[24px] p-[24px] border border-[#b0cbef] flex gap-[10px] items-start">
-                    <AlertCircle className="w-[24px] h-[24px] text-[#002554]" />
-                    <p className="font-body-medium text-[#002554]">
-                        {REQUEST_STATUS_LABELS[requestStatus.status] || '권한요청 승인 대기 중입니다.'}
-                    </p>
-                </div>
-
-                <p className="font-title-medium text-[#212529]">요청 현황</p>
-
-                {/* Status Box */}
-                <div className="bg-white rounded-[20px] p-[24px] border border-[#b0cbef] w-full relative">
-                    <div className="flex flex-col gap-[12px]">
-                        <div className="flex flex-col">
-                            <p className="font-title-small mb-1">요청일시</p>
-                            <p className="font-body-medium">{requestStatus.requestedAt}</p>
-                        </div>
-                        <div className="flex flex-col">
-                            <p className="font-title-small mb-1">요청권한</p>
-                            <p className="font-body-medium">{requestStatus.requestedRole?.name}</p>
-                        </div>
-                        <div className="flex flex-col">
-                            <p className="font-title-small mb-1">회사명</p>
-                            <p className="font-body-medium">{requestStatus.company?.companyName}</p>
-                        </div>
-                        <div className="flex flex-col">
-                            <p className="font-title-small mb-1">이름</p>
-                            <p className="font-body-medium">{user?.name || '사용자'}</p>
-                        </div>
-                        <div className="flex flex-col">
-                            <p className="font-title-small mb-1">상태</p>
-                            <p className="font-body-medium">{requestStatus.statusLabel}</p>
-                        </div>
-                        {requestStatus.rejectReason && (
-                          <div className="flex flex-col">
-                            <p className="font-title-small mb-1">반려 사유</p>
-                            <p className="font-body-medium text-red-600">{requestStatus.rejectReason}</p>
-                          </div>
-                        )}
-                    </div>
-                </div>
-
+        <div className="bg-white rounded-[32px] p-[48px] w-full max-w-[800px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)] border border-[#b0cbef]">
+          <div className="flex flex-col gap-[32px]">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <h1 className="font-heading-medium text-[#212529]">권한 요청 현황</h1>
+              <StatusBadge status={requestStatus.status} />
             </div>
+
+            {/* Status Description */}
+            <div className={`rounded-[16px] p-[20px] border ${statusConfig.bgColor} ${statusConfig.borderColor} flex gap-[12px] items-start`}>
+              <div className={statusConfig.textColor}>
+                {statusConfig.icon}
+              </div>
+              <p className={`font-body-medium ${statusConfig.textColor}`}>
+                {statusConfig.description}
+              </p>
+            </div>
+
+            {/* Request Details Card */}
+            <div className="bg-[#f8f9fa] rounded-[20px] p-[28px] border border-[#dee2e6]">
+              <h3 className="font-title-medium text-[#212529] mb-[20px]">요청 상세 정보</h3>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-[20px]">
+                {/* 요청자 정보 */}
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-[#dee2e6]">
+                    <User className="w-5 h-5 text-[#868e96]" />
+                  </div>
+                  <div>
+                    <p className="font-detail-small text-[#868e96]">요청자</p>
+                    <p className="font-body-medium text-[#212529]">{user?.name || '사용자'}</p>
+                  </div>
+                </div>
+
+                {/* 회사 정보 */}
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-[#dee2e6]">
+                    <Building2 className="w-5 h-5 text-[#868e96]" />
+                  </div>
+                  <div>
+                    <p className="font-detail-small text-[#868e96]">회사명</p>
+                    <p className="font-body-medium text-[#212529]">{requestStatus.company?.companyName || '-'}</p>
+                  </div>
+                </div>
+
+                {/* 요청 권한 */}
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-[#dee2e6]">
+                    <Shield className="w-5 h-5 text-[#868e96]" />
+                  </div>
+                  <div>
+                    <p className="font-detail-small text-[#868e96]">요청 권한</p>
+                    <p className="font-body-medium text-[#212529]">{requestStatus.requestedRole?.name || '-'}</p>
+                  </div>
+                </div>
+
+                {/* 도메인 정보 */}
+                {requestStatus.domain && (
+                  <div className="flex items-start gap-3">
+                    <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-[#dee2e6]">
+                      <FileText className="w-5 h-5 text-[#868e96]" />
+                    </div>
+                    <div>
+                      <p className="font-detail-small text-[#868e96]">서비스 도메인</p>
+                      <p className="font-body-medium text-[#212529]">{requestStatus.domain.name}</p>
+                    </div>
+                  </div>
+                )}
+
+                {/* 요청일 */}
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-[#dee2e6]">
+                    <Calendar className="w-5 h-5 text-[#868e96]" />
+                  </div>
+                  <div>
+                    <p className="font-detail-small text-[#868e96]">요청일시</p>
+                    <p className="font-body-medium text-[#212529]">{formatDate(requestStatus.requestedAt)}</p>
+                  </div>
+                </div>
+
+                {/* 처리일 */}
+                {requestStatus.processedAt && (
+                  <div className="flex items-start gap-3">
+                    <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center border border-[#dee2e6]">
+                      <CheckCircle className="w-5 h-5 text-[#868e96]" />
+                    </div>
+                    <div>
+                      <p className="font-detail-small text-[#868e96]">처리일시</p>
+                      <p className="font-body-medium text-[#212529]">{formatDate(requestStatus.processedAt)}</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* 요청 사유 */}
+              {requestStatus.reason && (
+                <div className="mt-[20px] pt-[20px] border-t border-[#dee2e6]">
+                  <p className="font-detail-small text-[#868e96] mb-2">요청 사유</p>
+                  <p className="font-body-medium text-[#212529] bg-white rounded-[12px] p-[16px] border border-[#dee2e6]">
+                    {requestStatus.reason}
+                  </p>
+                </div>
+              )}
+
+              {/* 반려 사유 */}
+              {requestStatus.status === 'REJECTED' && requestStatus.rejectReason && (
+                <div className="mt-[20px] pt-[20px] border-t border-[#dee2e6]">
+                  <p className="font-detail-small text-[#c62828] mb-2">반려 사유</p>
+                  <p className="font-body-medium text-[#c62828] bg-[#ffebee] rounded-[12px] p-[16px] border border-[#e57373]">
+                    {requestStatus.rejectReason}
+                  </p>
+                </div>
+              )}
+
+              {/* 처리자 정보 */}
+              {requestStatus.processedBy && (
+                <div className="mt-[20px] pt-[20px] border-t border-[#dee2e6]">
+                  <p className="font-detail-small text-[#868e96]">
+                    처리자: {requestStatus.processedBy.name}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex gap-3">
+              <Button
+                variant="secondary"
+                size="large"
+                className="flex-1"
+                onClick={() => navigate(-1)}
+              >
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                뒤로가기
+              </Button>
+
+              {requestStatus.status === 'REJECTED' && (
+                <Button
+                  variant="primary"
+                  size="large"
+                  className="flex-1"
+                  onClick={() => navigate('/permission/request')}
+                >
+                  다시 요청하기
+                </Button>
+              )}
+
+              {requestStatus.status === 'APPROVED' && (
+                <Button
+                  variant="primary"
+                  size="large"
+                  className="flex-1"
+                  onClick={() => navigate('/dashboard')}
+                >
+                  대시보드로 이동
+                </Button>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </GuestLayout>

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -279,6 +279,7 @@ export interface RoleRequestResponse {
 export interface RoleRequestStatusDto {
   accessRequestId: number;
   requestedRole: RoleSimpleDto;
+  domain?: DomainOptionDto;
   company: CompanySimpleDto;
   status: RequestStatus;
   statusLabel: string;


### PR DESCRIPTION
## Summary
- 권한 요청 상태 페이지 UI/UX 전면 개선
- 상태별 시각적 피드백 (뱃지, 안내 메시지)
- 상세 정보 카드 레이아웃으로 변경

## Changes
- `features/permission/PermissionStatusPage.tsx`: 상태 페이지 UI 전면 개선
- `src/types/api.types.ts`: RoleRequestStatusDto에 domain 필드 추가

## Features
- 상태별 뱃지 (PENDING: 노랑, APPROVED: 초록, REJECTED: 빨강)
- 상태별 안내 메시지 및 아이콘
- 날짜 한국어 포맷팅
- Loading/Error/Empty 상태 UI
- 도메인 정보 표시
- 처리일, 처리자, 반려 사유 표시
- 상태별 액션 버튼 (반려 → 다시 요청, 승인 → 대시보드 이동)

## Test Plan
- [ ] 로그인 후 `/permission/status` 페이지 접근
- [ ] Loading 스피너 표시 확인
- [ ] 요청 내역 없을 때 Empty UI 표시 확인
- [ ] PENDING 상태: 노란색 뱃지 및 대기 메시지 확인
- [ ] APPROVED 상태: 초록색 뱃지 및 승인 메시지, 대시보드 버튼 확인
- [ ] REJECTED 상태: 빨간색 뱃지 및 반려 사유, 다시 요청 버튼 확인
- [ ] 날짜 한국어 포맷 확인
- [ ] 뒤로가기 버튼 동작 확인

Closes #36