### PR TITLE
feat: #44 사용자/회사 관리 페이지 UI 구현 및 API 연동 (관리자)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,8 @@ import DiagnosticDetailPage from './features/diagnostics/DiagnosticDetailPage';
 import DiagnosticCreatePage from './features/diagnostics/DiagnosticCreatePage';
 import ReviewsListPage from './features/reviews/ReviewsListPage';
 import ReviewDetailPage from './features/reviews/ReviewDetailPage';
+import UserManagementPage from './features/management/UserManagementPage';
+import CompanyManagementPage from './features/management/CompanyManagementPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -93,6 +95,24 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <PermissionManagementPage />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Management Routes */}
+      <Route
+        path="/management/users"
+        element={
+          <ProtectedRoute>
+            <UserManagementPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/management/companies"
+        element={
+          <ProtectedRoute>
+            <CompanyManagementPage />
           </ProtectedRoute>
         }
       />

--- a/features/management/CompanyManagementPage.tsx
+++ b/features/management/CompanyManagementPage.tsx
@@ -1,0 +1,518 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Search, Building2, ChevronLeft, ChevronRight, Plus, X } from 'lucide-react';
+import { useCompanies, useRegisterCompany } from '../../src/hooks/useManagement';
+import type { CompanyListParams, RegisterCompanyRequest } from '../../src/api/management';
+import { z } from 'zod';
+
+const companySchema = z.object({
+  companyName: z.string().min(1, '회사명을 입력해주세요.').max(100, '회사명은 100자 이내로 입력해주세요.'),
+  companyType: z.enum(['SUPPLIER', 'CONTRACTOR'], { required_error: '회사 유형을 선택해주세요.' }),
+  businessNumber: z
+    .string()
+    .regex(/^\d{3}-\d{2}-\d{5}$/, '올바른 사업자등록번호 형식이 아닙니다. (예: 123-45-67890)')
+    .optional()
+    .or(z.literal('')),
+  address: z.string().max(200, '주소는 200자 이내로 입력해주세요.').optional(),
+  contactEmail: z.string().email('올바른 이메일 형식이 아닙니다.').optional().or(z.literal('')),
+  contactPhone: z
+    .string()
+    .regex(/^(\d{2,3}-\d{3,4}-\d{4})?$/, '올바른 전화번호 형식이 아닙니다. (예: 02-1234-5678)')
+    .optional()
+    .or(z.literal('')),
+});
+
+type CompanyFormData = z.infer<typeof companySchema>;
+
+const COMPANY_TYPE_OPTIONS = [
+  { value: '', label: '전체 유형' },
+  { value: 'SUPPLIER', label: '공급업체' },
+  { value: 'CONTRACTOR', label: '협력업체' },
+];
+
+const getCompanyTypeLabel = (type: string) => {
+  switch (type) {
+    case 'SUPPLIER':
+      return '공급업체';
+    case 'CONTRACTOR':
+      return '협력업체';
+    default:
+      return type;
+  }
+};
+
+const getCompanyTypeBadge = (type: string) => {
+  if (type === 'SUPPLIER') {
+    return (
+      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-[#e3f2fd] text-[#1565c0]">
+        공급업체
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-[#f3e5f5] text-[#7b1fa2]">
+      협력업체
+    </span>
+  );
+};
+
+export default function CompanyManagementPage() {
+  const navigate = useNavigate();
+  const [params, setParams] = useState<CompanyListParams>({ page: 0, size: 10 });
+  const [searchInput, setSearchInput] = useState('');
+  const [showRegisterModal, setShowRegisterModal] = useState(false);
+  const [formData, setFormData] = useState<CompanyFormData>({
+    companyName: '',
+    companyType: 'SUPPLIER',
+    businessNumber: '',
+    address: '',
+    contactEmail: '',
+    contactPhone: '',
+  });
+  const [formErrors, setFormErrors] = useState<Partial<Record<keyof CompanyFormData, string>>>({});
+
+  const { data, isLoading, error } = useCompanies(params);
+  const registerMutation = useRegisterCompany();
+
+  const handleSearch = () => {
+    setParams((prev) => ({ ...prev, search: searchInput, page: 0 }));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const handleTypeFilter = (type: string) => {
+    setParams((prev) => ({
+      ...prev,
+      companyType: type ? (type as 'SUPPLIER' | 'CONTRACTOR') : undefined,
+      page: 0,
+    }));
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setParams((prev) => ({ ...prev, page: newPage }));
+  };
+
+  const handleInputChange = (field: keyof CompanyFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (formErrors[field]) {
+      setFormErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const handleBusinessNumberChange = (value: string) => {
+    const digits = value.replace(/\D/g, '');
+    let formatted = '';
+    if (digits.length <= 3) {
+      formatted = digits;
+    } else if (digits.length <= 5) {
+      formatted = `${digits.slice(0, 3)}-${digits.slice(3)}`;
+    } else {
+      formatted = `${digits.slice(0, 3)}-${digits.slice(3, 5)}-${digits.slice(5, 10)}`;
+    }
+    handleInputChange('businessNumber', formatted);
+  };
+
+  const handlePhoneChange = (value: string) => {
+    const digits = value.replace(/\D/g, '');
+    let formatted = '';
+    if (digits.length <= 2) {
+      formatted = digits;
+    } else if (digits.length <= 6) {
+      formatted = `${digits.slice(0, 2)}-${digits.slice(2)}`;
+    } else if (digits.length <= 10) {
+      if (digits.startsWith('02')) {
+        formatted = `${digits.slice(0, 2)}-${digits.slice(2, 6)}-${digits.slice(6)}`;
+      } else {
+        formatted = `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+      }
+    } else {
+      if (digits.startsWith('02')) {
+        formatted = `${digits.slice(0, 2)}-${digits.slice(2, 6)}-${digits.slice(6, 10)}`;
+      } else {
+        formatted = `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7, 11)}`;
+      }
+    }
+    handleInputChange('contactPhone', formatted);
+  };
+
+  const resetForm = () => {
+    setFormData({
+      companyName: '',
+      companyType: 'SUPPLIER',
+      businessNumber: '',
+      address: '',
+      contactEmail: '',
+      contactPhone: '',
+    });
+    setFormErrors({});
+  };
+
+  const handleCloseModal = () => {
+    resetForm();
+    setShowRegisterModal(false);
+  };
+
+  const handleSubmit = () => {
+    const result = companySchema.safeParse(formData);
+
+    if (!result.success) {
+      const errors: Partial<Record<keyof CompanyFormData, string>> = {};
+      result.error.errors.forEach((err) => {
+        const field = err.path[0] as keyof CompanyFormData;
+        errors[field] = err.message;
+      });
+      setFormErrors(errors);
+      return;
+    }
+
+    const requestData: RegisterCompanyRequest = {
+      companyName: formData.companyName,
+      companyType: formData.companyType,
+      ...(formData.businessNumber && { businessNumber: formData.businessNumber }),
+      ...(formData.address && { address: formData.address }),
+      ...(formData.contactEmail && { contactEmail: formData.contactEmail }),
+      ...(formData.contactPhone && { contactPhone: formData.contactPhone }),
+    };
+
+    registerMutation.mutate(requestData, {
+      onSuccess: () => {
+        handleCloseModal();
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8f9fa]">
+      {/* Header */}
+      <header className="bg-white border-b border-[#dee2e6] px-6 py-4">
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => navigate('/dashboard')}
+              className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5 text-[#495057]" />
+            </button>
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 bg-[#003087] rounded-full flex items-center justify-center">
+                <Building2 className="w-5 h-5 text-white" />
+              </div>
+              <div>
+                <h1 className="font-heading-small text-[#212529]">회사 관리</h1>
+                <p className="font-detail-small text-[#868e96]">협력사 및 공급업체를 관리합니다</p>
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={() => setShowRegisterModal(true)}
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#003087] text-white rounded-[10px] font-body-medium hover:bg-[#002266] transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            회사 등록
+          </button>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto p-6">
+        {/* Filters */}
+        <div className="bg-white rounded-[16px] p-4 mb-6 border border-[#dee2e6]">
+          <div className="flex flex-wrap gap-4 items-center">
+            {/* Search */}
+            <div className="flex-1 min-w-[280px] relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#adb5bd]" />
+              <input
+                type="text"
+                placeholder="회사명으로 검색"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="w-full pl-10 pr-4 py-2.5 rounded-[8px] border border-[#dee2e6] font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none focus:border-[#003087]"
+              />
+            </div>
+
+            {/* Type Filter */}
+            <select
+              value={params.companyType || ''}
+              onChange={(e) => handleTypeFilter(e.target.value)}
+              className="px-4 py-2.5 rounded-[8px] border border-[#dee2e6] font-body-medium text-[#212529] focus:outline-none focus:border-[#003087] bg-white"
+            >
+              {COMPANY_TYPE_OPTIONS.map((type) => (
+                <option key={type.value} value={type.value}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+
+            <button
+              onClick={handleSearch}
+              className="px-6 py-2.5 bg-[#003087] text-white rounded-[8px] font-body-medium hover:bg-[#002266] transition-colors"
+            >
+              검색
+            </button>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white rounded-[16px] border border-[#dee2e6] overflow-hidden">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin w-8 h-8 border-2 border-[#003087] border-t-transparent rounded-full" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <p className="font-body-medium text-[#dc3545] mb-2">데이터를 불러오는 중 오류가 발생했습니다.</p>
+              <button
+                onClick={() => window.location.reload()}
+                className="text-[#003087] font-body-medium hover:underline"
+              >
+                새로고침
+              </button>
+            </div>
+          ) : !data?.content.length ? (
+            <div className="flex flex-col items-center justify-center py-20">
+              <Building2 className="w-12 h-12 text-[#adb5bd] mb-4" />
+              <p className="font-body-medium text-[#868e96] mb-4">등록된 회사가 없습니다.</p>
+              <button
+                onClick={() => setShowRegisterModal(true)}
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#003087] text-white rounded-[10px] font-body-medium hover:bg-[#002266] transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                첫 번째 회사 등록하기
+              </button>
+            </div>
+          ) : (
+            <>
+              <table className="w-full">
+                <thead className="bg-[#f8f9fa] border-b border-[#dee2e6]">
+                  <tr>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">회사명</th>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">유형</th>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">소속 사용자</th>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">등록일</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.content.map((company) => (
+                    <tr key={company.companyId} className="border-b border-[#dee2e6] last:border-b-0 hover:bg-[#f8f9fa] transition-colors">
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-3">
+                          <div className="w-9 h-9 bg-[#f8f9fa] rounded-full flex items-center justify-center border border-[#dee2e6]">
+                            <Building2 className="w-4 h-4 text-[#868e96]" />
+                          </div>
+                          <p className="font-body-medium text-[#212529]">{company.companyName}</p>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">{getCompanyTypeBadge(company.companyType)}</td>
+                      <td className="px-6 py-4">
+                        <span className="font-body-medium text-[#495057]">{company.userCount}명</span>
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className="font-body-medium text-[#868e96]">
+                          {company.createdAt
+                            ? new Date(company.createdAt).toLocaleDateString('ko-KR', {
+                                year: 'numeric',
+                                month: 'long',
+                                day: 'numeric',
+                              })
+                            : '-'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              {/* Pagination */}
+              {data.page && data.page.totalPages > 1 && (
+                <div className="flex items-center justify-between px-6 py-4 border-t border-[#dee2e6]">
+                  <p className="font-detail-small text-[#868e96]">
+                    총 {data.page.totalElements}개 중 {data.page.number * data.page.size + 1}-
+                    {Math.min((data.page.number + 1) * data.page.size, data.page.totalElements)}개
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handlePageChange(data.page.number - 1)}
+                      disabled={data.page.number === 0}
+                      className="p-2 rounded-[6px] border border-[#dee2e6] hover:bg-[#f8f9fa] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <ChevronLeft className="w-4 h-4 text-[#495057]" />
+                    </button>
+                    <span className="font-body-medium text-[#495057] px-3">
+                      {data.page.number + 1} / {data.page.totalPages}
+                    </span>
+                    <button
+                      onClick={() => handlePageChange(data.page.number + 1)}
+                      disabled={data.page.number >= data.page.totalPages - 1}
+                      className="p-2 rounded-[6px] border border-[#dee2e6] hover:bg-[#f8f9fa] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <ChevronRight className="w-4 h-4 text-[#495057]" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+
+      {/* Register Company Modal */}
+      {showRegisterModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-[24px] p-[32px] w-[560px] flex flex-col gap-[24px] shadow-xl max-h-[90vh] overflow-y-auto">
+            {/* Header */}
+            <div className="flex justify-between items-center">
+              <h2 className="font-heading-small text-[#212529]">회사 등록</h2>
+              <button onClick={handleCloseModal} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+                <X className="w-5 h-5 text-[#868e96]" />
+              </button>
+            </div>
+
+            {/* Form */}
+            <div className="flex flex-col gap-[20px]">
+              {/* Company Name */}
+              <div className="flex flex-col gap-2">
+                <label className="font-title-small text-[#212529]">
+                  회사명 <span className="text-[#dc3545]">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.companyName}
+                  onChange={(e) => handleInputChange('companyName', e.target.value)}
+                  placeholder="회사명을 입력해주세요"
+                  className={`w-full px-4 py-3 rounded-[12px] border font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none ${
+                    formErrors.companyName ? 'border-[#dc3545] focus:border-[#dc3545]' : 'border-[#dee2e6] focus:border-[#003087]'
+                  }`}
+                />
+                {formErrors.companyName && (
+                  <p className="font-detail-small text-[#dc3545]">{formErrors.companyName}</p>
+                )}
+              </div>
+
+              {/* Company Type */}
+              <div className="flex flex-col gap-2">
+                <label className="font-title-small text-[#212529]">
+                  회사 유형 <span className="text-[#dc3545]">*</span>
+                </label>
+                <div className="flex gap-3">
+                  <button
+                    type="button"
+                    onClick={() => handleInputChange('companyType', 'SUPPLIER')}
+                    className={`flex-1 py-3 px-4 rounded-[12px] border-2 font-body-medium transition-all ${
+                      formData.companyType === 'SUPPLIER'
+                        ? 'border-[#003087] bg-[#e7f1ff] text-[#003087]'
+                        : 'border-[#dee2e6] bg-white text-[#868e96] hover:border-[#adb5bd]'
+                    }`}
+                  >
+                    공급업체
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleInputChange('companyType', 'CONTRACTOR')}
+                    className={`flex-1 py-3 px-4 rounded-[12px] border-2 font-body-medium transition-all ${
+                      formData.companyType === 'CONTRACTOR'
+                        ? 'border-[#003087] bg-[#e7f1ff] text-[#003087]'
+                        : 'border-[#dee2e6] bg-white text-[#868e96] hover:border-[#adb5bd]'
+                    }`}
+                  >
+                    협력업체
+                  </button>
+                </div>
+              </div>
+
+              {/* Business Number */}
+              <div className="flex flex-col gap-2">
+                <label className="font-title-small text-[#212529]">사업자등록번호</label>
+                <input
+                  type="text"
+                  value={formData.businessNumber}
+                  onChange={(e) => handleBusinessNumberChange(e.target.value)}
+                  placeholder="000-00-00000"
+                  maxLength={12}
+                  className={`w-full px-4 py-3 rounded-[12px] border font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none ${
+                    formErrors.businessNumber ? 'border-[#dc3545] focus:border-[#dc3545]' : 'border-[#dee2e6] focus:border-[#003087]'
+                  }`}
+                />
+                {formErrors.businessNumber && (
+                  <p className="font-detail-small text-[#dc3545]">{formErrors.businessNumber}</p>
+                )}
+              </div>
+
+              {/* Address */}
+              <div className="flex flex-col gap-2">
+                <label className="font-title-small text-[#212529]">주소</label>
+                <input
+                  type="text"
+                  value={formData.address}
+                  onChange={(e) => handleInputChange('address', e.target.value)}
+                  placeholder="회사 주소를 입력해주세요"
+                  className={`w-full px-4 py-3 rounded-[12px] border font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none ${
+                    formErrors.address ? 'border-[#dc3545] focus:border-[#dc3545]' : 'border-[#dee2e6] focus:border-[#003087]'
+                  }`}
+                />
+                {formErrors.address && <p className="font-detail-small text-[#dc3545]">{formErrors.address}</p>}
+              </div>
+
+              {/* Contact Email */}
+              <div className="flex flex-col gap-2">
+                <label className="font-title-small text-[#212529]">담당자 이메일</label>
+                <input
+                  type="email"
+                  value={formData.contactEmail}
+                  onChange={(e) => handleInputChange('contactEmail', e.target.value)}
+                  placeholder="contact@company.com"
+                  className={`w-full px-4 py-3 rounded-[12px] border font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none ${
+                    formErrors.contactEmail ? 'border-[#dc3545] focus:border-[#dc3545]' : 'border-[#dee2e6] focus:border-[#003087]'
+                  }`}
+                />
+                {formErrors.contactEmail && (
+                  <p className="font-detail-small text-[#dc3545]">{formErrors.contactEmail}</p>
+                )}
+              </div>
+
+              {/* Contact Phone */}
+              <div className="flex flex-col gap-2">
+                <label className="font-title-small text-[#212529]">담당자 연락처</label>
+                <input
+                  type="tel"
+                  value={formData.contactPhone}
+                  onChange={(e) => handlePhoneChange(e.target.value)}
+                  placeholder="02-0000-0000"
+                  maxLength={13}
+                  className={`w-full px-4 py-3 rounded-[12px] border font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none ${
+                    formErrors.contactPhone ? 'border-[#dc3545] focus:border-[#dc3545]' : 'border-[#dee2e6] focus:border-[#003087]'
+                  }`}
+                />
+                {formErrors.contactPhone && (
+                  <p className="font-detail-small text-[#dc3545]">{formErrors.contactPhone}</p>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-3 pt-4">
+              <button
+                onClick={handleCloseModal}
+                disabled={registerMutation.isPending}
+                className="flex-1 py-3.5 px-4 rounded-[12px] border border-[#dee2e6] font-body-medium text-[#495057] hover:bg-[#f8f9fa] transition-colors disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={registerMutation.isPending}
+                className="flex-1 py-3.5 px-4 rounded-[12px] bg-[#003087] font-body-medium text-white hover:bg-[#002266] transition-colors disabled:opacity-50"
+              >
+                {registerMutation.isPending ? '등록 중...' : '등록하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/management/UserManagementPage.tsx
+++ b/features/management/UserManagementPage.tsx
@@ -1,0 +1,404 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Search, Users, ChevronLeft, ChevronRight, Check, X, MoreVertical } from 'lucide-react';
+import { useUsers, useUpdateUserRole, useUpdateUserStatus } from '../../src/hooks/useManagement';
+import type { UserListParams } from '../../src/api/management';
+import { ROLE_LABELS, type RoleCode } from '../../src/types/api.types';
+
+const ROLE_OPTIONS: { code: RoleCode; label: string }[] = [
+  { code: 'GUEST', label: '게스트' },
+  { code: 'DRAFTER', label: '기안자' },
+  { code: 'APPROVER', label: '결재자' },
+  { code: 'REVIEWER', label: '수신자' },
+];
+
+const STATUS_OPTIONS = [
+  { value: '', label: '전체 상태' },
+  { value: 'ACTIVE', label: '활성' },
+  { value: 'INACTIVE', label: '비활성' },
+];
+
+export default function UserManagementPage() {
+  const navigate = useNavigate();
+  const [params, setParams] = useState<UserListParams>({ page: 0, size: 10 });
+  const [searchInput, setSearchInput] = useState('');
+  const [selectedUser, setSelectedUser] = useState<number | null>(null);
+  const [showRoleDropdown, setShowRoleDropdown] = useState<number | null>(null);
+  const [showStatusConfirm, setShowStatusConfirm] = useState<{ userId: number; currentStatus: string } | null>(null);
+  const [showRoleConfirm, setShowRoleConfirm] = useState<{ userId: number; userName: string; newRole: RoleCode; newRoleName: string } | null>(null);
+
+  const { data, isLoading, error } = useUsers(params);
+  const updateRoleMutation = useUpdateUserRole();
+  const updateStatusMutation = useUpdateUserStatus();
+
+  const handleSearch = () => {
+    setParams((prev) => ({ ...prev, search: searchInput, page: 0 }));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const handleRoleFilter = (roleCode: string) => {
+    setParams((prev) => ({ ...prev, roleCode: roleCode || undefined, page: 0 }));
+  };
+
+  const handleStatusFilter = (status: string) => {
+    setParams((prev) => ({
+      ...prev,
+      status: status ? (status as 'ACTIVE' | 'INACTIVE') : undefined,
+      page: 0,
+    }));
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setParams((prev) => ({ ...prev, page: newPage }));
+  };
+
+  const handleRoleChange = (userId: number, userName: string, newRole: RoleCode, newRoleName: string) => {
+    setShowRoleDropdown(null);
+    setShowRoleConfirm({ userId, userName, newRole, newRoleName });
+  };
+
+  const confirmRoleChange = () => {
+    if (!showRoleConfirm) return;
+    updateRoleMutation.mutate(
+      { userId: showRoleConfirm.userId, data: { roleCode: showRoleConfirm.newRole } },
+      { onSuccess: () => setShowRoleConfirm(null) }
+    );
+  };
+
+  const handleStatusToggle = (userId: number, currentStatus: string) => {
+    setShowStatusConfirm({ userId, currentStatus });
+  };
+
+  const confirmStatusToggle = () => {
+    if (!showStatusConfirm) return;
+    const newStatus = showStatusConfirm.currentStatus === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE';
+    updateStatusMutation.mutate(
+      { userId: showStatusConfirm.userId, data: { status: newStatus } },
+      { onSuccess: () => setShowStatusConfirm(null) }
+    );
+  };
+
+  const getRoleLabel = (roleCode: string): string => {
+    return ROLE_LABELS[roleCode as RoleCode] || roleCode;
+  };
+
+  const getStatusBadge = (status: string) => {
+    if (status === 'ACTIVE') {
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-[#e8f5e9] text-[#2e7d32]">
+          <span className="w-1.5 h-1.5 rounded-full bg-[#2e7d32]" />
+          활성
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-[#f5f5f5] text-[#757575]">
+        <span className="w-1.5 h-1.5 rounded-full bg-[#757575]" />
+        비활성
+      </span>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8f9fa]">
+      {/* Header */}
+      <header className="bg-white border-b border-[#dee2e6] px-6 py-4">
+        <div className="max-w-7xl mx-auto flex items-center gap-4">
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5 text-[#495057]" />
+          </button>
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-[#003087] rounded-full flex items-center justify-center">
+              <Users className="w-5 h-5 text-white" />
+            </div>
+            <div>
+              <h1 className="font-heading-small text-[#212529]">사용자 관리</h1>
+              <p className="font-detail-small text-[#868e96]">사용자 역할 및 상태를 관리합니다</p>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto p-6">
+        {/* Filters */}
+        <div className="bg-white rounded-[16px] p-4 mb-6 border border-[#dee2e6]">
+          <div className="flex flex-wrap gap-4 items-center">
+            {/* Search */}
+            <div className="flex-1 min-w-[280px] relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#adb5bd]" />
+              <input
+                type="text"
+                placeholder="이름 또는 이메일로 검색"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="w-full pl-10 pr-4 py-2.5 rounded-[8px] border border-[#dee2e6] font-body-medium text-[#212529] placeholder:text-[#adb5bd] focus:outline-none focus:border-[#003087]"
+              />
+            </div>
+
+            {/* Role Filter */}
+            <select
+              value={params.roleCode || ''}
+              onChange={(e) => handleRoleFilter(e.target.value)}
+              className="px-4 py-2.5 rounded-[8px] border border-[#dee2e6] font-body-medium text-[#212529] focus:outline-none focus:border-[#003087] bg-white"
+            >
+              <option value="">전체 역할</option>
+              {ROLE_OPTIONS.map((role) => (
+                <option key={role.code} value={role.code}>
+                  {role.label}
+                </option>
+              ))}
+            </select>
+
+            {/* Status Filter */}
+            <select
+              value={params.status || ''}
+              onChange={(e) => handleStatusFilter(e.target.value)}
+              className="px-4 py-2.5 rounded-[8px] border border-[#dee2e6] font-body-medium text-[#212529] focus:outline-none focus:border-[#003087] bg-white"
+            >
+              {STATUS_OPTIONS.map((status) => (
+                <option key={status.value} value={status.value}>
+                  {status.label}
+                </option>
+              ))}
+            </select>
+
+            <button
+              onClick={handleSearch}
+              className="px-6 py-2.5 bg-[#003087] text-white rounded-[8px] font-body-medium hover:bg-[#002266] transition-colors"
+            >
+              검색
+            </button>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white rounded-[16px] border border-[#dee2e6] overflow-hidden">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin w-8 h-8 border-2 border-[#003087] border-t-transparent rounded-full" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <p className="font-body-medium text-[#dc3545] mb-2">데이터를 불러오는 중 오류가 발생했습니다.</p>
+              <button
+                onClick={() => window.location.reload()}
+                className="text-[#003087] font-body-medium hover:underline"
+              >
+                새로고침
+              </button>
+            </div>
+          ) : !data?.content.length ? (
+            <div className="flex flex-col items-center justify-center py-20">
+              <Users className="w-12 h-12 text-[#adb5bd] mb-4" />
+              <p className="font-body-medium text-[#868e96]">등록된 사용자가 없습니다.</p>
+            </div>
+          ) : (
+            <>
+              <table className="w-full">
+                <thead className="bg-[#f8f9fa] border-b border-[#dee2e6]">
+                  <tr>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">사용자</th>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">회사</th>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">역할</th>
+                    <th className="px-6 py-4 text-left font-title-small text-[#495057]">상태</th>
+                    <th className="px-6 py-4 text-center font-title-small text-[#495057]">관리</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.content.map((user) => (
+                    <tr
+                      key={user.userId}
+                      className={`border-b border-[#dee2e6] last:border-b-0 hover:bg-[#f8f9fa] transition-colors ${
+                        selectedUser === user.userId ? 'bg-[#e7f1ff]' : ''
+                      }`}
+                      onClick={() => setSelectedUser(user.userId)}
+                    >
+                      <td className="px-6 py-4">
+                        <div>
+                          <p className="font-body-medium text-[#212529]">{user.name}</p>
+                          <p className="font-detail-small text-[#868e96]">{user.email}</p>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <p className="font-body-medium text-[#495057]">{user.company || '-'}</p>
+                      </td>
+                      <td className="px-6 py-4 relative">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setShowRoleDropdown(showRoleDropdown === user.userId ? null : user.userId);
+                          }}
+                          className="inline-flex items-center gap-1 px-3 py-1.5 rounded-[6px] border border-[#dee2e6] font-body-medium text-[#495057] hover:border-[#003087] hover:text-[#003087] transition-colors"
+                        >
+                          {getRoleLabel(user.roleCode)}
+                          <ChevronRight className="w-4 h-4" />
+                        </button>
+
+                        {showRoleDropdown === user.userId && (
+                          <div className="absolute left-6 top-full mt-1 z-10 bg-white border border-[#dee2e6] rounded-[8px] shadow-lg py-1 min-w-[120px]">
+                            {ROLE_OPTIONS.map((role) => (
+                              <button
+                                key={role.code}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (role.code !== user.roleCode) {
+                                    handleRoleChange(user.userId, user.name, role.code, role.label);
+                                  } else {
+                                    setShowRoleDropdown(null);
+                                  }
+                                }}
+                                className={`w-full px-4 py-2 text-left font-body-medium hover:bg-[#f8f9fa] transition-colors ${
+                                  role.code === user.roleCode ? 'text-[#003087] bg-[#e7f1ff]' : 'text-[#495057]'
+                                }`}
+                              >
+                                {role.label}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-6 py-4">{getStatusBadge(user.status)}</td>
+                      <td className="px-6 py-4 text-center">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleStatusToggle(user.userId, user.status);
+                          }}
+                          className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                          title={user.status === 'ACTIVE' ? '비활성화' : '활성화'}
+                        >
+                          <MoreVertical className="w-5 h-5 text-[#868e96]" />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              {/* Pagination */}
+              {data.page && data.page.totalPages > 1 && (
+                <div className="flex items-center justify-between px-6 py-4 border-t border-[#dee2e6]">
+                  <p className="font-detail-small text-[#868e96]">
+                    총 {data.page.totalElements}명 중 {data.page.number * data.page.size + 1}-
+                    {Math.min((data.page.number + 1) * data.page.size, data.page.totalElements)}명
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handlePageChange(data.page.number - 1)}
+                      disabled={data.page.number === 0}
+                      className="p-2 rounded-[6px] border border-[#dee2e6] hover:bg-[#f8f9fa] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <ChevronLeft className="w-4 h-4 text-[#495057]" />
+                    </button>
+                    <span className="font-body-medium text-[#495057] px-3">
+                      {data.page.number + 1} / {data.page.totalPages}
+                    </span>
+                    <button
+                      onClick={() => handlePageChange(data.page.number + 1)}
+                      disabled={data.page.number >= data.page.totalPages - 1}
+                      className="p-2 rounded-[6px] border border-[#dee2e6] hover:bg-[#f8f9fa] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      <ChevronRight className="w-4 h-4 text-[#495057]" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+
+      {/* Role Change Confirmation Modal */}
+      {showRoleConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-[20px] p-[32px] w-[400px] flex flex-col gap-[24px] shadow-xl">
+            <div className="flex flex-col items-center gap-4">
+              <div className="w-16 h-16 bg-[#e7f1ff] rounded-full flex items-center justify-center">
+                <Users className="w-8 h-8 text-[#003087]" />
+              </div>
+              <h3 className="font-title-large text-[#212529]">역할을 변경하시겠습니까?</h3>
+              <p className="font-body-medium text-[#868e96] text-center">
+                {showRoleConfirm.userName}님의 역할을
+                <br />
+                <strong className="text-[#003087]">{showRoleConfirm.newRoleName}</strong>(으)로 변경합니다.
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowRoleConfirm(null)}
+                disabled={updateRoleMutation.isPending}
+                className="flex-1 py-3 px-4 rounded-[12px] border border-[#dee2e6] font-body-medium text-[#495057] hover:bg-[#f8f9fa] transition-colors disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={confirmRoleChange}
+                disabled={updateRoleMutation.isPending}
+                className="flex-1 py-3 px-4 rounded-[12px] bg-[#003087] font-body-medium text-white hover:bg-[#002266] transition-colors disabled:opacity-50"
+              >
+                {updateRoleMutation.isPending ? '처리 중...' : '확인'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Status Toggle Confirmation Modal */}
+      {showStatusConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-[20px] p-[32px] w-[400px] flex flex-col gap-[24px] shadow-xl">
+            <div className="flex flex-col items-center gap-4">
+              {showStatusConfirm.currentStatus === 'ACTIVE' ? (
+                <div className="w-16 h-16 bg-[#fff3e0] rounded-full flex items-center justify-center">
+                  <X className="w-8 h-8 text-[#f57c00]" />
+                </div>
+              ) : (
+                <div className="w-16 h-16 bg-[#e8f5e9] rounded-full flex items-center justify-center">
+                  <Check className="w-8 h-8 text-[#2e7d32]" />
+                </div>
+              )}
+              <h3 className="font-title-large text-[#212529]">
+                {showStatusConfirm.currentStatus === 'ACTIVE' ? '사용자를 비활성화하시겠습니까?' : '사용자를 활성화하시겠습니까?'}
+              </h3>
+              <p className="font-body-medium text-[#868e96] text-center">
+                {showStatusConfirm.currentStatus === 'ACTIVE'
+                  ? '비활성화된 사용자는 서비스에 로그인할 수 없습니다.'
+                  : '활성화된 사용자는 다시 서비스를 이용할 수 있습니다.'}
+              </p>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowStatusConfirm(null)}
+                disabled={updateStatusMutation.isPending}
+                className="flex-1 py-3 px-4 rounded-[12px] border border-[#dee2e6] font-body-medium text-[#495057] hover:bg-[#f8f9fa] transition-colors disabled:opacity-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={confirmStatusToggle}
+                disabled={updateStatusMutation.isPending}
+                className={`flex-1 py-3 px-4 rounded-[12px] font-body-medium text-white transition-colors disabled:opacity-50 ${
+                  showStatusConfirm.currentStatus === 'ACTIVE'
+                    ? 'bg-[#f57c00] hover:bg-[#e65100]'
+                    : 'bg-[#2e7d32] hover:bg-[#1b5e20]'
+                }`}
+              >
+                {updateStatusMutation.isPending ? '처리 중...' : '확인'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/api/management.ts
+++ b/src/api/management.ts
@@ -12,16 +12,45 @@ export interface UserListItem {
   name: string;
   email: string;
   role: string;
+  roleCode: string;
   company?: string;
-  status: string;
+  companyId?: number;
+  status: 'ACTIVE' | 'INACTIVE';
   lastLoginAt?: string;
+  createdAt?: string;
 }
 
 export interface CompanyListItem {
   companyId: number;
   companyName: string;
-  companyType: string;
+  companyType: 'SUPPLIER' | 'CONTRACTOR';
   userCount: number;
+  createdAt?: string;
+}
+
+export interface UserListParams {
+  page?: number;
+  size?: number;
+  search?: string;
+  roleCode?: string;
+  status?: 'ACTIVE' | 'INACTIVE';
+  companyId?: number;
+}
+
+export interface CompanyListParams {
+  page?: number;
+  size?: number;
+  search?: string;
+  companyType?: 'SUPPLIER' | 'CONTRACTOR';
+}
+
+export interface RegisterCompanyRequest {
+  companyName: string;
+  companyType: 'SUPPLIER' | 'CONTRACTOR';
+  businessNumber?: string;
+  address?: string;
+  contactEmail?: string;
+  contactPhone?: string;
 }
 
 export interface ActivityLogItem {
@@ -41,7 +70,7 @@ export const getPermissionsDashboard = async (): Promise<PermissionsDashboardRes
 };
 
 export const getUsers = async (
-  params: { page?: number; size?: number } = {}
+  params: UserListParams = {}
 ): Promise<PagedData<UserListItem>> => {
   const response = await apiClient.get<BaseResponse<PagedData<UserListItem>>>('/v1/management/users', {
     params: { page: 0, size: 10, ...params },
@@ -49,8 +78,19 @@ export const getUsers = async (
   return response.data.data;
 };
 
-export const getCompanies = async (): Promise<CompanyListItem[]> => {
-  const response = await apiClient.get<BaseResponse<CompanyListItem[]>>('/v1/management/companies');
+export const getCompanies = async (
+  params: CompanyListParams = {}
+): Promise<PagedData<CompanyListItem>> => {
+  const response = await apiClient.get<BaseResponse<PagedData<CompanyListItem>>>('/v1/management/companies', {
+    params: { page: 0, size: 10, ...params },
+  });
+  return response.data.data;
+};
+
+export const registerCompany = async (
+  data: RegisterCompanyRequest
+): Promise<CompanyListItem> => {
+  const response = await apiClient.post<BaseResponse<CompanyListItem>>('/v1/management/companies', data);
   return response.data.data;
 };
 

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -25,6 +25,7 @@ export const QUERY_KEYS = {
     PERMISSIONS_DASHBOARD: ['management', 'permissionsDashboard'] as const,
     USERS: (params?: object) => ['management', 'users', params] as const,
     COMPANIES: ['management', 'companies'] as const,
+    COMPANIES_LIST: (params?: object) => ['management', 'companiesList', params] as const,
     ACTIVITY_LOGS: (params?: object) => ['management', 'activityLogs', params] as const,
   },
   NOTIFICATIONS: {

--- a/src/hooks/useManagement.ts
+++ b/src/hooks/useManagement.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { toast } from 'sonner';
 import * as managementApi from '../api/management';
+import type { UserListParams, CompanyListParams, RegisterCompanyRequest } from '../api/management';
 import { QUERY_KEYS } from '../constants/queryKeys';
 import { handleApiError } from '../utils/errorHandler';
 import type { ErrorResponse } from '../types/api.types';
@@ -13,17 +14,17 @@ export const usePermissionsDashboard = () => {
   });
 };
 
-export const useUsers = (params?: { page?: number; size?: number }) => {
+export const useUsers = (params?: UserListParams) => {
   return useQuery({
     queryKey: QUERY_KEYS.MANAGEMENT.USERS(params),
     queryFn: () => managementApi.getUsers(params),
   });
 };
 
-export const useCompanies = () => {
+export const useCompanies = (params?: CompanyListParams) => {
   return useQuery({
-    queryKey: QUERY_KEYS.MANAGEMENT.COMPANIES,
-    queryFn: managementApi.getCompanies,
+    queryKey: QUERY_KEYS.MANAGEMENT.COMPANIES_LIST(params),
+    queryFn: () => managementApi.getCompanies(params),
   });
 };
 
@@ -75,6 +76,21 @@ export const useUpdateUserStatus = () => {
       managementApi.updateUserStatus(userId, data),
     onSuccess: () => {
       toast.success('상태가 변경되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['management'] });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      handleApiError(error);
+    },
+  });
+};
+
+export const useRegisterCompany = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: RegisterCompanyRequest) => managementApi.registerCompany(data),
+    onSuccess: () => {
+      toast.success('회사가 등록되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['management'] });
     },
     onError: (error: AxiosError<ErrorResponse>) => {


### PR DESCRIPTION
## Summary
- 사용자 관리 페이지 구현 (검색/필터/페이지네이션, 역할 변경, 상태 토글)
- 회사 관리 페이지 구현 (검색/필터/페이지네이션, 회사 등록 모달)
- 관련 API 및 훅 확장

## Test plan
- [ ] `/management/users` 페이지 접근 및 기능 확인
- [ ] `/management/companies` 페이지 접근 및 기능 확인
- [ ] 회사 등록 모달 폼 검증 확인

Closes #44