### PR TITLE
feat: #182 회원가입 좌측 상단 뒤로가기 버튼 추가

### DIFF
--- a/features/auth/SignupStep1Page.tsx
+++ b/features/auth/SignupStep1Page.tsx
@@ -27,8 +27,18 @@ export default function SignupStep1Page() {
               <div className="flex-1 min-h-px min-w-px rounded-[var(--radius-card)]">
                 <div className="overflow-clip rounded-[inherit] size-full">
                   <div className="flex flex-col gap-3 lg:gap-[24px] items-start p-3 lg:p-[24px] relative w-full">
-                    {/* Logo */}
-                    <div className="flex items-center py-[24px] shrink-0 w-full">
+                    {/* Back Button + Logo */}
+                    <div className="flex items-center gap-[12px] py-[24px] shrink-0 w-full">
+                      <button
+                        type="button"
+                        onClick={() => navigate('/login')}
+                        className="flex items-center justify-center w-[40px] h-[40px] rounded-full hover:bg-[var(--color-surface-primary)] transition-colors"
+                        aria-label="뒤로가기"
+                      >
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-text-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M15 18l-6-6 6-6" />
+                        </svg>
+                      </button>
                       <Logo size="small" />
                     </div>
 

--- a/features/auth/SignupStep2Page.tsx
+++ b/features/auth/SignupStep2Page.tsx
@@ -158,8 +158,18 @@ export default function SignupStep2Page() {
                 <div className="overflow-clip rounded-[inherit] size-full">
                   <div className="flex flex-col items-start p-3 lg:p-[24px] size-full">
                     <div className="flex flex-col gap-3 lg:gap-[24px] items-start shrink-0 w-full">
-                      {/* Logo */}
-                      <div className="flex items-center py-[24px] shrink-0 w-full">
+                      {/* Back Button + Logo */}
+                      <div className="flex items-center gap-[12px] py-[24px] shrink-0 w-full">
+                        <button
+                          type="button"
+                          onClick={() => navigate('/signup/step1')}
+                          className="flex items-center justify-center w-[40px] h-[40px] rounded-full hover:bg-[var(--color-surface-primary)] transition-colors"
+                          aria-label="뒤로가기"
+                        >
+                          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-text-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M15 18l-6-6 6-6" />
+                          </svg>
+                        </button>
                         <Logo size="small" />
                       </div>
 


### PR DESCRIPTION
## Summary
- 회원가입 Step1/Step2 페이지 좌측 상단(로고 옆)에 뒤로가기 화살표 버튼 추가
- Step1: 클릭 시 로그인 페이지로 이동
- Step2: 클릭 시 Step1으로 이동

## Test plan
- [ ] `/signup/step1` 좌측 상단 뒤로가기 버튼 클릭 → `/login` 이동 확인
- [ ] `/signup/step2` 좌측 상단 뒤로가기 버튼 클릭 → `/signup/step1` 이동 확인

Closes #182