### PR TITLE
feat: #113 헤더에 도메인별 역할 표시

### DIFF
--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import svgPaths from '../../imports/svg-h10djjhihc';
 import { useLogout } from '../../src/hooks/useAuth';
 import { useNotifications, useUnreadCount, useMarkAsRead } from '../../src/hooks/useNotifications';
+import { useAuthStore } from '../../src/store/authStore';
 
 interface HeaderProps {
   userName: string;
@@ -14,6 +15,12 @@ const roleLabels = {
   drafter: '기안자',
   approver: '결재자',
   guest: '게스트',
+};
+
+const domainShortLabels: Record<string, string> = {
+  ESG: 'ESG',
+  SAFETY: '안전',
+  COMPLIANCE: '컴플',
 };
 
 function formatShortTime(dateStr: string): string {
@@ -111,6 +118,8 @@ export default function Header({ userName, userRole }: HeaderProps) {
   const { data: unreadCount } = useUnreadCount();
   const [showDropdown, setShowDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { user } = useAuthStore();
+  const domainRoles = user?.domainRoles || [];
 
   const handleLogout = () => {
     logoutMutation.mutate();
@@ -156,11 +165,26 @@ export default function Header({ userName, userRole }: HeaderProps) {
           <p className="font-body-medium text-white">
             {userName}
           </p>
-          <div className="bg-[#f0fdf4] flex items-center justify-center px-[8px] py-[4px] rounded-[6px] border border-[#008233]">
-            <p className="font-title-small text-[#008233]">
-              {roleLabels[userRole]}
-            </p>
-          </div>
+          {domainRoles.length > 0 ? (
+            <div className="flex items-center gap-[4px]">
+              {domainRoles.map((dr) => (
+                <div
+                  key={dr.domainCode}
+                  className="bg-[#f0fdf4] flex items-center justify-center px-[8px] py-[4px] rounded-[6px] border border-[#008233]"
+                >
+                  <p className="font-title-small text-[#008233]">
+                    {domainShortLabels[dr.domainCode] || dr.domainName}-{dr.roleName}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="bg-[#f0fdf4] flex items-center justify-center px-[8px] py-[4px] rounded-[6px] border border-[#008233]">
+              <p className="font-title-small text-[#008233]">
+                {roleLabels[userRole]}
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Notification Icon with Badge */}


### PR DESCRIPTION
## Summary
- 헤더에 사용자의 도메인별 역할을 "도메인-역할" 형태로 표시
- 여러 도메인 소속 시 모든 도메인-역할 배지 표시
- domainRoles가 없으면 기존 역할만 표시 (하위 호환)

## Changes
- `Header.tsx`: domainRoles 기반 역할 배지 렌더링

## 표시 예시
| 조건 | 표시 |
|-----|------|
| ESG 기안자 | `ESG-기안자` |
| 안전보건 결재자 | `안전-결재자` |
| 다중 도메인 | `ESG-기안자` `안전-결재자` |

## Test plan
- [ ] 단일 도메인 사용자 로그인 시 "도메인-역할" 형태로 표시 확인
- [ ] 다중 도메인 사용자 로그인 시 모든 도메인-역할 표시 확인
- [ ] domainRoles 없는 사용자는 기존 역할만 표시 확인

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)