### PR TITLE
결재 목록/상세/처리 페이지 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,8 @@ import PermissionRequestPage from './features/permission/PermissionRequestPage';
 import PermissionStatusPage from './features/permission/PermissionStatusPage';
 import PermissionManagementPage from './features/permission/PermissionManagementPage';
 import NotificationsPage from './features/notifications/NotificationsPage';
+import ApprovalsListPage from './features/approvals/ApprovalsListPage';
+import ApprovalDetailPage from './features/approvals/ApprovalDetailPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -86,6 +88,24 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <PermissionManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Approvals */}
+      <Route
+        path="/approvals"
+        element={
+          <ProtectedRoute>
+            <ApprovalsListPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/approvals/:id"
+        element={
+          <ProtectedRoute>
+            <ApprovalDetailPage />
           </ProtectedRoute>
         }
       />

--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -1,0 +1,245 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useApprovalDetail, useProcessApproval, useSubmitToReviewer } from '../../src/hooks/useApprovals';
+import type { ApprovalStatus, DomainCode } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const STATUS_LABELS: Record<ApprovalStatus, string> = {
+  WAITING: '대기',
+  APPROVED: '승인',
+  REJECTED: '반려',
+};
+
+const STATUS_STYLES: Record<ApprovalStatus, string> = {
+  WAITING: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REJECTED: 'bg-red-50 text-red-700 border-red-200',
+};
+
+const RISK_LABELS: Record<string, { label: string; style: string }> = {
+  LOW: { label: '낮음', style: 'text-green-600' },
+  MEDIUM: { label: '보통', style: 'text-yellow-600' },
+  HIGH: { label: '높음', style: 'text-red-600' },
+};
+
+export default function ApprovalDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const approvalId = Number(id);
+
+  const { data: approval, isLoading, isError } = useApprovalDetail(approvalId);
+  const processApprovalMutation = useProcessApproval();
+  const submitToReviewerMutation = useSubmitToReviewer();
+
+  const [showModal, setShowModal] = useState<'APPROVED' | 'REJECTED' | null>(null);
+  const [comment, setComment] = useState('');
+  const [rejectReason, setRejectReason] = useState('');
+
+  const handleProcess = () => {
+    if (!showModal) return;
+    processApprovalMutation.mutate(
+      {
+        id: approvalId,
+        data: {
+          decision: showModal,
+          comment: comment || undefined,
+          rejectReason: showModal === 'REJECTED' ? rejectReason || undefined : undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          setShowModal(null);
+          setComment('');
+          setRejectReason('');
+        },
+      }
+    );
+  };
+
+  const handleSubmitToReviewer = () => {
+    submitToReviewerMutation.mutate(approvalId);
+  };
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center py-[120px]">
+          <div className="w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (isError || !approval) {
+    return (
+      <DashboardLayout>
+        <div className="flex flex-col items-center justify-center py-[120px] gap-[16px]">
+          <p className="font-body-medium text-[var(--color-state-error-text)]">
+            결재 정보를 불러오는 데 실패했습니다.
+          </p>
+          <button
+            onClick={() => navigate('/approvals')}
+            className="font-title-xsmall text-[var(--color-primary-main)] hover:underline"
+          >
+            목록으로 돌아가기
+          </button>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const isWaiting = approval.status === 'WAITING';
+  const isApproved = approval.status === 'APPROVED';
+  const risk = approval.riskLevel ? RISK_LABELS[approval.riskLevel] : null;
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[900px] mx-auto w-full">
+        {/* 뒤로가기 */}
+        <button
+          onClick={() => navigate('/approvals')}
+          className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          목록으로
+        </button>
+
+        {/* 제목 + 상태 */}
+        <div className="flex items-start justify-between gap-[16px]">
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{approval.title}</h1>
+          <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[approval.status]}`}>
+            {STATUS_LABELS[approval.status]}
+          </span>
+        </div>
+
+        {/* 기본 정보 */}
+        <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+          <div className="grid grid-cols-2 gap-[20px]">
+            <InfoRow label="도메인" value={DOMAIN_LABELS[approval.domainCode as DomainCode] || approval.domainCode} />
+            <InfoRow label="회사명" value={approval.companyName} />
+            <InfoRow label="기안자" value={approval.drafterName} />
+            <InfoRow label="제출일" value={new Date(approval.submittedAt).toLocaleDateString('ko-KR')} />
+            {risk && (
+              <InfoRow label="위험 등급" value={risk.label} valueClassName={risk.style} />
+            )}
+            {approval.aiVerdict && (
+              <InfoRow label="AI 판정" value={approval.aiVerdict} />
+            )}
+          </div>
+
+          {approval.comment && (
+            <div className="mt-[20px] pt-[20px] border-t border-[var(--color-border-default)]">
+              <p className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px]">코멘트</p>
+              <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{approval.comment}</p>
+            </div>
+          )}
+        </div>
+
+        {/* 액션 버튼 */}
+        {isWaiting && (
+          <div className="flex gap-[12px] justify-end">
+            <button
+              onClick={() => setShowModal('REJECTED')}
+              className="px-[24px] py-[12px] rounded-[8px] border border-red-300 text-red-600 font-title-small hover:bg-red-50 transition-colors"
+            >
+              반려
+            </button>
+            <button
+              onClick={() => setShowModal('APPROVED')}
+              className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+            >
+              승인
+            </button>
+          </div>
+        )}
+
+        {isApproved && (
+          <div className="flex justify-end">
+            <button
+              onClick={handleSubmitToReviewer}
+              disabled={submitToReviewerMutation.isPending}
+              className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors disabled:opacity-50"
+            >
+              {submitToReviewerMutation.isPending ? '제출 중...' : '원청에 제출'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 승인/반려 모달 */}
+      {showModal && (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-[16px] w-full max-w-[480px] mx-[16px] shadow-xl">
+            <div className="px-[24px] py-[20px] border-b border-[var(--color-border-default)]">
+              <h2 className="font-title-medium text-[var(--color-text-primary)]">
+                {showModal === 'APPROVED' ? '결재 승인' : '결재 반려'}
+              </h2>
+            </div>
+
+            <div className="px-[24px] py-[20px] flex flex-col gap-[16px]">
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                  코멘트 (선택)
+                </label>
+                <textarea
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  placeholder="코멘트를 입력하세요"
+                  rows={3}
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+
+              {showModal === 'REJECTED' && (
+                <div>
+                  <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                    반려 사유
+                  </label>
+                  <textarea
+                    value={rejectReason}
+                    onChange={(e) => setRejectReason(e.target.value)}
+                    placeholder="반려 사유를 입력하세요"
+                    rows={3}
+                    className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="px-[24px] py-[16px] border-t border-[var(--color-border-default)] flex justify-end gap-[12px]">
+              <button
+                onClick={() => { setShowModal(null); setComment(''); setRejectReason(''); }}
+                className="px-[20px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleProcess}
+                disabled={processApprovalMutation.isPending}
+                className={`px-[20px] py-[10px] rounded-[8px] font-title-small text-white transition-colors disabled:opacity-50 ${
+                  showModal === 'APPROVED'
+                    ? 'bg-[var(--color-primary-main)] hover:opacity-90'
+                    : 'bg-red-500 hover:bg-red-600'
+                }`}
+              >
+                {processApprovalMutation.isPending ? '처리 중...' : showModal === 'APPROVED' ? '승인' : '반려'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}
+
+function InfoRow({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
+  return (
+    <div>
+      <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">{label}</p>
+      <p className={`font-body-medium ${valueClassName || 'text-[var(--color-text-primary)]'}`}>{value}</p>
+    </div>
+  );
+}

--- a/features/approvals/ApprovalsListPage.tsx
+++ b/features/approvals/ApprovalsListPage.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useApprovals } from '../../src/hooks/useApprovals';
+import type { ApprovalStatus } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import type { DomainCode } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const STATUS_LABELS: Record<ApprovalStatus, string> = {
+  WAITING: '대기',
+  APPROVED: '승인',
+  REJECTED: '반려',
+};
+
+const STATUS_STYLES: Record<ApprovalStatus, string> = {
+  WAITING: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REJECTED: 'bg-red-50 text-red-700 border-red-200',
+};
+
+type StatusFilter = ApprovalStatus | 'ALL';
+
+export default function ApprovalsListPage() {
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [domainFilter, setDomainFilter] = useState<string>('');
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading, isError } = useApprovals({
+    status: statusFilter === 'ALL' ? undefined : statusFilter,
+    domainCode: domainFilter || undefined,
+    page,
+    size: 10,
+  });
+
+  const approvals = data?.content || [];
+  const pageInfo = data?.page;
+  const totalPages = pageInfo?.totalPages || 0;
+
+  const statusTabs: { key: StatusFilter; label: string }[] = [
+    { key: 'ALL', label: '전체' },
+    { key: 'WAITING', label: '대기' },
+    { key: 'APPROVED', label: '승인' },
+    { key: 'REJECTED', label: '반려' },
+  ];
+
+  const domainOptions: { value: string; label: string }[] = [
+    { value: '', label: '전체 도메인' },
+    { value: 'ESG', label: DOMAIN_LABELS.ESG },
+    { value: 'SAFETY', label: DOMAIN_LABELS.SAFETY },
+    { value: 'COMPLIANCE', label: DOMAIN_LABELS.COMPLIANCE },
+  ];
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[1200px] mx-auto w-full">
+        {/* 헤더 */}
+        <h1 className="font-heading-small text-[var(--color-text-primary)]">결재 관리</h1>
+
+        {/* 필터 영역 */}
+        <div className="flex flex-wrap items-center gap-[12px]">
+          {/* 상태 탭 */}
+          <div className="flex gap-[8px]">
+            {statusTabs.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => { setStatusFilter(tab.key); setPage(0); }}
+                className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+                  statusFilter === tab.key
+                    ? 'bg-[var(--color-primary-main)] text-white'
+                    : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* 도메인 필터 */}
+          <select
+            value={domainFilter}
+            onChange={(e) => { setDomainFilter(e.target.value); setPage(0); }}
+            className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
+          >
+            {domainOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* 테이블 */}
+        <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기안자</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제출일</th>
+                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <tr>
+                  <td colSpan={6} className="text-center py-[60px]">
+                    <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+                  </td>
+                </tr>
+              )}
+
+              {isError && (
+                <tr>
+                  <td colSpan={6} className="text-center py-[60px]">
+                    <p className="font-body-medium text-[var(--color-state-error-text)]">
+                      결재 목록을 불러오는 데 실패했습니다.
+                    </p>
+                  </td>
+                </tr>
+              )}
+
+              {!isLoading && !isError && approvals.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="text-center py-[60px]">
+                    <p className="font-body-medium text-[var(--color-text-tertiary)]">
+                      결재 내역이 없습니다.
+                    </p>
+                  </td>
+                </tr>
+              )}
+
+              {approvals.map((item) => (
+                <tr
+                  key={item.approvalId}
+                  onClick={() => navigate(`/approvals/${item.approvalId}`)}
+                  className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
+                    {item.title}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+                    {DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+                    {item.companyName}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+                    {item.drafterName}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
+                    {new Date(item.submittedAt).toLocaleDateString('ko-KR')}
+                  </td>
+                  <td className="px-[16px] py-[14px] text-center">
+                    <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
+                      {STATUS_LABELS[item.status]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-[8px] pt-[16px]">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              이전
+            </button>
+            <span className="font-body-medium text-[var(--color-text-primary)]">
+              {page + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/api/approvals.ts
+++ b/src/api/approvals.ts
@@ -41,7 +41,7 @@ export const getApprovalDetail = async (id: number): Promise<ApprovalDetail> => 
 
 export const processApproval = async (
   id: number,
-  data: { decision: 'APPROVED' | 'REJECTED'; comment?: string }
+  data: { decision: 'APPROVED' | 'REJECTED'; comment?: string; rejectReason?: string }
 ): Promise<void> => {
   await apiClient.patch(`/v1/approvals/${id}`, data);
 };

--- a/src/hooks/useApprovals.ts
+++ b/src/hooks/useApprovals.ts
@@ -32,7 +32,7 @@ export const useProcessApproval = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: { decision: 'APPROVED' | 'REJECTED'; comment?: string } }) =>
+    mutationFn: ({ id, data }: { id: number; data: { decision: 'APPROVED' | 'REJECTED'; comment?: string; rejectReason?: string } }) =>
       approvalsApi.processApproval(id, data),
     onSuccess: () => {
       toast.success('결재 처리가 완료되었습니다.');


### PR DESCRIPTION
## Summary
- 결재 목록 페이지: 상태(대기/승인/반려) 및 도메인 필터, 페이지네이션 테이블
- 결재 상세 페이지: 기본 정보 표시, AI 판정/위험등급, 승인·반려 모달(코멘트, 반려 사유)
- 승인된 건에 대해 원청 제출 기능
- processApproval API에 rejectReason 필드 추가

## Test plan
- [ ] 결재 목록 페이지 렌더링 확인
- [ ] 상태/도메인 필터 동작 확인
- [ ] 결재 상세 페이지 진입 및 정보 표시 확인
- [ ] 승인/반려 모달 동작 및 API 호출 확인
- [ ] 원청 제출 버튼 동작 확인

Closes #42