### PR TITLE
진단 목록/상세/생성 페이지 UI 구현 및 API 연동

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,6 +19,9 @@ import PermissionManagementPage from './features/permission/PermissionManagement
 import NotificationsPage from './features/notifications/NotificationsPage';
 import ApprovalsListPage from './features/approvals/ApprovalsListPage';
 import ApprovalDetailPage from './features/approvals/ApprovalDetailPage';
+import DiagnosticsListPage from './features/diagnostics/DiagnosticsListPage';
+import DiagnosticDetailPage from './features/diagnostics/DiagnosticDetailPage';
+import DiagnosticCreatePage from './features/diagnostics/DiagnosticCreatePage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +91,32 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <PermissionManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Diagnostics */}
+      <Route
+        path="/diagnostics"
+        element={
+          <ProtectedRoute>
+            <DiagnosticsListPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/diagnostics/new"
+        element={
+          <ProtectedRoute>
+            <DiagnosticCreatePage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/diagnostics/:id"
+        element={
+          <ProtectedRoute>
+            <DiagnosticDetailPage />
           </ProtectedRoute>
         }
       />

--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCreateDiagnostic } from '../../src/hooks/useDiagnostics';
+import { diagnosticCreateSchema, type DiagnosticCreateFormData } from '../../src/validation/diagnostic';
+import type { DomainCode } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const DOMAIN_OPTIONS: { value: DomainCode; label: string }[] = [
+  { value: 'ESG', label: DOMAIN_LABELS.ESG },
+  { value: 'SAFETY', label: DOMAIN_LABELS.SAFETY },
+  { value: 'COMPLIANCE', label: DOMAIN_LABELS.COMPLIANCE },
+];
+
+export default function DiagnosticCreatePage() {
+  const navigate = useNavigate();
+  const createMutation = useCreateDiagnostic();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<DiagnosticCreateFormData>({
+    resolver: zodResolver(diagnosticCreateSchema),
+    defaultValues: {
+      title: '',
+      domainCode: undefined,
+      periodStartDate: '',
+      periodEndDate: '',
+    },
+  });
+
+  const onSubmit = async (data: DiagnosticCreateFormData) => {
+    createMutation.mutate(data, {
+      onSuccess: (result) => {
+        navigate(`/diagnostics/${result.diagnosticId}`);
+      },
+    });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[700px] mx-auto w-full">
+        {/* 뒤로가기 */}
+        <button
+          onClick={() => navigate('/diagnostics')}
+          className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          목록으로
+        </button>
+
+        {/* 제목 */}
+        <h1 className="font-heading-small text-[var(--color-text-primary)]">새 진단 생성</h1>
+
+        {/* 폼 */}
+        <form onSubmit={handleSubmit(onSubmit)} className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+          <div className="flex flex-col gap-[24px]">
+            {/* 제목 */}
+            <div>
+              <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                진단 제목 <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                {...register('title')}
+                placeholder="진단 제목을 입력하세요"
+                className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] ${
+                  errors.title ? 'border-red-500' : 'border-[var(--color-border-default)]'
+                }`}
+              />
+              {errors.title && (
+                <p className="mt-[4px] font-body-small text-red-500">{errors.title.message}</p>
+              )}
+            </div>
+
+            {/* 도메인 */}
+            <div>
+              <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                도메인 <span className="text-red-500">*</span>
+              </label>
+              <select
+                {...register('domainCode')}
+                className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] bg-white ${
+                  errors.domainCode ? 'border-red-500' : 'border-[var(--color-border-default)]'
+                }`}
+              >
+                <option value="">도메인을 선택하세요</option>
+                {DOMAIN_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              {errors.domainCode && (
+                <p className="mt-[4px] font-body-small text-red-500">{errors.domainCode.message}</p>
+              )}
+            </div>
+
+            {/* 진단 기간 */}
+            <div className="grid grid-cols-2 gap-[16px]">
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                  진단 시작일 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="date"
+                  {...register('periodStartDate')}
+                  className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] ${
+                    errors.periodStartDate ? 'border-red-500' : 'border-[var(--color-border-default)]'
+                  }`}
+                />
+                {errors.periodStartDate && (
+                  <p className="mt-[4px] font-body-small text-red-500">{errors.periodStartDate.message}</p>
+                )}
+              </div>
+
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                  진단 종료일 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="date"
+                  {...register('periodEndDate')}
+                  className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] ${
+                    errors.periodEndDate ? 'border-red-500' : 'border-[var(--color-border-default)]'
+                  }`}
+                />
+                {errors.periodEndDate && (
+                  <p className="mt-[4px] font-body-small text-red-500">{errors.periodEndDate.message}</p>
+                )}
+              </div>
+            </div>
+
+            {/* 버튼 */}
+            <div className="flex justify-end gap-[12px] pt-[16px] border-t border-[var(--color-border-default)]">
+              <button
+                type="button"
+                onClick={() => navigate('/diagnostics')}
+                className="px-[20px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting || createMutation.isPending}
+                className="px-[20px] py-[10px] rounded-[8px] bg-[var(--color-primary-main)] font-title-small text-white hover:opacity-90 transition-colors disabled:opacity-50"
+              >
+                {createMutation.isPending ? '생성 중...' : '진단 생성'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  useDiagnosticDetail,
+  useDiagnosticHistory,
+  useSubmitDiagnostic,
+} from '../../src/hooks/useDiagnostics';
+import type { DiagnosticStatus, DomainCode } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const STATUS_LABELS: Record<DiagnosticStatus, string> = {
+  WRITING: '작성중',
+  SUBMITTED: '제출됨',
+  RETURNED: '반려됨',
+  APPROVED: '승인됨',
+  REVIEWING: '심사중',
+  COMPLETED: '완료',
+};
+
+const STATUS_STYLES: Record<DiagnosticStatus, string> = {
+  WRITING: 'bg-gray-50 text-gray-700 border-gray-200',
+  SUBMITTED: 'bg-blue-50 text-blue-700 border-blue-200',
+  RETURNED: 'bg-red-50 text-red-700 border-red-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REVIEWING: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  COMPLETED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+};
+
+export default function DiagnosticDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const diagnosticId = Number(id);
+
+  const { data: diagnostic, isLoading, isError } = useDiagnosticDetail(diagnosticId);
+  const { data: history } = useDiagnosticHistory(diagnosticId);
+  const submitMutation = useSubmitDiagnostic();
+
+  const [showSubmitModal, setShowSubmitModal] = useState(false);
+  const [approverId, setApproverId] = useState<number | ''>('');
+  const [comment, setComment] = useState('');
+
+  const handleSubmit = () => {
+    if (!approverId) return;
+    submitMutation.mutate(
+      {
+        id: diagnosticId,
+        data: {
+          approverId: Number(approverId),
+          comment: comment || undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          setShowSubmitModal(false);
+          setApproverId('');
+          setComment('');
+        },
+      }
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center py-[120px]">
+          <div className="w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (isError || !diagnostic) {
+    return (
+      <DashboardLayout>
+        <div className="flex flex-col items-center justify-center py-[120px] gap-[16px]">
+          <p className="font-body-medium text-[var(--color-state-error-text)]">
+            진단 정보를 불러오는 데 실패했습니다.
+          </p>
+          <button
+            onClick={() => navigate('/diagnostics')}
+            className="font-title-xsmall text-[var(--color-primary-main)] hover:underline"
+          >
+            목록으로 돌아가기
+          </button>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const canSubmit = diagnostic.status === 'WRITING' || diagnostic.status === 'RETURNED';
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[900px] mx-auto w-full">
+        {/* 뒤로가기 */}
+        <button
+          onClick={() => navigate('/diagnostics')}
+          className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          목록으로
+        </button>
+
+        {/* 제목 + 상태 */}
+        <div className="flex items-start justify-between gap-[16px]">
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{diagnostic.title}</h1>
+          <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[diagnostic.status]}`}>
+            {STATUS_LABELS[diagnostic.status]}
+          </span>
+        </div>
+
+        {/* 기본 정보 */}
+        <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+          <h2 className="font-title-medium text-[var(--color-text-primary)] mb-[20px]">진단 정보</h2>
+          <div className="grid grid-cols-2 gap-[20px]">
+            <InfoRow label="도메인" value={DOMAIN_LABELS[diagnostic.domainCode as DomainCode] || diagnostic.domainCode} />
+            <InfoRow label="회사명" value={diagnostic.company.companyName} />
+            <InfoRow label="기안자" value={diagnostic.drafter.name} />
+            <InfoRow label="생성일" value={new Date(diagnostic.createdAt).toLocaleDateString('ko-KR')} />
+            <InfoRow label="진단 시작일" value={new Date(diagnostic.periodStartDate).toLocaleDateString('ko-KR')} />
+            <InfoRow label="진단 종료일" value={new Date(diagnostic.periodEndDate).toLocaleDateString('ko-KR')} />
+            {diagnostic.submittedAt && (
+              <InfoRow label="제출일" value={new Date(diagnostic.submittedAt).toLocaleDateString('ko-KR')} />
+            )}
+          </div>
+        </div>
+
+        {/* 이력 */}
+        {history && history.length > 0 && (
+          <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
+            <h2 className="font-title-medium text-[var(--color-text-primary)] mb-[20px]">진단 이력</h2>
+            <div className="space-y-[16px]">
+              {history.map((item, index) => (
+                <div
+                  key={index}
+                  className="flex items-start gap-[12px] pb-[16px] border-b border-[var(--color-border-default)] last:border-b-0 last:pb-0"
+                >
+                  <span className={`shrink-0 inline-block px-[8px] py-[2px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
+                    {STATUS_LABELS[item.status]}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-body-medium text-[var(--color-text-primary)]">
+                      {item.changedBy}
+                    </p>
+                    {item.comment && (
+                      <p className="font-body-small text-[var(--color-text-tertiary)] mt-[4px]">
+                        {item.comment}
+                      </p>
+                    )}
+                  </div>
+                  <span className="shrink-0 font-body-small text-[var(--color-text-tertiary)]">
+                    {new Date(item.changedAt).toLocaleString('ko-KR')}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 액션 버튼 */}
+        {canSubmit && (
+          <div className="flex justify-end gap-[12px]">
+            <button
+              onClick={() => setShowSubmitModal(true)}
+              className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+            >
+              결재자에게 제출
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 제출 모달 */}
+      {showSubmitModal && (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-[16px] w-full max-w-[480px] mx-[16px] shadow-xl">
+            <div className="px-[24px] py-[20px] border-b border-[var(--color-border-default)]">
+              <h2 className="font-title-medium text-[var(--color-text-primary)]">
+                진단 제출
+              </h2>
+            </div>
+
+            <div className="px-[24px] py-[20px] flex flex-col gap-[16px]">
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                  결재자 ID <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="number"
+                  value={approverId}
+                  onChange={(e) => setApproverId(e.target.value ? Number(e.target.value) : '')}
+                  placeholder="결재자 ID를 입력하세요"
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+
+              <div>
+                <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
+                  코멘트 (선택)
+                </label>
+                <textarea
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  placeholder="코멘트를 입력하세요"
+                  rows={3}
+                  className="w-full px-[12px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] resize-none focus:outline-none focus:border-[var(--color-primary-main)]"
+                />
+              </div>
+            </div>
+
+            <div className="px-[24px] py-[16px] border-t border-[var(--color-border-default)] flex justify-end gap-[12px]">
+              <button
+                onClick={() => { setShowSubmitModal(false); setApproverId(''); setComment(''); }}
+                className="px-[20px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={!approverId || submitMutation.isPending}
+                className="px-[20px] py-[10px] rounded-[8px] bg-[var(--color-primary-main)] font-title-small text-white hover:opacity-90 transition-colors disabled:opacity-50"
+              >
+                {submitMutation.isPending ? '제출 중...' : '제출'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}
+
+function InfoRow({ label, value, valueClassName }: { label: string; value: string; valueClassName?: string }) {
+  return (
+    <div>
+      <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">{label}</p>
+      <p className={`font-body-medium ${valueClassName || 'text-[var(--color-text-primary)]'}`}>{value}</p>
+    </div>
+  );
+}

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
+import type { DiagnosticStatus, DomainCode } from '../../src/types/api.types';
+import { DOMAIN_LABELS } from '../../src/types/api.types';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+const STATUS_LABELS: Record<DiagnosticStatus, string> = {
+  WRITING: '작성중',
+  SUBMITTED: '제출됨',
+  RETURNED: '반려됨',
+  APPROVED: '승인됨',
+  REVIEWING: '심사중',
+  COMPLETED: '완료',
+};
+
+const STATUS_STYLES: Record<DiagnosticStatus, string> = {
+  WRITING: 'bg-gray-50 text-gray-700 border-gray-200',
+  SUBMITTED: 'bg-blue-50 text-blue-700 border-blue-200',
+  RETURNED: 'bg-red-50 text-red-700 border-red-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REVIEWING: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  COMPLETED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+};
+
+type StatusFilter = DiagnosticStatus | 'ALL';
+
+export default function DiagnosticsListPage() {
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [domainFilter, setDomainFilter] = useState<string>('');
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading, isError, refetch } = useDiagnosticsList({
+    status: statusFilter === 'ALL' ? undefined : statusFilter,
+    domainCode: domainFilter || undefined,
+    page,
+    size: 10,
+  });
+
+  const diagnostics = data?.content || [];
+  const pageInfo = data?.page;
+  const totalPages = pageInfo?.totalPages || 0;
+
+  const statusTabs: { key: StatusFilter; label: string }[] = [
+    { key: 'ALL', label: '전체' },
+    { key: 'WRITING', label: '작성중' },
+    { key: 'SUBMITTED', label: '제출됨' },
+    { key: 'RETURNED', label: '반려됨' },
+    { key: 'APPROVED', label: '승인됨' },
+    { key: 'REVIEWING', label: '심사중' },
+    { key: 'COMPLETED', label: '완료' },
+  ];
+
+  const domainOptions: { value: string; label: string }[] = [
+    { value: '', label: '전체 도메인' },
+    { value: 'ESG', label: DOMAIN_LABELS.ESG },
+    { value: 'SAFETY', label: DOMAIN_LABELS.SAFETY },
+    { value: 'COMPLIANCE', label: DOMAIN_LABELS.COMPLIANCE },
+  ];
+
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[1200px] mx-auto w-full">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between">
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">진단 관리</h1>
+          <button
+            onClick={() => navigate('/diagnostics/new')}
+            className="px-[20px] py-[10px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+          >
+            + 새 진단 생성
+          </button>
+        </div>
+
+        {/* 필터 영역 */}
+        <div className="flex flex-wrap items-center gap-[12px]">
+          {/* 상태 탭 */}
+          <div className="flex flex-wrap gap-[8px]">
+            {statusTabs.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => { setStatusFilter(tab.key); setPage(0); }}
+                className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+                  statusFilter === tab.key
+                    ? 'bg-[var(--color-primary-main)] text-white'
+                    : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* 도메인 필터 */}
+          <select
+            value={domainFilter}
+            onChange={(e) => { setDomainFilter(e.target.value); setPage(0); }}
+            className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
+          >
+            {domainOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* 테이블 */}
+        <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기간</th>
+                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <tr>
+                  <td colSpan={5} className="text-center py-[60px]">
+                    <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+                  </td>
+                </tr>
+              )}
+
+              {isError && (
+                <tr>
+                  <td colSpan={5} className="text-center py-[60px]">
+                    <div className="flex flex-col items-center gap-[12px]">
+                      <p className="font-body-medium text-[var(--color-state-error-text)]">
+                        진단 목록을 불러오는 데 실패했습니다.
+                      </p>
+                      <button
+                        onClick={() => refetch()}
+                        className="font-title-xsmall text-[var(--color-primary-main)] hover:underline"
+                      >
+                        다시 시도
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              )}
+
+              {!isLoading && !isError && diagnostics.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="text-center py-[60px]">
+                    <p className="font-body-medium text-[var(--color-text-tertiary)]">
+                      진단 내역이 없습니다.
+                    </p>
+                  </td>
+                </tr>
+              )}
+
+              {diagnostics.map((item) => (
+                <tr
+                  key={item.diagnosticId}
+                  onClick={() => navigate(`/diagnostics/${item.diagnosticId}`)}
+                  className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
+                    {item.title}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+                    {DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+                    {item.companyName}
+                  </td>
+                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
+                    {item.period}
+                  </td>
+                  <td className="px-[16px] py-[14px] text-center">
+                    <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
+                      {STATUS_LABELS[item.status]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-[8px] pt-[16px]">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              이전
+            </button>
+            <span className="font-body-medium text-[var(--color-text-primary)]">
+              {page + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-[12px] py-[8px] rounded-[8px] font-body-medium text-[var(--color-text-secondary)] hover:bg-gray-100 disabled:opacity-40"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -65,8 +65,16 @@ export const createDiagnostic = async (data: DiagnosticCreateRequest): Promise<D
   return response.data.data;
 };
 
-export const submitDiagnostic = async (id: number): Promise<void> => {
-  await apiClient.post(`/v1/diagnostics/${id}/submit`);
+export interface DiagnosticSubmitRequest {
+  approverId: number;
+  comment?: string;
+}
+
+export const submitDiagnostic = async (
+  id: number,
+  data: DiagnosticSubmitRequest
+): Promise<void> => {
+  await apiClient.post(`/v1/diagnostics/${id}/submit`, data);
 };
 
 export const getDiagnosticHistory = async (id: number): Promise<DiagnosticHistoryItem[]> => {

--- a/src/hooks/useDiagnostics.ts
+++ b/src/hooks/useDiagnostics.ts
@@ -47,7 +47,13 @@ export const useSubmitDiagnostic = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: diagnosticsApi.submitDiagnostic,
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: diagnosticsApi.DiagnosticSubmitRequest;
+    }) => diagnosticsApi.submitDiagnostic(id, data),
     onSuccess: () => {
       toast.success('기안이 제출되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['diagnostics'] });


### PR DESCRIPTION
## Summary
- 진단(Diagnostic) 목록/상세/생성 페이지 구현
- 역할별 진단 관리 기능 제공 (DRAFTER 중심)
- Zod 기반 폼 검증 및 React Query 상태 관리

## 변경 사항
- `features/diagnostics/DiagnosticsListPage.tsx`: 목록 조회, 상태/도메인 필터링, 페이지네이션
- `features/diagnostics/DiagnosticDetailPage.tsx`: 상세 조회, 이력 표시, 결재자 제출 모달
- `features/diagnostics/DiagnosticCreatePage.tsx`: Zod 검증 기반 진단 생성 폼
- `src/api/diagnostics.ts`: submitDiagnostic API 업데이트 (approverId, comment 추가)
- `src/hooks/useDiagnostics.ts`: useSubmitDiagnostic hook 업데이트
- `App.tsx`: 라우트 추가 (/diagnostics, /diagnostics/new, /diagnostics/:id)

## Test plan
- [ ] /diagnostics 접속 시 진단 목록 표시 확인
- [ ] 상태/도메인 필터 동작 확인
- [ ] /diagnostics/new 접속 시 생성 폼 표시 확인
- [ ] 진단 생성 후 상세 페이지 이동 확인
- [ ] /diagnostics/:id 접속 시 상세 정보 및 이력 표시 확인
- [ ] 결재자 제출 모달 동작 확인
- [ ] 로딩/에러/empty 상태 UI 확인

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)