### PR TITLE
feat: #175 캠페인 선택 시 기간 자동 설정

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -31,6 +31,8 @@ export default function DiagnosticCreatePage() {
   const {
     register,
     handleSubmit,
+    watch,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<DiagnosticCreateFormData>({
     resolver: zodResolver(diagnosticCreateSchema),
@@ -42,6 +44,28 @@ export default function DiagnosticCreatePage() {
       periodEndDate: '',
     },
   });
+
+  const selectedCampaignId = watch('campaignId');
+
+  useEffect(() => {
+    if (!selectedCampaignId || campaigns.length === 0) return;
+
+    const selectedCampaign = campaigns.find(
+      (c) => c.campaignId === selectedCampaignId
+    );
+    if (!selectedCampaign?.startDate || !selectedCampaign?.endDate) return;
+
+    const startDate = new Date(selectedCampaign.startDate);
+    const endDate = new Date(selectedCampaign.endDate);
+
+    const periodStart = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+    const periodEnd = new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0);
+
+    const formatDate = (d: Date) => d.toISOString().split('T')[0];
+
+    setValue('periodStartDate', formatDate(periodStart));
+    setValue('periodEndDate', formatDate(periodEnd));
+  }, [selectedCampaignId, campaigns, setValue]);
 
   const onSubmit = async (data: DiagnosticCreateFormData) => {
     createMutation.mutate(data, {


### PR DESCRIPTION
## 변경요약
- 기안 생성 시 캠페인 선택하면 기간(시작일/종료일)이 자동 설정됩니다
- 시작일: 캠페인 시작월의 1일
- 종료일: 캠페인 종료월의 말일

## 관련이슈
- Closes #175

## 테스트방법
1. 기안 생성 페이지(/diagnostics/create) 이동
2. 캠페인 선택
3. 시작일/종료일 필드가 캠페인 기간으로 자동 설정되는지 확인

## 명세준수 체크
- [x] 캠페인 선택 시 기간 자동 설정됨
- [x] 기간이 월의 1일~말일로 설정됨
- [ ] 캠페인 선택 시 도메인 자동 선택 ← **API에 domain 필드 없음**

## 리뷰포인트
- `useEffect`로 캠페인 선택 감지 후 `setValue`로 기간 필드 업데이트
- 날짜 계산 로직 (월의 1일/말일)

## TODO / 백엔드 요청
**도메인 자동 선택을 위해 Campaign API에 `domainCode` 필드 추가 필요**

현재 Campaign 응답:
```json
{
  "campaignId": 1,
  "campaignName": "...",
  "startDate": "2026-01-01",
  "endDate": "2026-12-31"
}
```

필요한 필드:
```json
{
  "campaignId": 1,
  "campaignName": "...",
  "domainCode": "ESG",  // ← 추가 필요
  "startDate": "2026-01-01",
  "endDate": "2026-12-31"
}
```