### PR TITLE
fix: #150 @shared alias import 경로 수정

### DIFF
--- a/src/shared/components/ai/AiJobErrorHandler.tsx
+++ b/src/shared/components/ai/AiJobErrorHandler.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shared/utils/cn';
+import { cn } from '../../utils/cn';
 import { useRetryJob } from '../../../hooks/useAiJobs';
 
 interface AiJobErrorHandlerProps {

--- a/src/shared/components/ai/AiJobProgress.tsx
+++ b/src/shared/components/ai/AiJobProgress.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@shared/utils/cn';
+import { cn } from '../../utils/cn';
 import type { JobStatus } from '../../../api/aiJobs';
 
 interface AiJobProgressProps {


### PR DESCRIPTION
## Summary
- `src/shared/components/ai/AiJobProgress.tsx`, `AiJobErrorHandler.tsx`에서 `@shared/utils/cn` alias를 상대 경로 `../../utils/cn`으로 수정
- vite에 `@shared` path alias가 설정되어 있지 않아 dev 서버 실행 시 resolve 실패하던 문제 해결

Closes #150