### PR TITLE
feat: #148 AI 분석 결과 표시 UI 컴포넌트 구현

### DIFF
--- a/shared/components/ai/AiHistoryTimeline.tsx
+++ b/shared/components/ai/AiHistoryTimeline.tsx
@@ -1,0 +1,125 @@
+import type { AiHistoryEntry, Verdict, RiskLevel } from './types';
+
+interface AiHistoryTimelineProps {
+  history: AiHistoryEntry[];
+  onSelect?: (entry: AiHistoryEntry) => void;
+  selectedId?: string;
+}
+
+const verdictConfig: Record<Verdict, { label: string; dotColor: string; textColor: string }> = {
+  PASS: {
+    label: '통과',
+    dotColor: 'bg-[var(--color-state-success-icon)]',
+    textColor: 'text-[var(--color-state-success-text)]',
+  },
+  WARN: {
+    label: '주의',
+    dotColor: 'bg-[var(--color-state-warning-icon)]',
+    textColor: 'text-[var(--color-state-warning-text)]',
+  },
+  NEED_CLARIFY: {
+    label: '보완 필요',
+    dotColor: 'bg-[var(--color-state-warning-icon)]',
+    textColor: 'text-[var(--color-state-warning-text)]',
+  },
+  NEED_FIX: {
+    label: '수정 필요',
+    dotColor: 'bg-[var(--color-state-error-icon)]',
+    textColor: 'text-[var(--color-state-error-text)]',
+  },
+};
+
+const riskConfig: Record<RiskLevel, { label: string; colorClass: string }> = {
+  LOW: {
+    label: '낮음',
+    colorClass: 'bg-[var(--color-risk-low-bg)] text-[var(--color-risk-low-text)]',
+  },
+  MEDIUM: {
+    label: '보통',
+    colorClass: 'bg-[var(--color-risk-medium-bg)] text-[var(--color-risk-medium-text)]',
+  },
+  HIGH: {
+    label: '높음',
+    colorClass: 'bg-[var(--color-risk-high-bg)] text-[var(--color-risk-high-text)]',
+  },
+};
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function AiHistoryTimeline({ history, onSelect, selectedId }: AiHistoryTimelineProps) {
+  if (history.length === 0) {
+    return (
+      <div className="text-center py-[24px] text-[var(--color-text-secondary)] font-body-medium">
+        분석 이력이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-[12px]">
+      <h3 className="font-title-small text-[var(--color-text-primary)]">AI 분석 이력</h3>
+      <div className="relative">
+        <div className="absolute left-[11px] top-[24px] bottom-[24px] w-[2px] bg-[var(--color-border-default)]" />
+        <div className="flex flex-col gap-[4px]">
+          {history.map((entry, index) => {
+            const vConfig = verdictConfig[entry.verdict];
+            const rConfig = riskConfig[entry.riskLevel];
+            const isSelected = selectedId === entry.id;
+            const isLatest = index === 0;
+
+            return (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => onSelect?.(entry)}
+                className={`relative flex items-start gap-[16px] p-[12px] rounded-[var(--radius-small)] text-left transition-colors ${
+                  isSelected
+                    ? 'bg-[var(--color-surface-primary)] border border-[var(--color-primary-border)]'
+                    : 'hover:bg-[var(--color-page-bg)] border border-transparent'
+                }`}
+              >
+                <div
+                  className={`relative z-10 w-[24px] h-[24px] rounded-full flex items-center justify-center ${vConfig.dotColor}`}
+                >
+                  <div className="w-[12px] h-[12px] rounded-full bg-[var(--color-surface-default)]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-[8px] mb-[4px]">
+                    <span className={`font-label-medium ${vConfig.textColor}`}>
+                      {vConfig.label}
+                    </span>
+                    <span
+                      className={`inline-flex items-center px-[6px] py-[2px] rounded-[var(--radius-badge)] font-label-xsmall ${rConfig.colorClass}`}
+                    >
+                      {rConfig.label}
+                    </span>
+                    {isLatest && (
+                      <span className="inline-flex items-center px-[6px] py-[2px] rounded-[var(--radius-badge)] bg-[var(--color-primary-light)] text-[var(--color-primary-text)] font-label-xsmall">
+                        최신
+                      </span>
+                    )}
+                  </div>
+                  <p className="font-body-small text-[var(--color-text-tertiary)] truncate">
+                    {entry.whySummary}
+                  </p>
+                  <span className="font-detail-small text-[var(--color-text-secondary)]">
+                    {formatDate(entry.analyzedAt)}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/shared/components/ai/AiResultSummary.tsx
+++ b/shared/components/ai/AiResultSummary.tsx
@@ -1,0 +1,80 @@
+import type { Verdict, RiskLevel } from './types';
+
+interface AiResultSummaryProps {
+  verdict: Verdict;
+  riskLevel: RiskLevel;
+  whySummary: string;
+}
+
+const verdictConfig: Record<Verdict, { label: string; colorClass: string; icon: string }> = {
+  PASS: {
+    label: '통과',
+    colorClass: 'bg-[var(--color-state-success-bg)] text-[var(--color-state-success-text)] border-[var(--color-state-success-border)]',
+    icon: '✓',
+  },
+  WARN: {
+    label: '주의',
+    colorClass: 'bg-[var(--color-state-warning-bg)] text-[var(--color-state-warning-text)] border-[var(--color-state-warning-border)]',
+    icon: '!',
+  },
+  NEED_CLARIFY: {
+    label: '보완 필요',
+    colorClass: 'bg-[var(--color-state-warning-bg)] text-[var(--color-state-warning-text)] border-[var(--color-state-warning-border)]',
+    icon: '?',
+  },
+  NEED_FIX: {
+    label: '수정 필요',
+    colorClass: 'bg-[var(--color-state-error-bg)] text-[var(--color-state-error-text)] border-[var(--color-state-error-border)]',
+    icon: '✕',
+  },
+};
+
+const riskConfig: Record<RiskLevel, { label: string; colorClass: string }> = {
+  LOW: {
+    label: '낮음',
+    colorClass: 'bg-[var(--color-risk-low-bg)] text-[var(--color-risk-low-text)]',
+  },
+  MEDIUM: {
+    label: '보통',
+    colorClass: 'bg-[var(--color-risk-medium-bg)] text-[var(--color-risk-medium-text)]',
+  },
+  HIGH: {
+    label: '높음',
+    colorClass: 'bg-[var(--color-risk-high-bg)] text-[var(--color-risk-high-text)]',
+  },
+};
+
+export function AiResultSummary({ verdict, riskLevel, whySummary }: AiResultSummaryProps) {
+  const vConfig = verdictConfig[verdict];
+  const rConfig = riskConfig[riskLevel];
+
+  return (
+    <div className="rounded-[var(--radius-small)] border border-[var(--color-border-default)] bg-[var(--color-surface-default)] p-[24px]">
+      <div className="flex items-center gap-[16px] mb-[16px]">
+        <div
+          className={`flex items-center justify-center w-[40px] h-[40px] rounded-full border ${vConfig.colorClass}`}
+        >
+          <span className="font-label-large">{vConfig.icon}</span>
+        </div>
+        <div className="flex flex-col gap-[4px]">
+          <span className="font-title-medium text-[var(--color-text-primary)]">
+            AI 분석 결과
+          </span>
+          <div className="flex items-center gap-[8px]">
+            <span
+              className={`inline-flex items-center px-[12px] py-[4px] rounded-[var(--radius-badge)] border font-label-medium ${vConfig.colorClass}`}
+            >
+              {vConfig.label}
+            </span>
+            <span
+              className={`inline-flex items-center px-[12px] py-[4px] rounded-[var(--radius-badge)] font-label-medium ${rConfig.colorClass}`}
+            >
+              위험도: {rConfig.label}
+            </span>
+          </div>
+        </div>
+      </div>
+      <p className="font-body-medium text-[var(--color-text-tertiary)]">{whySummary}</p>
+    </div>
+  );
+}

--- a/shared/components/ai/ClarificationList.tsx
+++ b/shared/components/ai/ClarificationList.tsx
@@ -1,0 +1,61 @@
+import type { Clarification } from './types';
+
+interface ClarificationListProps {
+  clarifications: Clarification[];
+  onReupload?: (slotName: string, fileIds: string[]) => void;
+}
+
+export function ClarificationList({ clarifications, onReupload }: ClarificationListProps) {
+  if (clarifications.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-[12px]">
+      <h3 className="font-title-small text-[var(--color-text-primary)]">보완 요청 사항</h3>
+      <div className="flex flex-col gap-[8px]">
+        {clarifications.map((item, index) => (
+          <div
+            key={`${item.slotName}-${index}`}
+            className="rounded-[var(--radius-small)] border border-[var(--color-state-warning-border)] bg-[var(--color-state-warning-bg)] p-[16px]"
+          >
+            <div className="flex items-start justify-between gap-[16px]">
+              <div className="flex-1">
+                <div className="flex items-center gap-[8px] mb-[8px]">
+                  <span className="font-label-large text-[var(--color-state-warning-icon)]">?</span>
+                  <span className="font-title-small text-[var(--color-state-warning-text)]">
+                    {item.slotName}
+                  </span>
+                </div>
+                <p className="font-body-small text-[var(--color-state-warning-text)]">
+                  {item.message}
+                </p>
+              </div>
+              {item.fileIds.length > 0 && onReupload && (
+                <button
+                  type="button"
+                  onClick={() => onReupload(item.slotName, item.fileIds)}
+                  className="flex items-center gap-[4px] px-[12px] py-[8px] rounded-[var(--radius-small)] bg-[var(--color-surface-default)] border border-[var(--color-state-warning-border)] font-label-small text-[var(--color-state-warning-text)] hover:bg-[var(--color-state-warning-border)] transition-colors whitespace-nowrap"
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  파일 재업로드
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/shared/components/ai/SlotResultList.tsx
+++ b/shared/components/ai/SlotResultList.tsx
@@ -1,0 +1,96 @@
+import type { SlotResult, Verdict } from './types';
+
+interface SlotResultListProps {
+  slotResults: SlotResult[];
+  onFileClick?: (fileId: string) => void;
+}
+
+const verdictConfig: Record<Verdict, { label: string; colorClass: string; icon: string }> = {
+  PASS: {
+    label: '통과',
+    colorClass: 'bg-[var(--color-state-success-bg)] text-[var(--color-state-success-text)] border-[var(--color-state-success-border)]',
+    icon: '✓',
+  },
+  WARN: {
+    label: '주의',
+    colorClass: 'bg-[var(--color-state-warning-bg)] text-[var(--color-state-warning-text)] border-[var(--color-state-warning-border)]',
+    icon: '!',
+  },
+  NEED_CLARIFY: {
+    label: '보완 필요',
+    colorClass: 'bg-[var(--color-state-warning-bg)] text-[var(--color-state-warning-text)] border-[var(--color-state-warning-border)]',
+    icon: '?',
+  },
+  NEED_FIX: {
+    label: '수정 필요',
+    colorClass: 'bg-[var(--color-state-error-bg)] text-[var(--color-state-error-text)] border-[var(--color-state-error-border)]',
+    icon: '✕',
+  },
+};
+
+export function SlotResultList({ slotResults, onFileClick }: SlotResultListProps) {
+  if (slotResults.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-[12px]">
+      <h3 className="font-title-small text-[var(--color-text-primary)]">슬롯별 검증 결과</h3>
+      <div className="flex flex-col gap-[8px]">
+        {slotResults.map((slot, index) => {
+          const vConfig = verdictConfig[slot.verdict];
+          return (
+            <div
+              key={`${slot.slotName}-${index}`}
+              className={`rounded-[var(--radius-small)] border p-[16px] ${vConfig.colorClass}`}
+            >
+              <div className="flex items-center justify-between mb-[8px]">
+                <div className="flex items-center gap-[8px]">
+                  <span className="font-label-large">{vConfig.icon}</span>
+                  <span className="font-title-small">{slot.slotName}</span>
+                </div>
+                <span
+                  className={`inline-flex items-center px-[8px] py-[2px] rounded-[var(--radius-badge)] font-label-small border ${vConfig.colorClass}`}
+                >
+                  {vConfig.label}
+                </span>
+              </div>
+              {slot.reasons.length > 0 && (
+                <ul className="list-disc list-inside mb-[8px] font-body-small">
+                  {slot.reasons.map((reason, idx) => (
+                    <li key={idx}>{reason}</li>
+                  ))}
+                </ul>
+              )}
+              {slot.fileNames.length > 0 && (
+                <div className="flex flex-wrap gap-[8px]">
+                  {slot.fileNames.map((fileName, idx) => (
+                    <button
+                      key={slot.fileIds[idx]}
+                      type="button"
+                      onClick={() => onFileClick?.(slot.fileIds[idx])}
+                      className="inline-flex items-center gap-[4px] px-[8px] py-[4px] rounded-[var(--radius-small)] bg-[var(--color-surface-default)] border border-[var(--color-border-default)] font-label-small text-[var(--color-text-tertiary)] hover:border-[var(--color-primary-border)] transition-colors"
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                        <polyline points="14 2 14 8 20 8" />
+                      </svg>
+                      {fileName}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/shared/components/ai/index.ts
+++ b/shared/components/ai/index.ts
@@ -1,0 +1,12 @@
+export { AiResultSummary } from './AiResultSummary';
+export { SlotResultList } from './SlotResultList';
+export { ClarificationList } from './ClarificationList';
+export { AiHistoryTimeline } from './AiHistoryTimeline';
+export type {
+  Verdict,
+  RiskLevel,
+  SlotResult,
+  Clarification,
+  AiAnalysisResult,
+  AiHistoryEntry,
+} from './types';

--- a/shared/components/ai/types.ts
+++ b/shared/components/ai/types.ts
@@ -1,0 +1,34 @@
+export type Verdict = 'PASS' | 'WARN' | 'NEED_CLARIFY' | 'NEED_FIX';
+
+export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export interface SlotResult {
+  slotName: string;
+  verdict: Verdict;
+  reasons: string[];
+  fileIds: string[];
+  fileNames: string[];
+}
+
+export interface Clarification {
+  slotName: string;
+  message: string;
+  fileIds: string[];
+}
+
+export interface AiAnalysisResult {
+  verdict: Verdict;
+  riskLevel: RiskLevel;
+  whySummary: string;
+  slotResults: SlotResult[];
+  clarifications: Clarification[];
+  analyzedAt: string;
+}
+
+export interface AiHistoryEntry {
+  id: string;
+  verdict: Verdict;
+  riskLevel: RiskLevel;
+  whySummary: string;
+  analyzedAt: string;
+}


### PR DESCRIPTION
## Summary
- AI 분석 결과를 시각적으로 표시하는 공통 UI 컴포넌트 구현
- 디자인 토큰 기반 색상 시스템 적용 (verdict/riskLevel별 색상)
- 파일 클릭 및 재업로드 콜백 지원

## 구현 컴포넌트
- `AiResultSummary`: 전체 verdict 및 riskLevel 뱃지 표시
- `SlotResultList`: 슬롯별 검증 결과 목록 (PASS/WARN/NEED_CLARIFY/NEED_FIX)
- `ClarificationList`: 보완 요청 사항 목록 (재업로드 버튼)
- `AiHistoryTimeline`: AI 분석 이력 타임라인 (시간순 표시)

## 색상 매핑
| verdict/riskLevel | 색상 |
|---|---|
| PASS / LOW | 초록 (success) |
| WARN / NEED_CLARIFY / MEDIUM | 노랑 (warning) |
| NEED_FIX / HIGH | 빨강 (error) |

Closes #148