### PR TITLE
fix: #118 로그인 후 PENDING 게스트 라우팅 처리

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import * as authApi from '../api/auth';
+import { getMyRoleRequests } from '../api/roles';
 import { useAuthStore } from '../store/authStore';
 import type { AuthUser } from '../store/authStore';
 import { QUERY_KEYS } from '../constants/queryKeys';
@@ -14,10 +15,19 @@ export const useLogin = () => {
 
   return useMutation({
     mutationFn: authApi.login,
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       const user = data.user;
       toast.success(`${user.name}님, 환영합니다.`);
       if (!user.role || user.role.code === 'GUEST') {
+        try {
+          const myRequest = await getMyRoleRequests();
+          if (myRequest && myRequest.status === 'PENDING') {
+            navigate('/permission/status');
+            return;
+          }
+        } catch {
+          // 요청 조회 실패 시 기본 권한 요청 페이지로 이동
+        }
         navigate('/permission/request');
       } else {
         navigate('/dashboard');


### PR DESCRIPTION
## Summary
- GUEST 로그인 시 기존 권한 요청 상태를 조회하여 PENDING이면 `/permission/status`로 자동 리다이렉트
- 기존: 모든 GUEST → `/permission/request`
- 변경: PENDING 요청 있는 GUEST → `/permission/status`, 없으면 `/permission/request`

## Test plan
- [ ] 신규 GUEST 로그인 → `/permission/request` 이동 확인
- [ ] PENDING 요청이 있는 GUEST 로그인 → `/permission/status` 이동 확인
- [ ] 승인된 사용자 로그인 → `/dashboard` 이동 확인
- [ ] API 조회 실패 시 `/permission/request`로 fallback 확인

Closes #118