### PR TITLE
fix: 백엔드 API 연동을 위한 타입 정의 및 누락 함수 수정

### DIFF
--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -52,3 +52,10 @@ export const getDownloadUrl = async (fileId: number): Promise<string> => {
 export const deleteFile = async (fileId: number): Promise<void> => {
   await apiClient.delete(`/v1/files/${fileId}`);
 };
+
+export const getPackageUrl = async (diagnosticId: number): Promise<string> => {
+  const response = await apiClient.get<BaseResponse<{ url: string }>>(
+    `/v1/files/diagnostics/${diagnosticId}/package-url`
+  );
+  return response.data.data.url;
+};

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -154,6 +154,7 @@ export interface UserInfoDto {
   email: string;
   name: string;
   role?: RoleInfoDto;
+  domainRoles?: UserDomainRole[];
   company?: CompanyInfoDto;
 }
 
@@ -261,7 +262,7 @@ export interface UserDomainRole {
 // --- 권한 요청 생성 ---
 export interface RoleRequestCreateDto {
   requestedRole: RoleCode;
-  domainId: DomainCode;
+  domainCode: DomainCode;
   companyId: number;
   reason?: string;
 }


### PR DESCRIPTION
## Summary
- `files.ts`: `getPackageUrl` 함수 추가 (전체 파일 패키지 다운로드 URL 조회)
- `api.types.ts`: `UserInfoDto`에 `domainRoles` 필드 추가
- `api.types.ts`: `RoleRequestCreateDto`의 `domainId` → `domainCode`로 변경

## Test plan
- [ ] 타입스크립트 빌드 오류 없음 확인
- [ ] 백엔드 API와 연동 테스트

Closes #63
