### PR TITLE
fix: #116 도메인 멤버십 기반 사이드 메뉴 접근 제어

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { useAuthStore } from './src/store/authStore';
 import { useMe } from './src/hooks/useAuth';
+import type { DomainCode } from './src/types/api.types';
 import OnboardingPage from './features/onboarding/OnboardingPage';
 import LoginPage from './features/auth/LoginPage';
 import SignupStep1Page from './features/auth/SignupStep1Page';
@@ -53,6 +54,43 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+function MemberRoute({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isGuest } = useAuthStore();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isGuest()) {
+    return <Navigate to="/permission/request" replace />;
+  }
+
+  return <>{children}</>;
+}
+
+interface DomainProtectedRouteProps {
+  children: React.ReactNode;
+  domainCode: DomainCode;
+}
+
+function DomainProtectedRoute({ children, domainCode }: DomainProtectedRouteProps) {
+  const { isAuthenticated, isGuest, hasDomainAccess } = useAuthStore();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isGuest()) {
+    return <Navigate to="/permission/request" replace />;
+  }
+
+  if (!hasDomainAccess(domainCode)) {
+    return <Navigate to="/permission/request" replace />;
+  }
+
+  return <>{children}</>;
+}
+
 function AppRoutes() {
   const { user } = useAuthStore();
 
@@ -96,9 +134,9 @@ function AppRoutes() {
       <Route
         path="/dashboard/permission"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <PermissionManagementPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
 
@@ -106,25 +144,25 @@ function AppRoutes() {
       <Route
         path="/management/users"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <UserManagementPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/management/companies"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <CompanyManagementPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/management/activity-logs"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <ActivityLogPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
 
@@ -132,41 +170,41 @@ function AppRoutes() {
       <Route
         path="/diagnostics"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <DiagnosticsListPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/diagnostics/new"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <DiagnosticCreatePage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/diagnostics/:id"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <DiagnosticDetailPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/diagnostics/:id/files"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <DiagnosticFilesPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/diagnostics/:id/ai-analysis"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <DiagnosticAiAnalysisPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
 
@@ -174,17 +212,17 @@ function AppRoutes() {
       <Route
         path="/approvals"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <ApprovalsListPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/approvals/:id"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <ApprovalDetailPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
 
@@ -192,17 +230,17 @@ function AppRoutes() {
       <Route
         path="/reviews"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <ReviewsListPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/reviews/:id"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <ReviewDetailPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
 
@@ -210,93 +248,97 @@ function AppRoutes() {
       <Route
         path="/notifications"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <NotificationsPage />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
 
-      {/* Protected Routes */}
+      {/* Dashboard Routes */}
       <Route
         path="/dashboard"
         element={
-          <ProtectedRoute>
+          <MemberRoute>
             <HomePage userRole={legacyRole} />
-          </ProtectedRoute>
+          </MemberRoute>
         }
       />
       <Route
         path="/dashboard/safety"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="SAFETY">
             <SafetyPage userRole={legacyRole} />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
       <Route
         path="/dashboard/compliance"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="COMPLIANCE">
             <CompliancePage userRole={legacyRole} />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
       <Route
         path="/dashboard/esg"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="ESG">
             <ESGPage userRole={legacyRole} />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
 
-      {/* Document Routes */}
+      {/* Document Routes - Safety */}
       <Route
         path="/dashboard/safety/upload"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="SAFETY">
             <FileUploadPage />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
       <Route
         path="/dashboard/safety/review/:id"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="SAFETY">
             <DocumentReviewPage userRole={legacyRole} />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
+
+      {/* Document Routes - Compliance */}
       <Route
         path="/dashboard/compliance/upload"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="COMPLIANCE">
             <FileUploadPage />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
       <Route
         path="/dashboard/compliance/review/:id"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="COMPLIANCE">
             <DocumentReviewPage userRole={legacyRole} />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
+
+      {/* Document Routes - ESG */}
       <Route
         path="/dashboard/esg/upload"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="ESG">
             <FileUploadPage />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
       <Route
         path="/dashboard/esg/review/:id"
         element={
-          <ProtectedRoute>
+          <DomainProtectedRoute domainCode="ESG">
             <DocumentReviewPage userRole={legacyRole} />
-          </ProtectedRoute>
+          </DomainProtectedRoute>
         }
       />
 

--- a/shared/layout/DashboardLayout.tsx
+++ b/shared/layout/DashboardLayout.tsx
@@ -9,7 +9,7 @@ interface DashboardLayoutProps {
 }
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
-  const { user } = useAuthStore();
+  const { user, isGuest } = useAuthStore();
 
   const userRole = (() => {
     if (!user?.role) return 'drafter' as const;
@@ -20,12 +20,13 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   })();
 
   const userName = user?.name || '사용자';
+  const isUserGuest = isGuest();
 
   return (
     <div className="bg-[#f8f9fa] min-h-screen flex flex-col">
       <Header userName={userName} userRole={userRole} />
       <div className="flex flex-1 relative">
-        <Sidebar userRole={userRole} />
+        {!isUserGuest && <Sidebar />}
         <div className="flex-1 min-w-0">
           {children}
         </div>

--- a/shared/layout/Sidebar.tsx
+++ b/shared/layout/Sidebar.tsx
@@ -1,26 +1,40 @@
 import { useNavigate, useLocation } from 'react-router-dom';
-
-interface SidebarProps {
-  userRole: 'receiver' | 'drafter' | 'approver';
-}
+import { useAuthStore } from '../../src/store/authStore';
+import type { DomainCode } from '../../src/types/api.types';
 
 interface MenuItem {
   label: string;
   path: string;
+  domainCode?: DomainCode;
 }
 
-export default function Sidebar({ userRole }: SidebarProps) {
+const DOMAIN_MENU_ITEMS: MenuItem[] = [
+  { label: '안전보건', path: '/dashboard/safety', domainCode: 'SAFETY' },
+  { label: '컴플라이언스', path: '/dashboard/compliance', domainCode: 'COMPLIANCE' },
+  { label: 'ESG', path: '/dashboard/esg', domainCode: 'ESG' },
+];
+
+export default function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { user, isGuest, getAccessibleDomains } = useAuthStore();
 
-  const menuItems: MenuItem[] = [
-    { label: '홈', path: '/dashboard' },
-    { label: '안전보건', path: '/dashboard/safety' },
-    { label: '컴플라이언스', path: '/dashboard/compliance' },
-    { label: 'ESG', path: '/dashboard/esg' },
-  ];
+  const isUserGuest = isGuest();
+  const accessibleDomains = getAccessibleDomains();
 
-  if (userRole === 'receiver') {
+  if (isUserGuest) {
+    return null;
+  }
+
+  const menuItems: MenuItem[] = [{ label: '홈', path: '/dashboard' }];
+
+  DOMAIN_MENU_ITEMS.forEach((item) => {
+    if (item.domainCode && accessibleDomains.includes(item.domainCode)) {
+      menuItems.push(item);
+    }
+  });
+
+  if (user?.role?.code === 'REVIEWER') {
     menuItems.push({ label: '권한 관리', path: '/dashboard/permission' });
   }
 


### PR DESCRIPTION
## Summary
- 사이드 메뉴를 사용자의 실제 도메인 멤버십 기반으로 렌더링
- 게스트 사용자는 사이드 메뉴 숨김 처리
- URL 직접 접근 시 권한 체크 후 권한요청 페이지로 리다이렉트
- 소속되지 않은 도메인 메뉴는 표시하지 않음

## Changes
- **authStore**: `isGuest`, `hasDomainAccess`, `getAccessibleDomains` 헬퍼 함수 추가
- **Sidebar**: `domainRoles` 기반으로 메뉴 항목 동적 필터링
- **DashboardLayout**: 게스트 사용자일 경우 사이드바 숨김
- **App.tsx**: 
  - `MemberRoute`: 게스트 접근 차단 (→ `/permission/request`)
  - `DomainProtectedRoute`: 도메인별 권한 체크 (→ `/permission/request`)

## Test Plan
- [ ] 게스트 로그인 시 사이드 메뉴 숨김 확인
- [ ] 게스트가 `/dashboard/compliance` URL 직접 접근 시 리다이렉트 확인
- [ ] ESG만 소속된 사용자가 안전보건 메뉴 비노출 확인
- [ ] 다중 도메인 사용자가 소속된 도메인 메뉴만 표시 확인

Closes #116