### PR TITLE
feat: #175 캠페인 선택 시 도메인 자동 선택

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -53,18 +53,26 @@ export default function DiagnosticCreatePage() {
     const selectedCampaign = campaigns.find(
       (c) => c.campaignId === selectedCampaignId
     );
-    if (!selectedCampaign?.startDate || !selectedCampaign?.endDate) return;
+    if (!selectedCampaign) return;
 
-    const startDate = new Date(selectedCampaign.startDate);
-    const endDate = new Date(selectedCampaign.endDate);
+    // 도메인 자동 설정
+    if (selectedCampaign.domainCode) {
+      setValue('domainCode', selectedCampaign.domainCode);
+    }
 
-    const periodStart = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
-    const periodEnd = new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0);
+    // 기간 자동 설정
+    if (selectedCampaign.startDate && selectedCampaign.endDate) {
+      const startDate = new Date(selectedCampaign.startDate);
+      const endDate = new Date(selectedCampaign.endDate);
 
-    const formatDate = (d: Date) => d.toISOString().split('T')[0];
+      const periodStart = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+      const periodEnd = new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0);
 
-    setValue('periodStartDate', formatDate(periodStart));
-    setValue('periodEndDate', formatDate(periodEnd));
+      const formatDate = (d: Date) => d.toISOString().split('T')[0];
+
+      setValue('periodStartDate', formatDate(periodStart));
+      setValue('periodEndDate', formatDate(periodEnd));
+    }
   }, [selectedCampaignId, campaigns, setValue]);
 
   const onSubmit = async (data: DiagnosticCreateFormData) => {

--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -4,6 +4,7 @@ import type { BaseResponse } from '../types/api.types';
 export interface Campaign {
   campaignId: number;
   campaignCode: string;
+  domainCode?: 'ESG' | 'SAFETY' | 'COMPLIANCE' | null;
   title: string;
   description?: string;
   startDate: string;


### PR DESCRIPTION
## 변경요약
- 캠페인 선택 시 도메인이 자동 선택됩니다
- Campaign 인터페이스에 `domainCode` 필드 추가 (백엔드 API 변경 반영)

## 관련이슈
- Closes #175

## 테스트방법
1. 기안 생성 페이지(/diagnostics/create) 이동
2. 캠페인 선택
3. 도메인 필드가 캠페인의 domainCode로 자동 설정되는지 확인
4. 기간(시작일/종료일)도 자동 설정되는지 확인

## 명세준수 체크
- [x] 캠페인 선택 시 도메인 자동 선택됨
- [x] 캠페인 선택 시 기간 자동 설정됨
- [x] 레거시 데이터(domainCode: null) 처리

## 리뷰포인트
- `domainCode`가 null인 경우 도메인 자동 설정 스킵 (레거시 데이터 대응)

## 변경 파일
- `src/api/campaigns.ts`: Campaign 인터페이스에 domainCode 필드 추가
- `features/diagnostics/DiagnosticCreatePage.tsx`: 도메인 자동 설정 로직 추가