### PR TITLE
fix: #103 결재자 리스트/상세 페이지 API 응답 필드 매핑 수정

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -17,11 +17,6 @@ const STATUS_STYLES: Record<ApprovalStatus, string> = {
   REJECTED: 'bg-red-50 text-red-700 border-red-200',
 };
 
-const RISK_LABELS: Record<string, { label: string; style: string }> = {
-  LOW: { label: '낮음', style: 'text-green-600' },
-  MEDIUM: { label: '보통', style: 'text-yellow-600' },
-  HIGH: { label: '높음', style: 'text-red-600' },
-};
 
 export default function ApprovalDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -91,7 +86,6 @@ export default function ApprovalDetailPage() {
 
   const isWaiting = approval.status === 'WAITING';
   const isApproved = approval.status === 'APPROVED';
-  const risk = approval.riskLevel ? RISK_LABELS[approval.riskLevel] : null;
 
   return (
     <DashboardLayout>
@@ -109,31 +103,36 @@ export default function ApprovalDetailPage() {
 
         {/* 제목 + 상태 */}
         <div className="flex items-start justify-between gap-[16px]">
-          <h1 className="font-heading-small text-[var(--color-text-primary)]">{approval.title}</h1>
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{approval.diagnostic?.title || '-'}</h1>
           <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[approval.status]}`}>
-            {STATUS_LABELS[approval.status]}
+            {approval.statusLabel || STATUS_LABELS[approval.status]}
           </span>
         </div>
 
         {/* 기본 정보 */}
         <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
           <div className="grid grid-cols-2 gap-[20px]">
-            <InfoRow label="도메인" value={DOMAIN_LABELS[approval.domainCode as DomainCode] || approval.domainCode} />
-            <InfoRow label="회사명" value={approval.companyName} />
-            <InfoRow label="기안자" value={approval.drafterName} />
-            <InfoRow label="제출일" value={new Date(approval.submittedAt).toLocaleDateString('ko-KR')} />
-            {risk && (
-              <InfoRow label="위험 등급" value={risk.label} valueClassName={risk.style} />
-            )}
-            {approval.aiVerdict && (
-              <InfoRow label="AI 판정" value={approval.aiVerdict} />
+            <InfoRow label="도메인" value={approval.domainName || DOMAIN_LABELS[approval.domainCode as DomainCode] || approval.domainCode} />
+            <InfoRow label="진단코드" value={approval.diagnostic?.diagnosticCode || '-'} />
+            <InfoRow label="기안자" value={approval.requester?.name || '-'} />
+            <InfoRow label="기안자 이메일" value={approval.requester?.email || '-'} />
+            <InfoRow label="요청일" value={approval.requestedAt ? new Date(approval.requestedAt).toLocaleDateString('ko-KR') : '-'} />
+            {approval.processedAt && (
+              <InfoRow label="처리일" value={new Date(approval.processedAt).toLocaleDateString('ko-KR')} />
             )}
           </div>
 
-          {approval.comment && (
+          {approval.requestComment && (
             <div className="mt-[20px] pt-[20px] border-t border-[var(--color-border-default)]">
-              <p className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px]">코멘트</p>
-              <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{approval.comment}</p>
+              <p className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px]">요청 코멘트</p>
+              <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{approval.requestComment}</p>
+            </div>
+          )}
+
+          {approval.approverComment && (
+            <div className="mt-[20px] pt-[20px] border-t border-[var(--color-border-default)]">
+              <p className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px]">결재자 코멘트</p>
+              <p className="font-body-medium text-[var(--color-text-primary)] whitespace-pre-wrap">{approval.approverComment}</p>
             </div>
           )}
         </div>

--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -78,6 +78,10 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
     navigate(`/diagnostics/${id}`);
   };
 
+  const handleApprovalClick = (id: number) => {
+    navigate(`/approvals/${id}`);
+  };
+
   const handleReviewClick = (id: number) => {
     navigate(`/dashboard/compliance/review/${id}`);
   };
@@ -167,22 +171,22 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleReviewClick(item.approvalId)}
+          onClick={() => handleApprovalClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.requester?.name || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.diagnostic?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.submittedAt)}
+            {formatDate(item.requestedAt)}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
               className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
             >
-              {approvalStatusLabels[item.status]}
+              {item.statusLabel || approvalStatusLabels[item.status]}
             </span>
           </td>
         </tr>

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -78,6 +78,10 @@ export default function ESGPage({ userRole }: ESGPageProps) {
     navigate(`/diagnostics/${id}`);
   };
 
+  const handleApprovalClick = (id: number) => {
+    navigate(`/approvals/${id}`);
+  };
+
   const handleReviewClick = (id: number) => {
     navigate(`/dashboard/esg/review/${id}`);
   };
@@ -167,22 +171,22 @@ export default function ESGPage({ userRole }: ESGPageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleReviewClick(item.approvalId)}
+          onClick={() => handleApprovalClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.requester?.name || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.diagnostic?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.submittedAt)}
+            {formatDate(item.requestedAt)}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
               className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
             >
-              {approvalStatusLabels[item.status]}
+              {item.statusLabel || approvalStatusLabels[item.status]}
             </span>
           </td>
         </tr>

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -250,6 +250,10 @@ export default function HomePage({ userRole }: HomePageProps) {
     navigate(`/diagnostics/${id}`);
   };
 
+  const handleApprovalClick = (id: number) => {
+    navigate(`/approvals/${id}`);
+  };
+
   const handleReviewClick = (id: number, domain: string) => {
     const domainPath = domain.toLowerCase();
     navigate(`/dashboard/${domainPath}/review/${id}`);
@@ -331,22 +335,22 @@ export default function HomePage({ userRole }: HomePageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleReviewClick(item.approvalId, item.domainCode)}
+          onClick={() => handleApprovalClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.requester?.name || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.diagnostic?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.submittedAt)}
+            {formatDate(item.requestedAt)}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
               className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
             >
-              {approvalStatusLabels[item.status]}
+              {item.statusLabel || approvalStatusLabels[item.status]}
             </span>
           </td>
         </tr>

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -78,6 +78,10 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
     navigate(`/diagnostics/${id}`);
   };
 
+  const handleApprovalClick = (id: number) => {
+    navigate(`/approvals/${id}`);
+  };
+
   const handleReviewClick = (id: number) => {
     navigate(`/dashboard/safety/review/${id}`);
   };
@@ -167,22 +171,22 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
         <tr
           key={item.approvalId}
           className="border-b border-[#f1f3f5] hover:bg-[#f8f9fa] cursor-pointer"
-          onClick={() => handleReviewClick(item.approvalId)}
+          onClick={() => handleApprovalClick(item.approvalId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.requester?.name || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.diagnostic?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.submittedAt)}
+            {formatDate(item.requestedAt)}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
               className={`inline-block px-[12px] py-[4px] rounded-[6px] font-title-xsmall ${approvalStatusColors[item.status]}`}
             >
-              {approvalStatusLabels[item.status]}
+              {item.statusLabel || approvalStatusLabels[item.status]}
             </span>
           </td>
         </tr>

--- a/src/api/approvals.ts
+++ b/src/api/approvals.ts
@@ -3,19 +3,28 @@ import type { BaseResponse, PagedData, ApprovalStatus } from '../types/api.types
 
 export interface ApprovalListItem {
   approvalId: number;
-  diagnosticId: number;
-  title: string;
+  diagnostic: {
+    diagnosticId: number;
+    diagnosticCode: string;
+    title: string;
+    qualitativeProgress: number;
+    quantitativeProgress: number;
+    overallScore: number | null;
+  };
+  requester: {
+    userId: number;
+    name: string;
+    email: string;
+  };
   domainCode: string;
-  companyName: string;
-  drafterName: string;
-  submittedAt: string;
+  domainName: string;
   status: ApprovalStatus;
-}
-
-export interface ApprovalDetail extends ApprovalListItem {
-  riskLevel?: string;
-  aiVerdict?: string;
-  comment?: string;
+  statusLabel: string;
+  requestComment: string | null;
+  requestedAt: string;
+  processedAt: string | null;
+  processedBy: string | null;
+  approverComment: string | null;
 }
 
 interface ApprovalListParams {
@@ -34,8 +43,8 @@ export const getApprovals = async (
   return response.data.data;
 };
 
-export const getApprovalDetail = async (id: number): Promise<ApprovalDetail> => {
-  const response = await apiClient.get<BaseResponse<ApprovalDetail>>(`/v1/approvals/${id}`);
+export const getApprovalDetail = async (id: number): Promise<ApprovalListItem> => {
+  const response = await apiClient.get<BaseResponse<ApprovalListItem>>(`/v1/approvals/${id}`);
   return response.data.data;
 };
 


### PR DESCRIPTION
## Summary
- `ApprovalListItem` 타입을 실제 API 응답 중첩 구조에 맞게 재정의 (`diagnostic.title`, `requester.name`, `requestedAt` 등)
- `ApprovalDetailPage` 필드 매핑 수정하여 회사명, 기안자, 제출일 등 정상 표시
- 4개 리스트 페이지(SafetyPage, CompliancePage, ESGPage, HomePage)에서 approver 테이블 필드 및 네비게이션 경로 수정 (`/approvals/:id`)

## Test plan
- [ ] 결재자로 로그인 후 리스트에서 기안자명, 진단명, 요청일 정상 표시 확인
- [ ] 리스트 항목 클릭 → `/approvals/:id` 이동 확인
- [ ] 상세 페이지에서 진단명, 기안자, 이메일, 요청일, 코멘트 정상 표시 확인
- [ ] Network 탭에서 `GET /v1/approvals/:id` 호출 확인

Closes #103