### PR TITLE
심사 목록/상세/처리 페이지 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,6 +22,8 @@ import ApprovalDetailPage from './features/approvals/ApprovalDetailPage';
 import DiagnosticsListPage from './features/diagnostics/DiagnosticsListPage';
 import DiagnosticDetailPage from './features/diagnostics/DiagnosticDetailPage';
 import DiagnosticCreatePage from './features/diagnostics/DiagnosticCreatePage';
+import ReviewsListPage from './features/reviews/ReviewsListPage';
+import ReviewDetailPage from './features/reviews/ReviewDetailPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -135,6 +137,24 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <ApprovalDetailPage />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Reviews */}
+      <Route
+        path="/reviews"
+        element={
+          <ProtectedRoute>
+            <ReviewsListPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/reviews/:id"
+        element={
+          <ProtectedRoute>
+            <ReviewDetailPage />
           </ProtectedRoute>
         }
       />

--- a/features/reviews/ReviewDetailPage.tsx
+++ b/features/reviews/ReviewDetailPage.tsx
@@ -1,0 +1,318 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useReviewDetail, useSubmitReview, useGenerateReport } from '../../src/hooks/useReviews';
+import type { ReviewStatus, RiskLevel, DomainCode } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const STATUS_LABELS: Record<ReviewStatus, string> = {
+  REVIEWING: '심사중',
+  APPROVED: '승인',
+  REVISION_REQUIRED: '보완요청',
+};
+
+const STATUS_STYLES: Record<ReviewStatus, string> = {
+  REVIEWING: 'bg-blue-50 text-blue-700 border-blue-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REVISION_REQUIRED: 'bg-orange-50 text-orange-700 border-orange-200',
+};
+
+const RISK_LABELS: Record<string, { label: string; style: string }> = {
+  LOW: { label: '낮음', style: 'text-green-600' },
+  MEDIUM: { label: '보통', style: 'text-yellow-600' },
+  HIGH: { label: '높음', style: 'text-red-600' },
+};
+
+export default function ReviewDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const reviewId = Number(id);
+
+  const { data: review, isLoading, isError } = useReviewDetail(reviewId);
+  const submitReviewMutation = useSubmitReview();
+  const generateReportMutation = useGenerateReport();
+
+  const [showModal, setShowModal] = useState(false);
+  const [decision, setDecision] = useState<'APPROVED' | 'REVISION_REQUIRED'>('APPROVED');
+  const [score, setScore] = useState('');
+  const [comment, setComment] = useState('');
+  const [categoryE, setCategoryE] = useState('');
+  const [categoryS, setCategoryS] = useState('');
+  const [categoryG, setCategoryG] = useState('');
+
+  const handleSubmit = () => {
+    submitReviewMutation.mutate(
+      {
+        id: reviewId,
+        data: {
+          decision,
+          score: score ? Number(score) : undefined,
+          comment: comment || undefined,
+          categoryCommentE: categoryE || undefined,
+          categoryCommentS: categoryS || undefined,
+          categoryCommentG: categoryG || undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          setShowModal(false);
+          resetForm();
+        },
+      }
+    );
+  };
+
+  const resetForm = () => {
+    setScore('');
+    setComment('');
+    setCategoryE('');
+    setCategoryS('');
+    setCategoryG('');
+  };
+
+  const handleGenerateReport = () => {
+    generateReportMutation.mutate(reviewId);
+  };
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center py-[120px]">
+          <div className="w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (isError || !review) {
+    return (
+      <DashboardLayout>
+        <div className="flex flex-col items-center justify-center py-[120px] gap-[16px]">
+          <p className="font-body-medium text-[var(--color-state-error-text)]">심사 정보를 불러오는 데 실패했습니다.</p>
+          <button onClick={() => navigate('/reviews')} className="font-title-xsmall text-[var(--color-primary-main)] hover:underline">
+            목록으로 돌아가기
+          </button>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const isReviewing = review.status === 'REVIEWING';
+  const risk = review.riskLevel ? RISK_LABELS[review.riskLevel] : null;
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[900px] mx-auto w-full">
+        {/* 뒤로가기 */}
+        <button
+          onClick={() => navigate('/reviews')}
+          className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          목록으로
+        </button>
+
+        {/* 제목 + 상태 */}
+        <div className="flex items-start justify-between gap-[16px]">
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{review.title}</h1>
+          <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[review.status]}`}>
+            {STATUS_LABELS[review.status]}
+          </span>
+        </div>
+
+        {/* 기본 정보 */}
+        <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+          <div className="grid grid-cols-2 gap-[20px]">
+            <InfoRow label="도메인" value={DOMAIN_LABELS[review.domainCode as DomainCode] || review.domainCode} />
+            <InfoRow label="회사명" value={review.companyName} />
+            <InfoRow label="기안자" value={review.drafterName} />
+            <InfoRow label="제출일" value={new Date(review.submittedAt).toLocaleDateString('ko-KR')} />
+            {risk && <InfoRow label="위험 등급" value={risk.label} valueClassName={risk.style} />}
+            {review.score != null && <InfoRow label="점수" value={String(review.score)} />}
+          </div>
+        </div>
+
+        {/* AI 분석 결과 */}
+        {(review.aiVerdict || review.whySummary) && (
+          <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+            <h2 className="font-title-medium text-[var(--color-text-primary)] mb-[16px]">AI 분석 결과</h2>
+            {review.aiVerdict && (
+              <div className="mb-[12px]">
+                <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">AI 판정</p>
+                <p className="font-body-medium text-[var(--color-text-primary)]">{review.aiVerdict}</p>
+              </div>
+            )}
+            {review.whySummary && (
+              <div>
+                <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">판정 근거</p>
+                <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{review.whySummary}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 카테고리별 코멘트 (이미 제출된 경우) */}
+        {(review.categoryCommentE || review.categoryCommentS || review.categoryCommentG) && (
+          <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+            <h2 className="font-title-medium text-[var(--color-text-primary)] mb-[16px]">카테고리별 의견</h2>
+            <div className="flex flex-col gap-[12px]">
+              {review.categoryCommentE && <CategoryComment label="E (환경)" value={review.categoryCommentE} />}
+              {review.categoryCommentS && <CategoryComment label="S (사회)" value={review.categoryCommentS} />}
+              {review.categoryCommentG && <CategoryComment label="G (지배구조)" value={review.categoryCommentG} />}
+            </div>
+          </div>
+        )}
+
+        {/* 코멘트 */}
+        {review.comment && (
+          <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+            <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">심사 코멘트</p>
+            <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{review.comment}</p>
+          </div>
+        )}
+
+        {/* 액션 버튼 */}
+        <div className="flex gap-[12px] justify-end">
+          {!isReviewing && (
+            <button
+              onClick={handleGenerateReport}
+              disabled={generateReportMutation.isPending}
+              className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              {generateReportMutation.isPending ? '생성 중...' : '리포트 생성'}
+            </button>
+          )}
+          {isReviewing && (
+            <>
+              <button
+                onClick={() => { setDecision('REVISION_REQUIRED'); setShowModal(true); }}
+                className="px-[24px] py-[12px] rounded-[8px] border border-orange-300 text-orange-600 font-title-small hover:bg-orange-50 transition-colors"
+              >
+                보완요청
+              </button>
+              <button
+                onClick={() => { setDecision('APPROVED'); setShowModal(true); }}
+                className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+              >
+                승인
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* 심사 결과 제출 모달 */}
+      {showModal && (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-[16px] w-full max-w-[560px] mx-[16px] shadow-xl max-h-[90vh] overflow-y-auto">
+            <div className="px-[24px] py-[20px] border-b border-[var(--color-border-default)]">
+              <h2 className="font-title-medium text-[var(--color-text-primary)]">
+                {decision === 'APPROVED' ? '심사 승인' : '보완 요청'}
+              </h2>
+            </div>
+
+            <div className="px-[24px] py-[20px] flex flex-col gap-[16px]">
+              {/* 점수 */}
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">점수 (선택)</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={score}
+                  onChange={(e) => setScore(e.target.value)}
+                  placeholder="0 ~ 100"
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+
+              {/* 코멘트 */}
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">코멘트 (선택)</label>
+                <textarea
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  placeholder="코멘트를 입력하세요"
+                  rows={3}
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+
+              {/* 카테고리별 의견 */}
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">E (환경) 의견</label>
+                <textarea
+                  value={categoryE}
+                  onChange={(e) => setCategoryE(e.target.value)}
+                  placeholder="환경 관련 의견"
+                  rows={2}
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">S (사회) 의견</label>
+                <textarea
+                  value={categoryS}
+                  onChange={(e) => setCategoryS(e.target.value)}
+                  placeholder="사회 관련 의견"
+                  rows={2}
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">G (지배구조) 의견</label>
+                <textarea
+                  value={categoryG}
+                  onChange={(e) => setCategoryG(e.target.value)}
+                  placeholder="지배구조 관련 의견"
+                  rows={2}
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+            </div>
+
+            <div className="px-[24px] py-[16px] border-t border-[var(--color-border-default)] flex justify-end gap-[12px]">
+              <button
+                onClick={() => { setShowModal(false); resetForm(); }}
+                className="px-[20px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={submitReviewMutation.isPending}
+                className={`px-[20px] py-[10px] rounded-[8px] font-title-small text-white transition-colors disabled:opacity-50 ${
+                  decision === 'APPROVED'
+                    ? 'bg-[var(--color-primary-main)] hover:opacity-90'
+                    : 'bg-orange-500 hover:bg-orange-600'
+                }`}
+              >
+                {submitReviewMutation.isPending ? '처리 중...' : decision === 'APPROVED' ? '승인' : '보완요청'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}
+
+function InfoRow({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
+  return (
+    <div>
+      <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">{label}</p>
+      <p className={`font-body-medium ${valueClassName || 'text-[var(--color-text-primary)]'}`}>{value}</p>
+    </div>
+  );
+}
+
+function CategoryComment({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="font-title-xsmall text-[var(--color-text-secondary)] mb-[4px]">{label}</p>
+      <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{value}</p>
+    </div>
+  );
+}

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -1,0 +1,287 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useReviews, useBulkReport, useExportReviews } from '../../src/hooks/useReviews';
+import type { ReviewStatus, RiskLevel, DomainCode } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const STATUS_LABELS: Record<ReviewStatus, string> = {
+  REVIEWING: '심사중',
+  APPROVED: '승인',
+  REVISION_REQUIRED: '보완요청',
+};
+
+const STATUS_STYLES: Record<ReviewStatus, string> = {
+  REVIEWING: 'bg-blue-50 text-blue-700 border-blue-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REVISION_REQUIRED: 'bg-orange-50 text-orange-700 border-orange-200',
+};
+
+const RISK_STYLES: Record<RiskLevel, string> = {
+  LOW: 'text-green-600',
+  MEDIUM: 'text-yellow-600',
+  HIGH: 'text-red-600',
+};
+
+const RISK_LABELS: Record<RiskLevel, string> = {
+  LOW: '낮음',
+  MEDIUM: '보통',
+  HIGH: '높음',
+};
+
+type StatusFilter = ReviewStatus | 'ALL';
+type RiskFilter = RiskLevel | 'ALL';
+
+export default function ReviewsListPage() {
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [domainFilter, setDomainFilter] = useState('');
+  const [riskFilter, setRiskFilter] = useState<RiskFilter>('ALL');
+  const [page, setPage] = useState(0);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+
+  const { data, isLoading, isError } = useReviews({
+    status: statusFilter === 'ALL' ? undefined : statusFilter,
+    domainCode: domainFilter || undefined,
+    riskLevel: riskFilter === 'ALL' ? undefined : riskFilter,
+    page,
+    size: 10,
+  });
+
+  const bulkReportMutation = useBulkReport();
+  const exportMutation = useExportReviews();
+
+  const reviews = data?.content || [];
+  const totalPages = data?.page?.totalPages || 0;
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]
+    );
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedIds.length === reviews.length) {
+      setSelectedIds([]);
+    } else {
+      setSelectedIds(reviews.map((r) => r.reviewId));
+    }
+  };
+
+  const handleBulkReport = () => {
+    if (selectedIds.length === 0) return;
+    bulkReportMutation.mutate(selectedIds);
+  };
+
+  const handleExport = (format: 'EXCEL' | 'CSV') => {
+    const ids = selectedIds.length > 0 ? selectedIds : reviews.map((r) => r.reviewId);
+    exportMutation.mutate({ format, reviewIds: ids });
+  };
+
+  const statusTabs: { key: StatusFilter; label: string }[] = [
+    { key: 'ALL', label: '전체' },
+    { key: 'REVIEWING', label: '심사중' },
+    { key: 'APPROVED', label: '승인' },
+    { key: 'REVISION_REQUIRED', label: '보완요청' },
+  ];
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[1200px] mx-auto w-full">
+        <h1 className="font-heading-small text-[var(--color-text-primary)]">심사 관리</h1>
+
+        {/* 필터 */}
+        <div className="flex flex-wrap items-center gap-[12px]">
+          <div className="flex gap-[8px]">
+            {statusTabs.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => { setStatusFilter(tab.key); setPage(0); setSelectedIds([]); }}
+                className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+                  statusFilter === tab.key
+                    ? 'bg-[var(--color-primary-main)] text-white'
+                    : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          <select
+            value={domainFilter}
+            onChange={(e) => { setDomainFilter(e.target.value); setPage(0); }}
+            className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
+          >
+            <option value="">전체 도메인</option>
+            <option value="ESG">{DOMAIN_LABELS.ESG}</option>
+            <option value="SAFETY">{DOMAIN_LABELS.SAFETY}</option>
+            <option value="COMPLIANCE">{DOMAIN_LABELS.COMPLIANCE}</option>
+          </select>
+
+          <select
+            value={riskFilter}
+            onChange={(e) => { setRiskFilter(e.target.value as RiskFilter); setPage(0); }}
+            className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
+          >
+            <option value="ALL">전체 위험등급</option>
+            <option value="LOW">낮음</option>
+            <option value="MEDIUM">보통</option>
+            <option value="HIGH">높음</option>
+          </select>
+        </div>
+
+        {/* 액션 바 */}
+        <div className="flex items-center justify-between">
+          <p className="font-body-medium text-[var(--color-text-tertiary)]">
+            {selectedIds.length > 0 ? `${selectedIds.length}건 선택됨` : ''}
+          </p>
+          <div className="flex gap-[8px]">
+            <button
+              onClick={handleBulkReport}
+              disabled={selectedIds.length === 0 || bulkReportMutation.isPending}
+              className="px-[16px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-title-xsmall text-[var(--color-text-secondary)] hover:bg-gray-50 disabled:opacity-40 transition-colors"
+            >
+              {bulkReportMutation.isPending ? '생성 중...' : '일괄 리포트'}
+            </button>
+            <button
+              onClick={() => handleExport('EXCEL')}
+              disabled={exportMutation.isPending}
+              className="px-[16px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-title-xsmall text-[var(--color-text-secondary)] hover:bg-gray-50 disabled:opacity-40 transition-colors"
+            >
+              Excel
+            </button>
+            <button
+              onClick={() => handleExport('CSV')}
+              disabled={exportMutation.isPending}
+              className="px-[16px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-title-xsmall text-[var(--color-text-secondary)] hover:bg-gray-50 disabled:opacity-40 transition-colors"
+            >
+              CSV
+            </button>
+          </div>
+        </div>
+
+        {/* 테이블 */}
+        <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+                <th className="px-[16px] py-[12px] w-[48px]">
+                  <input
+                    type="checkbox"
+                    checked={reviews.length > 0 && selectedIds.length === reviews.length}
+                    onChange={toggleSelectAll}
+                    className="w-[16px] h-[16px] cursor-pointer"
+                  />
+                </th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
+                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">위험등급</th>
+                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">점수</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제출일</th>
+                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <tr>
+                  <td colSpan={8} className="text-center py-[60px]">
+                    <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+                  </td>
+                </tr>
+              )}
+
+              {isError && (
+                <tr>
+                  <td colSpan={8} className="text-center py-[60px]">
+                    <p className="font-body-medium text-[var(--color-state-error-text)]">심사 목록을 불러오는 데 실패했습니다.</p>
+                  </td>
+                </tr>
+              )}
+
+              {!isLoading && !isError && reviews.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="text-center py-[60px]">
+                    <p className="font-body-medium text-[var(--color-text-tertiary)]">심사 내역이 없습니다.</p>
+                  </td>
+                </tr>
+              )}
+
+              {reviews.map((item) => (
+                <tr
+                  key={item.reviewId}
+                  className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  <td className="px-[16px] py-[14px]" onClick={(e) => e.stopPropagation()}>
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.includes(item.reviewId)}
+                      onChange={() => toggleSelect(item.reviewId)}
+                      className="w-[16px] h-[16px] cursor-pointer"
+                    />
+                  </td>
+                  <td
+                    className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]"
+                    onClick={() => navigate(`/reviews/${item.reviewId}`)}
+                  >
+                    {item.title}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
+                    {DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
+                    {item.companyName}
+                  </td>
+                  <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
+                    {item.riskLevel ? (
+                      <span className={`font-title-xsmall ${RISK_STYLES[item.riskLevel]}`}>
+                        {RISK_LABELS[item.riskLevel]}
+                      </span>
+                    ) : (
+                      <span className="font-body-medium text-[var(--color-text-tertiary)]">-</span>
+                    )}
+                  </td>
+                  <td className="px-[16px] py-[14px] text-center font-body-medium text-[var(--color-text-primary)]" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
+                    {item.score != null ? item.score : '-'}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
+                    {new Date(item.submittedAt).toLocaleDateString('ko-KR')}
+                  </td>
+                  <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
+                    <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
+                      {STATUS_LABELS[item.status]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-[8px] pt-[16px]">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              이전
+            </button>
+            <span className="font-body-medium text-[var(--color-text-primary)]">
+              {page + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -39,6 +39,9 @@ export const ERROR_HANDLERS: Record<string, ErrorConfig> = {
   // Server
   S001: { action: 'toast', customMessage: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
 
+  // Review
+  RV001: { action: 'toast', customMessage: '심사 건을 찾을 수 없습니다.' },
+
   // AI
   AI001: { action: 'toast', customMessage: 'AI 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.' },
   AI002: { action: 'toast', customMessage: '이미 분석이 진행 중입니다. 완료 후 다시 시도해주세요.' },


### PR DESCRIPTION
## Summary
- 심사 목록 페이지: 상태/도메인/위험등급 필터, 체크박스 선택, 일괄 리포트, Excel/CSV 내보내기
- 심사 상세 페이지: 기본 정보, AI 분석 결과, 카테고리별(E/S/G) 의견 표시
- 심사 결과 제출 모달: 점수, 코멘트, E/S/G 카테고리별 의견 입력
- 리포트 생성 (단건/일괄) 및 내보내기 기능
- API/Hook 확장 및 RV001 에러 코드 추가

## Test plan
- [ ] 심사 목록 페이지 렌더링 및 필터 동작 확인
- [ ] 체크박스 선택 및 일괄 리포트 동작 확인
- [ ] Excel/CSV 내보내기 동작 확인
- [ ] 심사 상세 페이지 진입 및 정보 표시 확인
- [ ] 승인/보완요청 모달 동작 및 API 호출 확인
- [ ] 리포트 생성 버튼 동작 확인

Closes #43