### PR TITLE
fix: 새 기안 상세 페이지 undefined 에러 수정

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -311,7 +311,7 @@ export default function DiagnosticDetailPage() {
             <div className="flex items-center justify-center py-[32px]">
               <div className="w-[24px] h-[24px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
             </div>
-          ) : previewData ? (
+          ) : previewData?.requiredSlotStatus ? (
             <div className="mb-[20px]">
               <div className="flex items-center justify-between mb-[8px]">
                 <span className="font-body-medium text-[var(--color-text-secondary)]">필수 항목</span>


### PR DESCRIPTION
## Summary
- 새로 생성된 기안 상세 페이지에서 `requiredSlotStatus` undefined 에러 수정
- `previewData?.requiredSlotStatus`로 optional chaining 추가

## Problem
새 기안 생성 후 대시보드에서 기안을 클릭하면 빈 화면이 표시되고 다음 에러 발생:
```
Cannot read properties of undefined (reading 'filter')
```

## Solution
`previewData.requiredSlotStatus`에 접근하기 전에 optional chaining으로 undefined 체크 추가

## Test plan
- [ ] 새 기안 생성 후 상세 페이지 접근 시 정상 표시 확인
- [ ] 기존 기안 상세 페이지 정상 동작 확인