### PR TITLE
fix: #120 수신자 ReviewListItem 필드 매핑 수정

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -211,10 +211,10 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
           onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.domainName || item.domainCode}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {formatDate(item.submittedAt)}

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -211,10 +211,10 @@ export default function ESGPage({ userRole }: ESGPageProps) {
           onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.domainName || item.domainCode}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {formatDate(item.submittedAt)}

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -376,10 +376,10 @@ export default function HomePage({ userRole }: HomePageProps) {
           onClick={() => handleReviewClick(item.reviewId, item.domainCode)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.domainName || item.domainCode}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {formatDate(item.submittedAt)}

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -211,10 +211,10 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
           onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.companyName || '-'}
+            {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.title}
+            {item.domainName || item.domainCode}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {formatDate(item.submittedAt)}

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -149,7 +149,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                 <div className="flex items-center gap-[8px]">
                   <span className="font-body-small text-[#868e96]">협력사:</span>
                   <span className="font-title-small text-[#212529]">
-                    {review.companyName}
+                    {review.company?.companyName || '-'}
                   </span>
                 </div>
                 <div className="w-[1px] h-[16px] bg-[#dee2e6]"></div>
@@ -161,7 +161,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                 </div>
               </div>
               <p className="font-body-small text-[#868e96] mt-[8px]">
-                Ref: {review.title}
+                Ref: {review.reviewIdLabel || review.diagnostic?.diagnosticCode || '-'}
               </p>
             </div>
           </div>

--- a/features/reviews/ReviewDetailPage.tsx
+++ b/features/reviews/ReviewDetailPage.tsx
@@ -116,7 +116,7 @@ export default function ReviewDetailPage() {
 
         {/* 제목 + 상태 */}
         <div className="flex items-start justify-between gap-[16px]">
-          <h1 className="font-heading-small text-[var(--color-text-primary)]">{review.title}</h1>
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{review.reviewIdLabel || `R-${review.reviewId}`}</h1>
           <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[review.status]}`}>
             {STATUS_LABELS[review.status]}
           </span>
@@ -125,9 +125,9 @@ export default function ReviewDetailPage() {
         {/* 기본 정보 */}
         <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
           <div className="grid grid-cols-2 gap-[20px]">
-            <InfoRow label="도메인" value={DOMAIN_LABELS[review.domainCode as DomainCode] || review.domainCode} />
-            <InfoRow label="회사명" value={review.companyName} />
-            <InfoRow label="기안자" value={review.drafterName} />
+            <InfoRow label="도메인" value={review.domainName || DOMAIN_LABELS[review.domainCode as DomainCode] || review.domainCode} />
+            <InfoRow label="회사명" value={review.company?.companyName || '-'} />
+            <InfoRow label="진단코드" value={review.diagnostic?.diagnosticCode || '-'} />
             <InfoRow label="제출일" value={new Date(review.submittedAt).toLocaleDateString('ko-KR')} />
             {risk && <InfoRow label="위험 등급" value={risk.label} valueClassName={risk.style} />}
             {review.score != null && <InfoRow label="점수" value={String(review.score)} />}

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -225,13 +225,13 @@ export default function ReviewsListPage() {
                     className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]"
                     onClick={() => navigate(`/reviews/${item.reviewId}`)}
                   >
-                    {item.title}
+                    {item.reviewIdLabel || `R-${item.reviewId}`}
                   </td>
                   <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
-                    {DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
+                    {item.domainName || DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
                   </td>
                   <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
-                    {item.companyName}
+                    {item.company?.companyName || '-'}
                   </td>
                   <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/reviews/${item.reviewId}`)}>
                     {item.riskLevel ? (

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -11,15 +11,39 @@ export interface ReviewDashboardResponse {
 
 export interface ReviewListItem {
   reviewId: number;
-  diagnosticId: number;
-  title: string;
+  reviewIdLabel: string;
+  diagnostic: {
+    diagnosticId: number;
+    diagnosticCode: string;
+  };
+  company: {
+    companyId: number;
+    companyName: string;
+    companyType: string;
+  };
   domainCode: string;
-  companyName: string;
-  drafterName: string;
-  submittedAt: string;
-  status: ReviewStatus;
+  domainName: string;
+  score: number | null;
   riskLevel?: RiskLevel;
-  score?: number;
+  riskLevelLabel?: string;
+  riskColorClass?: string;
+  status: ReviewStatus;
+  statusLabel: string;
+  submittedAt: string;
+  files: {
+    diagnosticPdfUrl: string | null;
+    dataPackageUrl: string | null;
+    modificationLogUrl: string | null;
+    aiReportUrl: string | null;
+    hasDiagnosticPdf: boolean;
+    hasDataPackage: boolean;
+    hasModificationLog: boolean;
+    hasAiReport: boolean;
+  };
+  assignedTo: {
+    userId: number;
+    name: string;
+  };
 }
 
 export interface ReviewDetail extends ReviewListItem {


### PR DESCRIPTION
## Summary
- ReviewListItem 타입을 실제 API 응답의 중첩 구조에 맞게 수정
- 수신자 리스트/상세 페이지 전체(SafetyPage, CompliancePage, ESGPage, HomePage, ReviewsListPage, ReviewDetailPage, DocumentReviewPage)의 필드 매핑 수정

## Test plan
- [ ] 수신자로 로그인 후 각 도메인 리스트 페이지에서 회사명, 도메인명 표시 확인
- [ ] 심사 관리 리스트에서 제목, 도메인, 회사명 표시 확인
- [ ] 심사 상세 페이지에서 회사명, 진단코드 표시 확인

Closes #120