### PR TITLE
fix: #99 useDiagnosticsList 훅에 keyword 파라미터 추가

### DIFF
--- a/src/hooks/useDiagnostics.ts
+++ b/src/hooks/useDiagnostics.ts
@@ -9,6 +9,7 @@ import type { ErrorResponse, DiagnosticStatus } from '../types/api.types';
 interface DiagnosticsListParams {
   domainCode?: string;
   status?: DiagnosticStatus;
+  keyword?: string;
   page?: number;
   size?: number;
 }


### PR DESCRIPTION
## Summary
- `useDiagnosticsList` 훅의 `DiagnosticsListParams` 인터페이스에 `keyword` 필드 추가
- `src/api/diagnostics.ts`의 `DiagnosticListParams`와 타입 정합성 확보
- 백엔드 keyword 검색 필터(SmartChain-HD/Backend#77) 대응

## Test plan
- [ ] 진단 목록 페이지에서 키워드 검색 시 API에 `keyword` 파라미터 정상 전달 확인
- [ ] TypeScript 컴파일 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #99