### PR TITLE
feat: #141 AI Jobs 공통 API 및 React Query 훅 추가

### DIFF
--- a/src/api/aiJobs.ts
+++ b/src/api/aiJobs.ts
@@ -1,0 +1,23 @@
+import { apiClient } from './client';
+import type { BaseResponse } from '../types/api.types';
+
+export type JobStatus = 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
+
+export interface JobDetail {
+  jobId: string;
+  status: JobStatus;
+  result?: unknown;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const getJobStatus = async (jobId: string): Promise<JobDetail> => {
+  const response = await apiClient.get<BaseResponse<JobDetail>>(`/v1/jobs/${jobId}`);
+  return response.data.data;
+};
+
+export const retryJob = async (jobId: string): Promise<JobDetail> => {
+  const response = await apiClient.post<BaseResponse<JobDetail>>(`/v1/jobs/${jobId}/retry`);
+  return response.data.data;
+};

--- a/src/hooks/useAiJobs.ts
+++ b/src/hooks/useAiJobs.ts
@@ -1,0 +1,37 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import { toast } from 'sonner';
+import * as aiJobsApi from '../api/aiJobs';
+import type { JobDetail } from '../api/aiJobs';
+import { QUERY_KEYS } from '../constants/queryKeys';
+
+export const useJobStatus = (jobId: string | null) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.JOBS.STATUS(jobId ?? ''),
+    queryFn: () => aiJobsApi.getJobStatus(jobId!),
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status === 'SUCCEEDED' || status === 'FAILED') {
+        return false;
+      }
+      return 5000;
+    },
+  });
+};
+
+export const useRetryJob = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (jobId: string) => aiJobsApi.retryJob(jobId),
+    onSuccess: (_data: JobDetail, jobId: string) => {
+      toast.success('작업 재시도가 요청되었습니다.');
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.JOBS.STATUS(jobId) });
+    },
+    onError: (error: AxiosError) => {
+      toast.error('작업 재시도에 실패했습니다.');
+      console.error('Job retry failed:', error);
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- `src/api/aiJobs.ts`: Job 상태 조회(`GET /v1/jobs/{jobId}`) 및 재시도(`POST /v1/jobs/{jobId}/retry`) API 함수 추가
- `src/hooks/useAiJobs.ts`: `useJobStatus` (5초 폴링, SUCCEEDED/FAILED 시 중단) 및 `useRetryJob` React Query 훅 추가

Closes #141