### PR TITLE
fix: #86 진단 생성 플로우 통합 및 FileUploadPage API 연동

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -29,7 +29,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
   const navigate = useNavigate();
 
   const handleUpload = () => {
-    navigate('/dashboard/compliance/upload');
+    navigate('/diagnostics/new');
   };
 
   const handleRowClick = (index: number) => {

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -29,7 +29,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
   const navigate = useNavigate();
 
   const handleUpload = () => {
-    navigate('/dashboard/esg/upload');
+    navigate('/diagnostics/new');
   };
 
   const handleRowClick = (index: number) => {

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -243,8 +243,7 @@ export default function HomePage({ userRole }: HomePageProps) {
   }, [userRole, diagnosticsQuery, approvalsQuery, reviewsListQuery]);
 
   const handleCreateDraft = () => {
-    const domainPath = activeTab.toLowerCase();
-    navigate(`/dashboard/${domainPath}/upload`);
+    navigate('/diagnostics/new');
   };
 
   const handleRowClick = (id: number, domain: string) => {

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -30,7 +30,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
   const navigate = useNavigate();
 
   const handleUpload = () => {
-    navigate('/dashboard/safety/upload');
+    navigate('/diagnostics/new');
   };
 
   const handleRowClick = (index: number) => {

--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -37,7 +37,8 @@ export default function DiagnosticCreatePage() {
   const onSubmit = async (data: DiagnosticCreateFormData) => {
     createMutation.mutate(data, {
       onSuccess: (result) => {
-        navigate(`/diagnostics/${result.diagnosticId}`);
+        const domainPath = data.domainCode.toLowerCase();
+        navigate(`/dashboard/${domainPath}/upload?diagnosticId=${result.diagnosticId}`);
       },
     });
   };

--- a/features/documents/FileUploadPage.tsx
+++ b/features/documents/FileUploadPage.tsx
@@ -1,86 +1,172 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useRef, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
-import { FileText, Image as ImageIcon, Upload, X, CheckCircle2 } from 'lucide-react';
+import { useUploadFile, useDeleteFile } from '../../src/hooks/useFiles';
+import { useJobPolling } from '../../src/hooks/useJobs';
+import type { JobStatus } from '../../src/api/jobs';
+import { FileText, Image as ImageIcon, Upload, X, CheckCircle2, Loader2, Trash2 } from 'lucide-react';
 
 interface UploadedFile {
-  id: string;
+  id: number;
   name: string;
-  type: 'pdf' | 'image' | 'document';
-  size: string;
-  autoTag: string;
+  jobId: string;
+  status: JobStatus;
+  progress?: number;
 }
+
+const JOB_STATUS_LABELS: Record<JobStatus, string> = {
+  PENDING: '대기중',
+  RUNNING: '분석중',
+  SUCCEEDED: '완료',
+  FAILED: '실패',
+};
+
+const JOB_STATUS_STYLES: Record<JobStatus, string> = {
+  PENDING: 'bg-gray-100 text-gray-700',
+  RUNNING: 'bg-blue-100 text-blue-700',
+  SUCCEEDED: 'bg-green-100 text-green-700',
+  FAILED: 'bg-red-100 text-red-700',
+};
 
 const requiredFiles = [
   'TBM 활동일지',
   '현장 안전 사진',
-  '위험성평가 결과서 (변수)',
+  '위험성평가 결과서',
   '안전교육 일지',
   '비상연락망',
 ];
 
-const fileTypeIcons = {
-  pdf: FileText,
-  image: ImageIcon,
-  document: FileText,
-};
-
-const autoTagColors = {
-  'TBM 활동일지': 'bg-[#e3f2fd] text-[#002554]',
-  '현장 안전 사진': 'bg-[#f0fdf4] text-[#008233]',
-  '위험성평가': 'bg-[#fff3e0] text-[#e65100]',
-  '안전교육': 'bg-[#fef2f2] text-[#b91c1c]',
-  '비상연락망': 'bg-[#f3e5f5] text-[#7b1fa2]',
-};
-
 export default function FileUploadPage() {
   const navigate = useNavigate();
-  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([
-    {
-      id: '1',
-      name: 'ABC건설_202601_TBM일지H.pdf',
-      type: 'pdf',
-      size: '2.4 MB',
-      autoTag: 'TBM 활동일지',
-    },
-    {
-      id: '2',
-      name: 'ABC건설_202601_현장사진.jpg',
-      type: 'image',
-      size: '1.8 MB',
-      autoTag: '현장 안전 사진',
-    },
-  ]);
+  const [searchParams] = useSearchParams();
+  const diagnosticId = searchParams.get('diagnosticId');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const uploadMutation = useUploadFile();
+  const deleteMutation = useDeleteFile();
+
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [isDragging, setIsDragging] = useState(false);
 
-  const handleDragOver = (e: React.DragEvent) => {
+  // Job polling for files in progress
+  const activeJobId = uploadedFiles.find(f => f.status === 'PENDING' || f.status === 'RUNNING')?.jobId || null;
+  const { data: jobStatus } = useJobPolling(activeJobId);
+
+  // Update file status when job status changes
+  if (jobStatus && activeJobId) {
+    const fileIndex = uploadedFiles.findIndex(f => f.jobId === activeJobId);
+    if (fileIndex !== -1 && uploadedFiles[fileIndex].status !== jobStatus.status) {
+      setUploadedFiles(prev =>
+        prev.map(f => f.jobId === activeJobId
+          ? { ...f, status: jobStatus.status, progress: jobStatus.progress }
+          : f
+        )
+      );
+    }
+  }
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(true);
-  };
+  }, []);
 
-  const handleDragLeave = () => {
+  const handleDragLeave = useCallback(() => {
     setIsDragging(false);
-  };
+  }, []);
 
-  const handleDrop = (e: React.DragEvent) => {
+  const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(false);
-    // File handling logic would go here
+    const files = Array.from(e.dataTransfer.files);
+    handleFilesUpload(files);
+  }, [diagnosticId]);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    handleFilesUpload(files);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
   };
 
-  const handleRemoveFile = (id: string) => {
-    setUploadedFiles(uploadedFiles.filter((f) => f.id !== id));
+  const handleFilesUpload = async (files: File[]) => {
+    if (!diagnosticId) {
+      alert('진단 정보가 없습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    for (const file of files) {
+      try {
+        const result = await uploadMutation.mutateAsync({
+          diagnosticId: Number(diagnosticId),
+          file
+        });
+        setUploadedFiles(prev => [
+          ...prev,
+          {
+            id: result.fileId,
+            name: result.originalFileName || result.fileName,
+            jobId: result.jobId,
+            status: 'PENDING',
+          },
+        ]);
+      } catch {
+        // Error handled by mutation
+      }
+    }
+  };
+
+  const handleRemoveFile = async (fileId: number) => {
+    try {
+      await deleteMutation.mutateAsync(fileId);
+      setUploadedFiles(prev => prev.filter(f => f.id !== fileId));
+    } catch {
+      // Error handled by mutation
+    }
   };
 
   const handleSubmit = () => {
-    // Navigate to review page
-    navigate('/dashboard/safety/review/1');
+    if (diagnosticId) {
+      navigate(`/diagnostics/${diagnosticId}`);
+    } else {
+      navigate('/diagnostics');
+    }
   };
 
-  const getTagColor = (tag: string): string => {
-    const matchedKey = Object.keys(autoTagColors).find((key) => tag.includes(key));
-    return matchedKey ? autoTagColors[matchedKey as keyof typeof autoTagColors] : 'bg-[#e3f2fd] text-[#002554]';
+  const handleClickUploadArea = () => {
+    fileInputRef.current?.click();
   };
+
+  const getFileIcon = (fileName: string) => {
+    const ext = fileName.split('.').pop()?.toLowerCase();
+    if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(ext || '')) {
+      return ImageIcon;
+    }
+    return FileText;
+  };
+
+  // diagnosticId가 없으면 에러 표시
+  if (!diagnosticId) {
+    return (
+      <DashboardLayout>
+        <div className="p-[32px]">
+          <div className="max-w-[1468px] mx-auto">
+            <div className="bg-white rounded-[20px] p-[44px] text-center">
+              <p className="font-body-medium text-red-500 mb-[16px]">
+                진단 정보가 없습니다.
+              </p>
+              <button
+                onClick={() => navigate('/diagnostics/new')}
+                className="bg-[#003087] text-white px-[24px] py-[12px] rounded-[8px] font-title-small hover:bg-[#002554] transition-colors"
+              >
+                새 기안 생성하기
+              </button>
+            </div>
+          </div>
+        </div>
+      </DashboardLayout>
+    );
+  }
 
   return (
     <DashboardLayout>
@@ -89,7 +175,7 @@ export default function FileUploadPage() {
           {/* Page Title */}
           <h1 className="font-heading-medium text-[#212529] mb-[24px]">파일 업로드</h1>
 
-          <div className="grid grid-cols-[1fr,340px] gap-[24px]">
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr,340px] gap-[24px]">
             {/* Left: Upload Area */}
             <div className="bg-white rounded-[20px] p-[44px]">
               {/* Guide */}
@@ -102,20 +188,31 @@ export default function FileUploadPage() {
                     파일명 가이드:
                   </p>
                   <p className="font-body-small text-[#495057]">
-                    협력사명_기간_자료명 (예: ABC건설_202601_TBM일지H.pdf)
+                    협력사명_기간_자료명 (예: ABC건설_202601_TBM일지.pdf)
                   </p>
                 </div>
               </div>
+
+              {/* Hidden file input */}
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept=".pdf,.jpg,.jpeg,.png,.xlsx,.xls,.doc,.docx"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
 
               {/* Drag & Drop Area */}
               <div
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
-                className={`border-2 border-dashed rounded-[12px] p-[48px] text-center mb-[32px] transition-all ${
+                onClick={handleClickUploadArea}
+                className={`border-2 border-dashed rounded-[12px] p-[48px] text-center mb-[32px] transition-all cursor-pointer ${
                   isDragging
                     ? 'border-[#003087] bg-[#e3f2fd]'
-                    : 'border-[#dee2e6] hover:border-[#adb5bd]'
+                    : 'border-[#dee2e6] hover:border-[#adb5bd] hover:bg-[#f8f9fa]'
                 }`}
               >
                 <div className="flex flex-col items-center">
@@ -124,58 +221,94 @@ export default function FileUploadPage() {
                     여기에 파일을 놓거나 클릭하여 업로드
                   </p>
                   <p className="font-body-small text-[#868e96]">
-                    PDF, JPG, PNG, XLSX 파일을 업로드할 수 있습니다
+                    PDF, JPG, PNG, XLSX, DOC 파일을 업로드할 수 있습니다 (최대 50MB)
                   </p>
                 </div>
               </div>
 
+              {/* Upload Progress */}
+              {uploadMutation.isPending && (
+                <div className="flex items-center gap-[12px] p-[16px] bg-blue-50 rounded-[12px] mb-[24px]">
+                  <Loader2 className="w-[24px] h-[24px] text-[#003087] animate-spin" />
+                  <span className="font-body-medium text-[#003087]">
+                    파일 업로드 중...
+                  </span>
+                </div>
+              )}
+
               {/* Uploaded Files List */}
-              <div className="space-y-[12px] mb-[32px]">
-                {uploadedFiles.map((file) => {
-                  const Icon = fileTypeIcons[file.type];
-                  return (
-                    <div
-                      key={file.id}
-                      className="border border-[#dee2e6] rounded-[12px] p-[16px] flex items-center gap-[16px] hover:bg-[#f8f9fa] transition-colors"
-                    >
-                      <Icon className="w-[32px] h-[32px] text-[#003087] flex-shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="font-title-small text-[#212529] truncate mb-[4px]">
-                          {file.name}
-                        </p>
-                        <div className="flex items-center gap-[8px]">
-                          <span
-                            className={`inline-block px-[8px] py-[2px] rounded-[4px] font-detail-small ${getTagColor(
-                              file.autoTag
-                            )}`}
-                          >
-                            Auto-tag: {file.autoTag}
-                          </span>
-                          <span className="font-detail-small text-[#868e96]">
-                            {file.size}
-                          </span>
-                        </div>
-                      </div>
-                      <button
-                        onClick={() => handleRemoveFile(file.id)}
-                        className="p-[8px] hover:bg-[#f1f3f5] rounded-[8px] transition-colors"
+              {uploadedFiles.length > 0 && (
+                <div className="space-y-[12px] mb-[32px]">
+                  <h3 className="font-title-small text-[#212529] mb-[12px]">
+                    업로드된 파일 ({uploadedFiles.length})
+                  </h3>
+                  {uploadedFiles.map((file) => {
+                    const Icon = getFileIcon(file.name);
+                    return (
+                      <div
+                        key={file.id}
+                        className="border border-[#dee2e6] rounded-[12px] p-[16px] flex items-center gap-[16px] hover:bg-[#f8f9fa] transition-colors"
                       >
-                        <X className="w-[20px] h-[20px] text-[#868e96]" />
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
+                        <Icon className="w-[32px] h-[32px] text-[#003087] flex-shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <p className="font-title-small text-[#212529] truncate mb-[4px]">
+                            {file.name}
+                          </p>
+                          <div className="flex items-center gap-[8px]">
+                            <span className={`inline-block px-[8px] py-[2px] rounded-full text-xs font-medium ${JOB_STATUS_STYLES[file.status]}`}>
+                              {JOB_STATUS_LABELS[file.status]}
+                            </span>
+                            {file.status === 'RUNNING' && file.progress !== undefined && (
+                              <span className="font-body-small text-[#868e96]">
+                                {file.progress}%
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* Progress bar for pending/running */}
+                        {(file.status === 'PENDING' || file.status === 'RUNNING') && (
+                          <div className="w-[80px] h-[4px] bg-gray-200 rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-[#003087] transition-all"
+                              style={{ width: `${file.progress || (file.status === 'PENDING' ? 10 : 50)}%` }}
+                            />
+                          </div>
+                        )}
+
+                        <button
+                          onClick={() => handleRemoveFile(file.id)}
+                          disabled={deleteMutation.isPending}
+                          className="p-[8px] hover:bg-red-50 rounded-[8px] transition-colors disabled:opacity-50"
+                        >
+                          <Trash2 className="w-[20px] h-[20px] text-red-500" />
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Empty state */}
+              {uploadedFiles.length === 0 && !uploadMutation.isPending && (
+                <div className="text-center py-[24px] text-[#868e96]">
+                  <p className="font-body-medium">아직 업로드된 파일이 없습니다.</p>
+                </div>
+              )}
 
               {/* Action Buttons */}
               <div className="flex gap-[12px]">
-                <button className="flex-1 bg-[#003087] text-white px-[24px] py-[14px] rounded-[8px] font-title-small hover:bg-[#002554] transition-colors flex items-center justify-center gap-[8px]">
+                <button
+                  onClick={handleClickUploadArea}
+                  className="flex-1 bg-[#003087] text-white px-[24px] py-[14px] rounded-[8px] font-title-small hover:bg-[#002554] transition-colors flex items-center justify-center gap-[8px]"
+                >
                   <Upload className="w-[20px] h-[20px]" />
                   파일 추가
                 </button>
                 <button
                   onClick={handleSubmit}
-                  className="flex-1 bg-[#00ad1d] text-white px-[24px] py-[14px] rounded-[8px] font-title-small hover:bg-[#008a18] transition-colors"
+                  disabled={uploadedFiles.length === 0}
+                  className="flex-1 bg-[#00ad1d] text-white px-[24px] py-[14px] rounded-[8px] font-title-small hover:bg-[#008a18] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   검토 화면 이동
                 </button>
@@ -183,13 +316,21 @@ export default function FileUploadPage() {
             </div>
 
             {/* Right: Required Files Checklist */}
-            <div className="bg-[#f8f9fa] rounded-[20px] p-[32px]">
+            <div className="bg-[#f8f9fa] rounded-[20px] p-[32px] h-fit">
               <h2 className="font-title-large text-[#212529] mb-[24px]">
                 필수 첨부 자료 리스트
               </h2>
               <div className="space-y-[12px]">
-                {requiredFiles.map((file, index) => {
-                  const isUploaded = uploadedFiles.some((f) => f.autoTag.includes(file.split(' ')[0]));
+                {requiredFiles.map((requiredFile, index) => {
+                  // 파일명에서 필수 자료와 매칭 확인
+                  const isUploaded = uploadedFiles.some((f) =>
+                    f.name.toLowerCase().includes(requiredFile.split(' ')[0].toLowerCase()) ||
+                    f.name.includes('TBM') && requiredFile.includes('TBM') ||
+                    f.name.includes('사진') && requiredFile.includes('사진') ||
+                    f.name.includes('위험성') && requiredFile.includes('위험성') ||
+                    f.name.includes('교육') && requiredFile.includes('교육') ||
+                    f.name.includes('연락망') && requiredFile.includes('연락망')
+                  );
                   return (
                     <div key={index} className="flex items-center gap-[12px]">
                       <div
@@ -204,7 +345,7 @@ export default function FileUploadPage() {
                           isUploaded ? 'text-[#212529]' : 'text-[#868e96]'
                         }`}
                       >
-                        {file}
+                        {requiredFile}
                       </p>
                     </div>
                   );

--- a/tests/diagnostic-create.spec.ts
+++ b/tests/diagnostic-create.spec.ts
@@ -4,7 +4,23 @@ import { DiagnosticCreatePage } from './pages/DiagnosticCreatePage';
 // 인증은 auth.setup.ts의 storageState를 통해 처리됨
 test.describe('이슈 #69: 진단 생성 프로세스 테스트', () => {
 
-  test('제목, 도메인, 기간 입력 후 제출 → 성공 확인', async ({ page }) => {
+  test('대시보드에서 "새 기안 생성" 버튼 클릭 → 진단 생성 페이지로 이동', async ({ page }) => {
+    // 대시보드로 이동
+    await page.goto('/dashboard');
+
+    // "새 기안 생성" 버튼 클릭
+    const createButton = page.getByRole('button', { name: '+ 새 기안 생성' });
+    await expect(createButton).toBeVisible();
+    await createButton.click();
+
+    // 진단 생성 페이지로 이동 확인
+    await expect(page).toHaveURL('/diagnostics/new');
+
+    // 페이지 타이틀 확인
+    await expect(page.getByRole('heading', { name: '새 진단 생성' })).toBeVisible();
+  });
+
+  test('제목, 캠페인, 도메인, 기간 입력 후 제출 → 파일 업로드 페이지로 이동', async ({ page }) => {
     const diagnosticPage = new DiagnosticCreatePage(page);
     await diagnosticPage.goto();
 
@@ -31,8 +47,12 @@ test.describe('이슈 #69: 진단 생성 프로세스 테스트', () => {
     // API 성공 확인 (201 Created)
     expect(response.status()).toBe(201);
 
-    // 생성 후 상세 페이지로 이동 확인 (/diagnostics/:id)
-    await expect(page).toHaveURL(/\/diagnostics\/\d+/, { timeout: 10000 });
+    // API 응답에서 diagnosticId 추출
+    const responseBody = await response.json();
+    const diagnosticId = responseBody.data.diagnosticId;
+
+    // 파일 업로드 페이지로 이동 확인 (/dashboard/{domain}/upload?diagnosticId={id})
+    await expect(page).toHaveURL(new RegExp(`/dashboard/esg/upload\\?diagnosticId=${diagnosticId}`), { timeout: 10000 });
   });
 
   test('필수값(제목) 누락 시 → 클라이언트 유효성 검사 메시지 확인', async ({ page }) => {
@@ -79,13 +99,22 @@ test.describe('이슈 #69: 진단 생성 프로세스 테스트', () => {
     await diagnosticPage.expectValidationError('날짜 형식이 올바르지 않습니다');
   });
 
-  test('생성 후 상세 페이지로 이동 확인', async ({ page }) => {
-    const diagnosticPage = new DiagnosticCreatePage(page);
-    await diagnosticPage.goto();
+  test('전체 플로우: 대시보드 → 기안 생성 → 파일 업로드 페이지', async ({ page }) => {
+    // 1. 대시보드에서 시작
+    await page.goto('/dashboard');
 
-    // 폼 데이터 입력
+    // 2. "새 기안 생성" 버튼 클릭
+    const createButton = page.getByRole('button', { name: '+ 새 기안 생성' });
+    await createButton.click();
+
+    // 3. 진단 생성 페이지 확인
+    await expect(page).toHaveURL('/diagnostics/new');
+    await expect(page.getByRole('heading', { name: '새 진단 생성' })).toBeVisible();
+
+    // 4. 폼 데이터 입력
+    const diagnosticPage = new DiagnosticCreatePage(page);
     const testData = {
-      title: `상태확인 테스트 진단 ${Date.now()}`,
+      title: `플로우 테스트 진단 ${Date.now()}`,
       domain: 'SAFETY' as const,
       startDate: '2025-02-01',
       endDate: '2025-06-30',
@@ -93,22 +122,25 @@ test.describe('이슈 #69: 진단 생성 프로세스 테스트', () => {
 
     await diagnosticPage.fillForm(testData);
 
-    // API 응답을 기다리며 제출
+    // 5. API 응답을 기다리며 제출
     const responsePromise = page.waitForResponse(
       (response) => response.url().includes('/v1/diagnostics') && response.request().method() === 'POST'
     );
     await diagnosticPage.submit();
     const response = await responsePromise;
 
-    // API 성공 확인 (201 Created)
+    // 6. API 성공 확인 (201 Created)
     expect(response.status()).toBe(201);
 
-    // API 응답에서 diagnosticId 추출하여 검증
+    // 7. API 응답에서 diagnosticId 추출
     const responseBody = await response.json();
     const diagnosticId = responseBody.data.diagnosticId;
     expect(diagnosticId).toBeGreaterThan(0);
 
-    // 상세 페이지로 이동 확인 (/diagnostics/:id)
-    await expect(page).toHaveURL(`/diagnostics/${diagnosticId}`, { timeout: 10000 });
+    // 8. 파일 업로드 페이지로 이동 확인
+    await expect(page).toHaveURL(`/dashboard/safety/upload?diagnosticId=${diagnosticId}`, { timeout: 10000 });
+
+    // 9. 파일 업로드 페이지 요소 확인
+    await expect(page.getByRole('heading', { name: '파일 업로드' })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- 대시보드 "새 기안 생성" 버튼을 `/diagnostics/new`로 연결
- 기안 생성 후 `/dashboard/{domain}/upload?diagnosticId={id}`로 이동하도록 변경
- `FileUploadPage`에 실제 파일 업로드 API 연동 구현
- E2E 테스트를 새 플로우에 맞게 업데이트

## 변경된 플로우
```
대시보드 "새 기안 생성" 버튼
    ↓
/diagnostics/new (기안 생성 폼)
    ↓
/dashboard/{domain}/upload?diagnosticId={id} (파일 업로드)
    ↓
/diagnostics/{id} (진단 상세)
```

## 변경 파일
- `features/dashboard/HomePage.tsx` - 버튼 연결 변경
- `features/dashboard/SafetyPage.tsx` - 버튼 연결 변경
- `features/dashboard/CompliancePage.tsx` - 버튼 연결 변경
- `features/dashboard/ESGPage.tsx` - 버튼 연결 변경
- `features/diagnostics/DiagnosticCreatePage.tsx` - 생성 후 파일 업로드 페이지로 이동
- `features/documents/FileUploadPage.tsx` - 실제 API 연동 구현
- `tests/diagnostic-create.spec.ts` - 새 플로우 테스트

## Test plan
- [x] `npx playwright test diagnostic-create.spec.ts` 실행 - 7개 테스트 모두 통과

Closes #86