### PR TITLE
fix: #97 역할별 상세 페이지 네비게이션 경로 수정

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -74,7 +74,11 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (id: number) => {
+  const handleDiagnosticClick = (id: number) => {
+    navigate(`/diagnostics/${id}`);
+  };
+
+  const handleReviewClick = (id: number) => {
     navigate(`/dashboard/compliance/review/${id}`);
   };
 
@@ -126,7 +130,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
         <tr
           key={item.diagnosticId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.diagnosticId)}
+          onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.summary || '-'}
@@ -163,7 +167,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.approvalId)}
+          onClick={() => handleReviewClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}
@@ -200,7 +204,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
         <tr
           key={item.reviewId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.reviewId)}
+          onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -74,7 +74,11 @@ export default function ESGPage({ userRole }: ESGPageProps) {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (id: number) => {
+  const handleDiagnosticClick = (id: number) => {
+    navigate(`/diagnostics/${id}`);
+  };
+
+  const handleReviewClick = (id: number) => {
     navigate(`/dashboard/esg/review/${id}`);
   };
 
@@ -126,7 +130,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
         <tr
           key={item.diagnosticId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.diagnosticId)}
+          onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.summary || '-'}
@@ -163,7 +167,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.approvalId)}
+          onClick={() => handleReviewClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}
@@ -200,7 +204,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
         <tr
           key={item.reviewId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.reviewId)}
+          onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -246,7 +246,11 @@ export default function HomePage({ userRole }: HomePageProps) {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (id: number, domain: string) => {
+  const handleDiagnosticClick = (id: number) => {
+    navigate(`/diagnostics/${id}`);
+  };
+
+  const handleReviewClick = (id: number, domain: string) => {
     const domainPath = domain.toLowerCase();
     navigate(`/dashboard/${domainPath}/review/${id}`);
   };
@@ -289,7 +293,7 @@ export default function HomePage({ userRole }: HomePageProps) {
         <tr
           key={item.diagnosticId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.diagnosticId, item.domain?.code || activeTab)}
+          onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.summary || '-'}
@@ -327,7 +331,7 @@ export default function HomePage({ userRole }: HomePageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.approvalId, item.domainCode)}
+          onClick={() => handleReviewClick(item.approvalId, item.domainCode)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}
@@ -365,7 +369,7 @@ export default function HomePage({ userRole }: HomePageProps) {
         <tr
           key={item.reviewId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.reviewId, item.domainCode)}
+          onClick={() => handleReviewClick(item.reviewId, item.domainCode)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -74,7 +74,11 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
     navigate('/diagnostics/new');
   };
 
-  const handleRowClick = (id: number) => {
+  const handleDiagnosticClick = (id: number) => {
+    navigate(`/diagnostics/${id}`);
+  };
+
+  const handleReviewClick = (id: number) => {
     navigate(`/dashboard/safety/review/${id}`);
   };
 
@@ -126,7 +130,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
         <tr
           key={item.diagnosticId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.diagnosticId)}
+          onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.summary || '-'}
@@ -163,7 +167,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.approvalId)}
+          onClick={() => handleReviewClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}
@@ -200,7 +204,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
         <tr
           key={item.reviewId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleRowClick(item.reviewId)}
+          onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
             {item.companyName || '-'}


### PR DESCRIPTION
## Summary
- drafter가 리스트 클릭 시 diagnosticId로 review 상세에 접근하여 404 발생하던 문제 수정
- 역할별 올바른 상세 페이지로 네비게이션 분리 (drafter → `/diagnostics/:id`, approver/receiver → `/dashboard/:domain/review/:id`)

## Test plan
- [ ] drafter로 SafetyPage/CompliancePage/ESGPage 리스트 클릭 → `/diagnostics/:id` 진입 확인
- [ ] approver로 리스트 클릭 → `/dashboard/:domain/review/:id` 진입 확인
- [ ] receiver로 리스트 클릭 → `/dashboard/:domain/review/:id` 진입 확인
- [ ] HomePage에서 동일하게 동작 확인

Closes #97