### PR TITLE
fix: #181 회원가입 페이지 반응형 레이아웃 및 온보딩 헤더 반응형

### DIFF
--- a/features/auth/SignupStep1Page.tsx
+++ b/features/auth/SignupStep1Page.tsx
@@ -19,14 +19,14 @@ export default function SignupStep1Page() {
   };
 
   return (
-    <div className="bg-[var(--color-page-bg)] min-h-screen w-full flex items-center justify-center p-4 lg:p-[70px]">
-      <div className="w-full max-w-[1776px] shadow-[var(--shadow-card)]">
-        <div className="bg-white rounded-[var(--radius-card)] w-full">
+    <div className="bg-[var(--color-page-bg)] h-screen w-full flex items-center justify-center p-4 lg:p-[70px] overflow-hidden">
+      <div className="w-full max-w-[1776px] max-h-full shadow-[var(--shadow-card)]">
+        <div className="bg-white rounded-[var(--radius-card)] w-full max-h-[calc(100vh-32px)] lg:max-h-[calc(100vh-140px)] overflow-y-auto">
           <div className="overflow-clip rounded-[inherit] size-full">
-            <div className="flex items-start p-[24px] relative w-full">
+            <div className="flex items-start p-3 lg:p-[24px] relative w-full">
               <div className="flex-1 min-h-px min-w-px rounded-[var(--radius-card)]">
                 <div className="overflow-clip rounded-[inherit] size-full">
-                  <div className="flex flex-col gap-[24px] items-start p-[24px] relative w-full">
+                  <div className="flex flex-col gap-3 lg:gap-[24px] items-start p-3 lg:p-[24px] relative w-full">
                     {/* Logo */}
                     <div className="flex items-center py-[24px] shrink-0 w-full">
                       <Logo size="small" />
@@ -72,7 +72,7 @@ export default function SignupStep1Page() {
                       <p className="font-title-medium leading-[1.4] text-[var(--color-text-primary)] w-full">
                         [필수] 개인정보수집 및 이용
                       </p>
-                      <div className="bg-white relative rounded-[24px] shrink-0 w-full max-h-[200px] overflow-y-auto">
+                      <div className="bg-white relative rounded-[24px] shrink-0 w-full max-h-[120px] lg:max-h-[200px] overflow-y-auto">
                         <div className="overflow-clip rounded-[inherit] size-full">
                           <div className="flex flex-col gap-[12px] items-start p-[24px] text-[var(--color-text-primary)] w-full">
                             <p className="font-title-medium leading-[1.4]">약관동의 및 개인정보수집이용동의</p>

--- a/features/auth/SignupStep2Page.tsx
+++ b/features/auth/SignupStep2Page.tsx
@@ -148,16 +148,16 @@ export default function SignupStep2Page() {
   const isVerificationLoading = checkEmailMutation.isPending || sendVerificationMutation.isPending;
 
   return (
-    <div className="bg-[var(--color-page-bg)] min-h-screen w-full flex items-center justify-center p-4 lg:p-[70px]">
-      <div className="w-full max-w-[1776px] shadow-[var(--shadow-card)]">
-        <div className="bg-white rounded-[var(--radius-card)] w-full">
+    <div className="bg-[var(--color-page-bg)] h-screen w-full flex items-center justify-center p-4 lg:p-[70px] overflow-hidden">
+      <div className="w-full max-w-[1776px] max-h-full shadow-[var(--shadow-card)]">
+        <div className="bg-white rounded-[var(--radius-card)] w-full max-h-[calc(100vh-32px)] lg:max-h-[calc(100vh-140px)] overflow-y-auto">
           <div className="flex flex-col items-end justify-end overflow-clip rounded-[inherit] size-full">
-            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col items-end justify-end p-[24px] relative size-full">
+            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col items-end justify-end p-3 lg:p-[24px] relative size-full">
               {/* Main Content */}
               <div className="flex-1 min-h-px min-w-px rounded-[var(--radius-card)] w-full">
                 <div className="overflow-clip rounded-[inherit] size-full">
-                  <div className="flex flex-col items-start p-[24px] size-full">
-                    <div className="flex flex-col gap-[24px] items-start shrink-0 w-full">
+                  <div className="flex flex-col items-start p-3 lg:p-[24px] size-full">
+                    <div className="flex flex-col gap-3 lg:gap-[24px] items-start shrink-0 w-full">
                       {/* Logo */}
                       <div className="flex items-center py-[24px] shrink-0 w-full">
                         <Logo size="small" />
@@ -174,7 +174,7 @@ export default function SignupStep2Page() {
 
                       {/* Form */}
                       <div className="flex flex-col items-center justify-center shrink-0 w-full">
-                        <div className="flex flex-col gap-[24px] items-center justify-center shrink-0 w-full max-w-[480px]">
+                        <div className="flex flex-col gap-3 lg:gap-[24px] items-center justify-center shrink-0 w-full max-w-[480px]">
                           {/* Name */}
                           <div className="w-full">
                             <Input

--- a/features/onboarding/OnboardingPage.tsx
+++ b/features/onboarding/OnboardingPage.tsx
@@ -33,19 +33,19 @@ export default function OnboardingPage() {
   return (
     <div className="ob-page">
       {/* Header */}
-      <header className="absolute top-0 left-0 right-0 z-20 py-6">
-        <div className="container mx-auto px-6 flex justify-between items-center">
+      <header className="absolute top-0 left-0 right-0 z-20 py-3 md:py-6">
+        <div className="container mx-auto px-4 md:px-6 flex justify-between items-center">
           <div
-            className="text-white font-bold text-4xl cursor-pointer"
+            className="text-white font-bold text-2xl md:text-4xl cursor-pointer"
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
           >
             SmartChain
           </div>
-          <div className="flex gap-4 items-center">
-            <button onClick={() => scrollTo('features')} className="ob-btn-secondary">
+          <div className="flex gap-2 md:gap-4 items-center">
+            <button onClick={() => scrollTo('features')} className="ob-btn-secondary ob-btn-header">
               더 알아보기
             </button>
-            <button onClick={() => navigate('/login')} className="ob-btn-primary">
+            <button onClick={() => navigate('/login')} className="ob-btn-primary ob-btn-header">
               시작하기
             </button>
           </div>

--- a/features/onboarding/onboarding.css
+++ b/features/onboarding/onboarding.css
@@ -328,8 +328,28 @@
   50% { opacity: 1; transform: scale(1.05); }
 }
 
+/* Header buttons - smaller on mobile */
+.ob-btn-header {
+  padding: 1rem 2rem;
+  font-size: 1.4rem;
+}
+
+@media (min-width: 769px) {
+  .ob-btn-header {
+    padding: 1.8rem 3.6rem;
+    font-size: 1.8rem;
+  }
+}
+
 @media (max-width: 768px) {
   .ob-section-title { font-size: 3.2rem; }
   .ob-section-subtitle { font-size: 1.6rem; }
   .ob-step-connector::after { display: none; }
+
+  .ob-btn-primary,
+  .ob-btn-secondary {
+    padding: 1.2rem 2.4rem;
+    font-size: 1.4rem;
+    border-radius: 12px;
+  }
 }


### PR DESCRIPTION
## Summary
- 회원가입 Step1/Step2 페이지를 뷰포트 안에 맞도록 반응형 레이아웃 적용 (스크롤 제거)
- 온보딩 헤더 버튼이 작은 화면에서 UI 겹침 방지를 위해 반응형 처리

## 변경 파일
- `features/auth/SignupStep1Page.tsx` — h-screen + 카드 내부 스크롤, padding/gap 반응형
- `features/auth/SignupStep2Page.tsx` — 동일 처리
- `features/onboarding/OnboardingPage.tsx` — 헤더 로고/버튼 반응형 사이즈
- `features/onboarding/onboarding.css` — 모바일 버튼 스타일 추가

## Test plan
- [ ] `/signup/step1`, `/signup/step2` 1920x1080 및 1366x768에서 스크롤 없이 표시 확인
- [ ] 온보딩 페이지 헤더 버튼이 작은 화면에서 겹치지 않는지 확인

Closes #181