### PR TITLE
fix: #95 도메인별 리스트 페이지 mock 제거 및 API 연동

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -1,39 +1,228 @@
 import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
+import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
+import { useApprovals } from '../../src/hooks/useApprovals';
+import { useReviews } from '../../src/hooks/useReviews';
+import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 
 interface CompliancePageProps {
   userRole: 'receiver' | 'drafter' | 'approver';
 }
 
-const mockSubmissions = [
-  { company: '(주)ABC사', period: '25년 4월 컴플라이언스 점검', date: '2026/01/08', status: 'approved' },
-  { company: '(주)XYZ사', period: '25년 4월 컴플라이언스 점검', date: '2026/01/08', status: 'review' },
-  { company: '(주)DEF사', period: '25년 4월 컴플라이언스 점검', date: '2026/01/08', status: 'pending' },
-];
-
-const statusLabels = {
-  pending: '보완',
-  approved: '적합',
-  rejected: '부적합',
-  review: '검토',
+const diagnosticStatusLabels: Record<DiagnosticStatus, string> = {
+  WRITING: '작성중',
+  SUBMITTED: '제출됨',
+  RETURNED: '반려됨',
+  APPROVED: '승인',
+  REVIEWING: '검토중',
+  COMPLETED: '완료',
 };
 
-const statusColors = {
-  pending: 'text-[#e65100] bg-[#fff3e0]',
-  approved: 'text-[#008233] bg-[#f0fdf4]',
-  rejected: 'text-[#b91c1c] bg-[#fef2f2]',
-  review: 'text-[#002554] bg-[#e3f2fd]',
+const diagnosticStatusColors: Record<DiagnosticStatus, string> = {
+  WRITING: 'text-[#495057] bg-[#f1f3f5]',
+  SUBMITTED: 'text-[#002554] bg-[#e3f2fd]',
+  RETURNED: 'text-[#b91c1c] bg-[#fef2f2]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVIEWING: 'text-[#e65100] bg-[#fff3e0]',
+  COMPLETED: 'text-[#008233] bg-[#f0fdf4]',
 };
+
+const approvalStatusLabels: Record<ApprovalStatus, string> = {
+  WAITING: '대기중',
+  APPROVED: '승인',
+  REJECTED: '반려',
+};
+
+const approvalStatusColors: Record<ApprovalStatus, string> = {
+  WAITING: 'text-[#e65100] bg-[#fff3e0]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REJECTED: 'text-[#b91c1c] bg-[#fef2f2]',
+};
+
+const reviewStatusLabels: Record<ReviewStatus, string> = {
+  REVIEWING: '검토중',
+  APPROVED: '적합',
+  REVISION_REQUIRED: '보완필요',
+};
+
+const reviewStatusColors: Record<ReviewStatus, string> = {
+  REVIEWING: 'text-[#002554] bg-[#e3f2fd]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVISION_REQUIRED: 'text-[#e65100] bg-[#fff3e0]',
+};
+
+function formatDate(dateString?: string): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+}
 
 export default function CompliancePage({ userRole }: CompliancePageProps) {
   const navigate = useNavigate();
+
+  const diagnosticsQuery = useDiagnosticsList(
+    userRole === 'drafter' ? { domainCode: 'COMPLIANCE' } : undefined
+  );
+  const approvalsQuery = useApprovals(
+    userRole === 'approver' ? { domainCode: 'COMPLIANCE' } : undefined
+  );
+  const reviewsQuery = useReviews(
+    userRole === 'receiver' ? { domainCode: 'COMPLIANCE' } : undefined
+  );
 
   const handleUpload = () => {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (index: number) => {
-    navigate(`/dashboard/compliance/review/${index + 1}`);
+  const handleRowClick = (id: number) => {
+    navigate(`/dashboard/compliance/review/${id}`);
+  };
+
+  const isLoading =
+    (userRole === 'drafter' && diagnosticsQuery.isLoading) ||
+    (userRole === 'approver' && approvalsQuery.isLoading) ||
+    (userRole === 'receiver' && reviewsQuery.isLoading);
+
+  const isError =
+    (userRole === 'drafter' && diagnosticsQuery.isError) ||
+    (userRole === 'approver' && approvalsQuery.isError) ||
+    (userRole === 'receiver' && reviewsQuery.isError);
+
+  const renderTableBody = () => {
+    if (isLoading) {
+      return (
+        <tr>
+          <td colSpan={4} className="py-[48px] text-center">
+            <div className="flex justify-center">
+              <div className="animate-spin rounded-full h-[32px] w-[32px] border-b-2 border-[#003087]" />
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    if (isError) {
+      return (
+        <tr>
+          <td colSpan={4} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
+            데이터를 불러오는데 실패했습니다.
+          </td>
+        </tr>
+      );
+    }
+
+    if (userRole === 'drafter') {
+      const items = diagnosticsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              등록된 기안이 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.diagnosticId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.diagnosticId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.campaign?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.createdAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${diagnosticStatusColors[item.status]}`}
+            >
+              {diagnosticStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'approver') {
+      const items = approvalsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              대기 중인 결재가 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.approvalId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.approvalId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.companyName || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.title}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
+            >
+              {approvalStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'receiver') {
+      const items = reviewsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              심사 대상이 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.reviewId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.reviewId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.companyName || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.title}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${reviewStatusColors[item.status]}`}
+            >
+              {reviewStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    return null;
   };
 
   return (
@@ -74,32 +263,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
                 </tr>
               </thead>
               <tbody>
-                {mockSubmissions.map((item, index) => (
-                  <tr
-                    key={index}
-                    className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-                    onClick={() => handleRowClick(index)}
-                  >
-                    <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-                      {item.company}
-                    </td>
-                    <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-                      {item.period}
-                    </td>
-                    <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-                      {item.date}
-                    </td>
-                    <td className="py-[16px] px-[16px] text-center">
-                      <span
-                        className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${
-                          statusColors[item.status as keyof typeof statusColors]
-                        }`}
-                      >
-                        {statusLabels[item.status as keyof typeof statusLabels]}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
+                {renderTableBody()}
               </tbody>
             </table>
           </div>

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -1,39 +1,228 @@
 import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
+import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
+import { useApprovals } from '../../src/hooks/useApprovals';
+import { useReviews } from '../../src/hooks/useReviews';
+import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 
 interface ESGPageProps {
   userRole: 'receiver' | 'drafter' | 'approver';
 }
 
-const mockSubmissions = [
-  { company: '(주)ABC사', period: '25년 4월 ESG 점검', date: '2026/01/07', status: 'approved' },
-  { company: '(주)XYZ사', period: '25년 4월 ESG 점검', date: '2026/01/07', status: 'review' },
-  { company: '(주)DEF사', period: '25년 4월 ESG 점검', date: '2026/01/07', status: 'rejected' },
-];
-
-const statusLabels = {
-  pending: '보완',
-  approved: '적합',
-  rejected: '부적합',
-  review: '검토',
+const diagnosticStatusLabels: Record<DiagnosticStatus, string> = {
+  WRITING: '작성중',
+  SUBMITTED: '제출됨',
+  RETURNED: '반려됨',
+  APPROVED: '승인',
+  REVIEWING: '검토중',
+  COMPLETED: '완료',
 };
 
-const statusColors = {
-  pending: 'text-[#e65100] bg-[#fff3e0]',
-  approved: 'text-[#008233] bg-[#f0fdf4]',
-  rejected: 'text-[#b91c1c] bg-[#fef2f2]',
-  review: 'text-[#002554] bg-[#e3f2fd]',
+const diagnosticStatusColors: Record<DiagnosticStatus, string> = {
+  WRITING: 'text-[#495057] bg-[#f1f3f5]',
+  SUBMITTED: 'text-[#002554] bg-[#e3f2fd]',
+  RETURNED: 'text-[#b91c1c] bg-[#fef2f2]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVIEWING: 'text-[#e65100] bg-[#fff3e0]',
+  COMPLETED: 'text-[#008233] bg-[#f0fdf4]',
 };
+
+const approvalStatusLabels: Record<ApprovalStatus, string> = {
+  WAITING: '대기중',
+  APPROVED: '승인',
+  REJECTED: '반려',
+};
+
+const approvalStatusColors: Record<ApprovalStatus, string> = {
+  WAITING: 'text-[#e65100] bg-[#fff3e0]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REJECTED: 'text-[#b91c1c] bg-[#fef2f2]',
+};
+
+const reviewStatusLabels: Record<ReviewStatus, string> = {
+  REVIEWING: '검토중',
+  APPROVED: '적합',
+  REVISION_REQUIRED: '보완필요',
+};
+
+const reviewStatusColors: Record<ReviewStatus, string> = {
+  REVIEWING: 'text-[#002554] bg-[#e3f2fd]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVISION_REQUIRED: 'text-[#e65100] bg-[#fff3e0]',
+};
+
+function formatDate(dateString?: string): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+}
 
 export default function ESGPage({ userRole }: ESGPageProps) {
   const navigate = useNavigate();
+
+  const diagnosticsQuery = useDiagnosticsList(
+    userRole === 'drafter' ? { domainCode: 'ESG' } : undefined
+  );
+  const approvalsQuery = useApprovals(
+    userRole === 'approver' ? { domainCode: 'ESG' } : undefined
+  );
+  const reviewsQuery = useReviews(
+    userRole === 'receiver' ? { domainCode: 'ESG' } : undefined
+  );
 
   const handleUpload = () => {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (index: number) => {
-    navigate(`/dashboard/esg/review/${index + 1}`);
+  const handleRowClick = (id: number) => {
+    navigate(`/dashboard/esg/review/${id}`);
+  };
+
+  const isLoading =
+    (userRole === 'drafter' && diagnosticsQuery.isLoading) ||
+    (userRole === 'approver' && approvalsQuery.isLoading) ||
+    (userRole === 'receiver' && reviewsQuery.isLoading);
+
+  const isError =
+    (userRole === 'drafter' && diagnosticsQuery.isError) ||
+    (userRole === 'approver' && approvalsQuery.isError) ||
+    (userRole === 'receiver' && reviewsQuery.isError);
+
+  const renderTableBody = () => {
+    if (isLoading) {
+      return (
+        <tr>
+          <td colSpan={4} className="py-[48px] text-center">
+            <div className="flex justify-center">
+              <div className="animate-spin rounded-full h-[32px] w-[32px] border-b-2 border-[#003087]" />
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    if (isError) {
+      return (
+        <tr>
+          <td colSpan={4} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
+            데이터를 불러오는데 실패했습니다.
+          </td>
+        </tr>
+      );
+    }
+
+    if (userRole === 'drafter') {
+      const items = diagnosticsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              등록된 기안이 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.diagnosticId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.diagnosticId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.campaign?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.createdAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${diagnosticStatusColors[item.status]}`}
+            >
+              {diagnosticStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'approver') {
+      const items = approvalsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              대기 중인 결재가 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.approvalId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.approvalId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.companyName || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.title}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
+            >
+              {approvalStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'receiver') {
+      const items = reviewsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              심사 대상이 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.reviewId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.reviewId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.companyName || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.title}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${reviewStatusColors[item.status]}`}
+            >
+              {reviewStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    return null;
   };
 
   return (
@@ -74,32 +263,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
                 </tr>
               </thead>
               <tbody>
-                {mockSubmissions.map((item, index) => (
-                  <tr
-                    key={index}
-                    className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-                    onClick={() => handleRowClick(index)}
-                  >
-                    <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-                      {item.company}
-                    </td>
-                    <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-                      {item.period}
-                    </td>
-                    <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-                      {item.date}
-                    </td>
-                    <td className="py-[16px] px-[16px] text-center">
-                      <span
-                        className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${
-                          statusColors[item.status as keyof typeof statusColors]
-                        }`}
-                      >
-                        {statusLabels[item.status as keyof typeof statusLabels]}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
+                {renderTableBody()}
               </tbody>
             </table>
           </div>

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -289,16 +289,16 @@ export default function HomePage({ userRole }: HomePageProps) {
         <tr
           key={item.diagnosticId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.diagnosticId, item.domainCode)}
+          onClick={() => handleRowClick(item.diagnosticId, item.domain?.code || activeTab)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.summary || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.campaign?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.submittedAt)}
+            {formatDate(item.createdAt)}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -1,40 +1,228 @@
 import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
+import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
+import { useApprovals } from '../../src/hooks/useApprovals';
+import { useReviews } from '../../src/hooks/useReviews';
+import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 
 interface SafetyPageProps {
   userRole: 'receiver' | 'drafter' | 'approver';
 }
 
-const mockSubmissions = [
-  { company: '(주)ABC사', period: '25년 4월 안전보건 점검', date: '2026/01/09', status: 'pending' },
-  { company: '(주)XYZ사', period: '25년 4월 안전보건 점검', date: '2026/01/09', status: 'approved' },
-  { company: '(주)DEF사', period: '25년 4월 안전보건 점검', date: '2026/01/09', status: 'rejected' },
-  { company: '(주)GHI사', period: '25년 4월 안전보건 점검', date: '2026/01/09', status: 'review' },
-];
-
-const statusLabels = {
-  pending: '보완',
-  approved: '적합',
-  rejected: '부적합',
-  review: '검토',
+const diagnosticStatusLabels: Record<DiagnosticStatus, string> = {
+  WRITING: '작성중',
+  SUBMITTED: '제출됨',
+  RETURNED: '반려됨',
+  APPROVED: '승인',
+  REVIEWING: '검토중',
+  COMPLETED: '완료',
 };
 
-const statusColors = {
-  pending: 'text-[#e65100] bg-[#fff3e0]',
-  approved: 'text-[#008233] bg-[#f0fdf4]',
-  rejected: 'text-[#b91c1c] bg-[#fef2f2]',
-  review: 'text-[#002554] bg-[#e3f2fd]',
+const diagnosticStatusColors: Record<DiagnosticStatus, string> = {
+  WRITING: 'text-[#495057] bg-[#f1f3f5]',
+  SUBMITTED: 'text-[#002554] bg-[#e3f2fd]',
+  RETURNED: 'text-[#b91c1c] bg-[#fef2f2]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVIEWING: 'text-[#e65100] bg-[#fff3e0]',
+  COMPLETED: 'text-[#008233] bg-[#f0fdf4]',
 };
+
+const approvalStatusLabels: Record<ApprovalStatus, string> = {
+  WAITING: '대기중',
+  APPROVED: '승인',
+  REJECTED: '반려',
+};
+
+const approvalStatusColors: Record<ApprovalStatus, string> = {
+  WAITING: 'text-[#e65100] bg-[#fff3e0]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REJECTED: 'text-[#b91c1c] bg-[#fef2f2]',
+};
+
+const reviewStatusLabels: Record<ReviewStatus, string> = {
+  REVIEWING: '검토중',
+  APPROVED: '적합',
+  REVISION_REQUIRED: '보완필요',
+};
+
+const reviewStatusColors: Record<ReviewStatus, string> = {
+  REVIEWING: 'text-[#002554] bg-[#e3f2fd]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVISION_REQUIRED: 'text-[#e65100] bg-[#fff3e0]',
+};
+
+function formatDate(dateString?: string): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+}
 
 export default function SafetyPage({ userRole }: SafetyPageProps) {
   const navigate = useNavigate();
+
+  const diagnosticsQuery = useDiagnosticsList(
+    userRole === 'drafter' ? { domainCode: 'SAFETY' } : undefined
+  );
+  const approvalsQuery = useApprovals(
+    userRole === 'approver' ? { domainCode: 'SAFETY' } : undefined
+  );
+  const reviewsQuery = useReviews(
+    userRole === 'receiver' ? { domainCode: 'SAFETY' } : undefined
+  );
 
   const handleUpload = () => {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (index: number) => {
-    navigate(`/dashboard/safety/review/${index + 1}`);
+  const handleRowClick = (id: number) => {
+    navigate(`/dashboard/safety/review/${id}`);
+  };
+
+  const isLoading =
+    (userRole === 'drafter' && diagnosticsQuery.isLoading) ||
+    (userRole === 'approver' && approvalsQuery.isLoading) ||
+    (userRole === 'receiver' && reviewsQuery.isLoading);
+
+  const isError =
+    (userRole === 'drafter' && diagnosticsQuery.isError) ||
+    (userRole === 'approver' && approvalsQuery.isError) ||
+    (userRole === 'receiver' && reviewsQuery.isError);
+
+  const renderTableBody = () => {
+    if (isLoading) {
+      return (
+        <tr>
+          <td colSpan={4} className="py-[48px] text-center">
+            <div className="flex justify-center">
+              <div className="animate-spin rounded-full h-[32px] w-[32px] border-b-2 border-[#003087]" />
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    if (isError) {
+      return (
+        <tr>
+          <td colSpan={4} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
+            데이터를 불러오는데 실패했습니다.
+          </td>
+        </tr>
+      );
+    }
+
+    if (userRole === 'drafter') {
+      const items = diagnosticsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              등록된 기안이 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.diagnosticId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.diagnosticId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.campaign?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.createdAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${diagnosticStatusColors[item.status]}`}
+            >
+              {diagnosticStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'approver') {
+      const items = approvalsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              대기 중인 결재가 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.approvalId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.approvalId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.companyName || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.title}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
+            >
+              {approvalStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'receiver') {
+      const items = reviewsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+              심사 대상이 없습니다.
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.reviewId}
+          className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
+          onClick={() => handleRowClick(item.reviewId)}
+        >
+          <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.companyName || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.title}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="py-[16px] px-[16px] text-center">
+            <span
+              className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${reviewStatusColors[item.status]}`}
+            >
+              {reviewStatusLabels[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    return null;
   };
 
   return (
@@ -75,32 +263,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
                 </tr>
               </thead>
               <tbody>
-                {mockSubmissions.map((item, index) => (
-                  <tr
-                    key={index}
-                    className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-                    onClick={() => handleRowClick(index)}
-                  >
-                    <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-                      {item.company}
-                    </td>
-                    <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-                      {item.period}
-                    </td>
-                    <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-                      {item.date}
-                    </td>
-                    <td className="py-[16px] px-[16px] text-center">
-                      <span
-                        className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${
-                          statusColors[item.status as keyof typeof statusColors]
-                        }`}
-                      >
-                        {statusLabels[item.status as keyof typeof statusLabels]}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
+                {renderTableBody()}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- SafetyPage, CompliancePage, ESGPage에서 하드코딩된 `mockSubmissions` 제거하고 `useDiagnosticsList` / `useApprovals` / `useReviews` API hook으로 교체
- DocumentReviewPage에서 `mockData` 제거하고 `useReviewDetail` / `useSubmitReview` 연동
- HomePage drafter 진단 목록에서 `DiagnosticListItem` 실제 필드 구조에 맞게 매핑 수정 (`campaign.title`, `summary`, `createdAt`, `domain.code`)

## Test plan
- [ ] drafter 로그인 후 `/dashboard/safety`, `/dashboard/compliance`, `/dashboard/esg` 접근 시 실제 진단 목록 표시 확인
- [ ] approver/receiver 역할로 동일 페이지 접근 시 결재/심사 목록 표시 확인
- [ ] 데이터 없을 때 빈 상태 메시지 표시 확인
- [ ] HomePage 탭 전환 시 진단 목록 정상 렌더링 확인
- [ ] Network 탭에서 domainCode 파라미터가 올바르게 전달되는지 확인

Closes #95