### PR TITLE
fix: #105 도메인별 리스트 테이블 헤더를 역할별로 분기 처리

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -257,16 +257,16 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
               <thead>
                 <tr className="border-b border-[#dee2e6]">
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    협력사 명
+                    {userRole === 'approver' ? '기안자' : '협력사 명'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    기간
+                    {userRole === 'approver' ? '진단명' : userRole === 'drafter' ? '캠페인' : '기간'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    제출일
+                    {userRole === 'approver' ? '요청일' : '제출일'}
                   </th>
                   <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    결과
+                    상태
                   </th>
                 </tr>
               </thead>

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -257,16 +257,16 @@ export default function ESGPage({ userRole }: ESGPageProps) {
               <thead>
                 <tr className="border-b border-[#dee2e6]">
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    협력사 명
+                    {userRole === 'approver' ? '기안자' : '협력사 명'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    기간
+                    {userRole === 'approver' ? '진단명' : userRole === 'drafter' ? '캠페인' : '기간'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    제출일
+                    {userRole === 'approver' ? '요청일' : '제출일'}
                   </th>
                   <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    결과
+                    상태
                   </th>
                 </tr>
               </thead>

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -257,16 +257,16 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
               <thead>
                 <tr className="border-b border-[#dee2e6]">
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    협력사 명
+                    {userRole === 'approver' ? '기안자' : '협력사 명'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    기간
+                    {userRole === 'approver' ? '진단명' : userRole === 'drafter' ? '캠페인' : '기간'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    제출일
+                    {userRole === 'approver' ? '요청일' : '제출일'}
                   </th>
                   <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    결과
+                    상태
                   </th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- SafetyPage, CompliancePage, ESGPage 테이블 헤더를 userRole에 따라 동적으로 표시
- drafter: 협력사 명 / 캠페인 / 제출일 / 상태
- approver: 기안자 / 진단명 / 요청일 / 상태
- receiver: 협력사 명 / 기간 / 제출일 / 상태

## Test plan
- [ ] 각 역할로 로그인 후 안전보건/컴플라이언스/ESG 페이지에서 헤더와 데이터 일치 확인

Closes #105