### PR TITLE
fix: #174 대시보드 탭에서 도메인 필터링 미적용 수정

### DIFF
--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -5,6 +5,7 @@ import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import { useApprovals } from '../../src/hooks/useApprovals';
 import { useReviewsDashboard, useReviews } from '../../src/hooks/useReviews';
 import { useNotifications, useMarkAsRead } from '../../src/hooks/useNotifications';
+import { useAuthStore } from '../../src/store/authStore';
 import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 
 interface HomePageProps {
@@ -221,7 +222,17 @@ function formatDate(dateString?: string): string {
 
 export default function HomePage({ userRole }: HomePageProps) {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<DomainCode>('SAFETY');
+  const { getAccessibleDomains } = useAuthStore();
+  const accessibleDomains = getAccessibleDomains();
+
+  // 사용자가 접근 가능한 도메인만 필터링
+  const filteredDomainTabs = useMemo(() => {
+    return domainTabs.filter((tab) => accessibleDomains.includes(tab.key));
+  }, [accessibleDomains]);
+
+  const [activeTab, setActiveTab] = useState<DomainCode>(
+    filteredDomainTabs[0]?.key || 'SAFETY'
+  );
 
   // API calls based on user role
   const diagnosticsQuery = useDiagnosticsList(
@@ -518,7 +529,7 @@ export default function HomePage({ userRole }: HomePageProps) {
 
             {/* Tabs */}
             <div className="flex gap-[8px] mb-[24px] border-b border-[#dee2e6] overflow-x-auto">
-              {domainTabs.map((tab) => (
+              {filteredDomainTabs.map((tab) => (
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}


### PR DESCRIPTION
## Summary
- 대시보드 탭에서 사용자가 속한 도메인만 표시되도록 필터링 적용
- 사이드메뉴와 동일한 `getAccessibleDomains()` 로직 재사용
- 초기 활성 탭을 필터링된 도메인 중 첫 번째 값으로 설정

## 변경사항
- `features/dashboard/HomePage.tsx`
  - `useAuthStore`에서 `getAccessibleDomains` import
  - `filteredDomainTabs`로 사용자 접근 가능 도메인만 필터링
  - 탭 렌더링 시 `filteredDomainTabs` 사용

Closes #174