### PR TITLE
test: #78 대시보드 및 알림 조회 E2E 테스트

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   projects: [
     {
       name: 'setup',
-      testMatch: /auth\.setup\.ts/,
+      testMatch: /^auth\.setup\.ts$/,
     },
     {
       name: 'approver-setup',

--- a/tests/dashboard-and-notifications.spec.ts
+++ b/tests/dashboard-and-notifications.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+import { DashboardPage } from './pages/DashboardPage';
+import { NotificationsPage } from './pages/NotificationsPage';
+
+// 기본 storageState 사용 (DRAFTER 역할)
+test.use({ storageState: 'tests/.auth/storageState.json' });
+
+test.describe('이슈 #78: 대시보드 및 알림 조회 테스트', () => {
+
+  test('메인 대시보드(/dashboard) 정상 렌더링', async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    await page.goto('/dashboard');
+    await dashboardPage.waitForLoaded();
+
+    // 대시보드 페이지 요소 확인
+    await expect(dashboardPage.getPageHeading()).toBeVisible();
+    await expect(dashboardPage.statsSection).toBeVisible();
+
+    // 테이블 또는 콘텐츠 영역이 렌더링되었는지 확인
+    const table = dashboardPage.getTable();
+    await expect(table).toBeVisible({ timeout: 10000 });
+  });
+
+  test('ESG 대시보드 정상 렌더링', async ({ page }) => {
+    await page.goto('/dashboard/esg');
+
+    // ESG 페이지 헤딩 확인
+    const heading = page.getByRole('heading', { name: 'ESG' });
+    await expect(heading).toBeVisible({ timeout: 15000 });
+
+    // 테이블 렌더링 확인
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+
+    // 테이블 헤더 확인
+    await expect(page.getByText('협력사 명')).toBeVisible();
+    await expect(page.getByText('기간')).toBeVisible();
+    await expect(page.getByText('제출일')).toBeVisible();
+    await expect(page.getByText('결과')).toBeVisible();
+  });
+
+  test('Safety 대시보드 정상 렌더링', async ({ page }) => {
+    await page.goto('/dashboard/safety');
+
+    // Safety 페이지 헤딩 확인
+    const heading = page.getByRole('heading', { name: '안전보건' });
+    await expect(heading).toBeVisible({ timeout: 15000 });
+
+    // 테이블 렌더링 확인
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+  });
+
+  test('Compliance 대시보드 정상 렌더링', async ({ page }) => {
+    await page.goto('/dashboard/compliance');
+
+    // Compliance 페이지 헤딩 확인
+    const heading = page.getByRole('heading', { name: '컴플라이언스' });
+    await expect(heading).toBeVisible({ timeout: 15000 });
+
+    // 테이블 렌더링 확인
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+  });
+
+  test('알림 목록(/notifications) 조회 확인', async ({ page }) => {
+    const notificationsPage = new NotificationsPage(page);
+
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes('/v1/notifications') && res.request().method() === 'GET',
+      { timeout: 15000 }
+    );
+
+    await page.goto('/notifications');
+    const response = await responsePromise;
+
+    await expect(notificationsPage.pageTitle).toBeVisible({ timeout: 15000 });
+    await notificationsPage.waitForLoaded();
+
+    // API 응답 확인
+    if (response.status() !== 200) {
+      // 서버 에러인 경우 에러 메시지 표시 확인
+      await expect(notificationsPage.errorMessage).toBeVisible({ timeout: 5000 });
+      return;
+    }
+
+    // 알림이 있거나 빈 메시지가 표시
+    const notificationCount = await notificationsPage.getNotificationCount();
+    if (notificationCount === 0) {
+      await expect(notificationsPage.emptyMessage).toBeVisible();
+    } else {
+      expect(notificationCount).toBeGreaterThan(0);
+    }
+
+    // 필터 탭 확인
+    await expect(notificationsPage.getFilterTab('전체')).toBeVisible();
+    await expect(notificationsPage.getFilterTab('안읽음')).toBeVisible();
+    await expect(notificationsPage.getFilterTab('읽음')).toBeVisible();
+
+    // 모두 읽음 버튼 확인
+    await expect(notificationsPage.markAllReadButton).toBeVisible();
+  });
+
+  test('각 대시보드 간 네비게이션 동작 확인', async ({ page }) => {
+    const dashboardPage = new DashboardPage(page);
+
+    // 메인 대시보드에서 시작
+    await page.goto('/dashboard');
+    await dashboardPage.waitForLoaded();
+
+    // ESG 페이지로 이동
+    await dashboardPage.navigateToESG();
+    await expect(page.getByRole('heading', { name: 'ESG' })).toBeVisible({ timeout: 10000 });
+
+    // Safety 페이지로 이동
+    await dashboardPage.navigateToSafety();
+    await expect(page.getByRole('heading', { name: '안전보건' })).toBeVisible({ timeout: 10000 });
+
+    // Compliance 페이지로 이동
+    await dashboardPage.navigateToCompliance();
+    await expect(page.getByRole('heading', { name: '컴플라이언스' })).toBeVisible({ timeout: 10000 });
+
+    // 홈으로 돌아가기
+    await dashboardPage.navigateToHome();
+    await expect(dashboardPage.getPageHeading()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/pages/DashboardPage.ts
+++ b/tests/pages/DashboardPage.ts
@@ -1,0 +1,65 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class DashboardPage {
+  readonly page: Page;
+  readonly pageTitle: Locator;
+  readonly loadingSpinner: Locator;
+  readonly statsSection: Locator;
+  readonly notificationFeed: Locator;
+
+  // Navigation (sidebar)
+  readonly sidebar: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.pageTitle = page.getByRole('heading', { name: '대시보드' });
+    this.loadingSpinner = page.locator('.animate-spin');
+    this.statsSection = page.locator('.bg-white.rounded-\\[20px\\]').first();
+    this.notificationFeed = page.getByText('실시간 알림 피드');
+
+    // Sidebar navigation
+    this.sidebar = page.locator('nav, aside, [class*="sidebar"]').first();
+  }
+
+  getSidebarLink(name: string): Locator {
+    // 사이드바 내 텍스트로 네비게이션 요소 찾기
+    return this.page.locator('a, button, [role="button"]').filter({ hasText: name }).first();
+  }
+
+  async goto() {
+    await this.page.goto('/dashboard');
+    await this.waitForLoaded();
+  }
+
+  async waitForLoaded() {
+    await expect(this.loadingSpinner).toBeHidden({ timeout: 15000 });
+  }
+
+  async navigateToESG() {
+    await this.page.getByText('ESG', { exact: true }).first().click();
+    await expect(this.page).toHaveURL(/\/dashboard\/esg/, { timeout: 10000 });
+  }
+
+  async navigateToSafety() {
+    await this.page.getByText('안전보건', { exact: true }).first().click();
+    await expect(this.page).toHaveURL(/\/dashboard\/safety/, { timeout: 10000 });
+  }
+
+  async navigateToCompliance() {
+    await this.page.getByText('컴플라이언스', { exact: true }).first().click();
+    await expect(this.page).toHaveURL(/\/dashboard\/compliance/, { timeout: 10000 });
+  }
+
+  async navigateToHome() {
+    await this.page.getByText('홈', { exact: true }).first().click();
+    await expect(this.page).toHaveURL(/\/dashboard$/, { timeout: 10000 });
+  }
+
+  getPageHeading(): Locator {
+    return this.page.locator('h1').first();
+  }
+
+  getTable(): Locator {
+    return this.page.locator('table');
+  }
+}

--- a/tests/pages/NotificationsPage.ts
+++ b/tests/pages/NotificationsPage.ts
@@ -1,0 +1,49 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+export class NotificationsPage {
+  readonly page: Page;
+  readonly pageTitle: Locator;
+  readonly loadingSpinner: Locator;
+  readonly emptyMessage: Locator;
+  readonly errorMessage: Locator;
+  readonly markAllReadButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.pageTitle = page.getByRole('heading', { name: '알림' });
+    this.loadingSpinner = page.locator('.animate-spin');
+    this.emptyMessage = page.getByText('알림이 없습니다.');
+    this.errorMessage = page.getByText('알림을 불러오는 데 실패했습니다.');
+    this.markAllReadButton = page.getByRole('button', { name: '모두 읽음' });
+  }
+
+  async goto() {
+    await this.page.goto('/notifications');
+    await expect(this.pageTitle).toBeVisible({ timeout: 15000 });
+    await this.waitForLoaded();
+  }
+
+  async waitForLoaded() {
+    await expect(this.loadingSpinner).toBeHidden({ timeout: 15000 });
+  }
+
+  getFilterTab(label: string): Locator {
+    return this.page.getByRole('button', { name: label, exact: true });
+  }
+
+  getNotificationCards(): Locator {
+    return this.page.locator('[class*="rounded-\\[12px\\]"][class*="border"]').filter({
+      has: this.page.locator('[class*="font-title-small"]'),
+    });
+  }
+
+  async getNotificationCount(): Promise<number> {
+    const cards = this.getNotificationCards();
+    return cards.count();
+  }
+
+  async clickFirstNotification() {
+    const firstCard = this.getNotificationCards().first();
+    await firstCard.click();
+  }
+}


### PR DESCRIPTION
## Summary
- DashboardPage, NotificationsPage POM 클래스 작성
- playwright.config.ts setup 패턴 수정 (정확한 파일 매칭)

## 검증 시나리오
- [x] 메인 대시보드(/dashboard) 정상 렌더링
- [x] ESG 대시보드 정상 렌더링
- [x] Safety 대시보드 정상 렌더링
- [x] Compliance 대시보드 정상 렌더링
- [x] 알림 목록(/notifications) 조회 확인
- [x] 각 대시보드 간 네비게이션 동작 확인

## Test plan
- `npx playwright test tests/dashboard-and-notifications.spec.ts --project=chromium`

## 실행 결과
```
Running 6 tests using 6 workers
  6 passed (12.5s)
```

Closes #78