### PR TITLE
fix: #184 동일 줄 텍스트 폰트 사이즈 불일치 수정

### DIFF
--- a/features/permission/PermissionRequestPage.tsx
+++ b/features/permission/PermissionRequestPage.tsx
@@ -243,7 +243,7 @@ export default function PermissionRequestPage() {
 
                 {/* Reason Input */}
                 <div className="flex flex-col gap-[12px]">
-                    <p className="font-title-medium text-[#212529]">요청 사유 <span className="font-body-small text-[#adb5bd]">(선택)</span></p>
+                    <p className="font-title-medium text-[#212529]">요청 사유 <span className="font-title-medium text-[#adb5bd]">(선택)</span></p>
                     <textarea
                         value={reason}
                         onChange={(e) => setReason(e.target.value)}

--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -68,7 +68,7 @@ function NotificationDropdown({ onClose }: { onClose: () => void }) {
         <span className="font-title-small text-[var(--color-text-primary)]">알림</span>
         <button
           onClick={handleViewAll}
-          className="font-detail-medium text-[var(--color-primary-main)] hover:underline"
+          className="font-title-small text-[var(--color-primary-main)] hover:underline"
         >
           전체보기
         </button>


### PR DESCRIPTION
## Summary
- 같은 줄에 있는 텍스트의 폰트 사이즈가 다른 케이스를 전체 탐색하여 수정
- PermissionRequestPage: "요청 사유 (선택)" 라벨에서 1.8rem + 1.4rem 혼용 → 1.8rem 통일
- Header 알림 드롭다운: "알림" 1.6rem + "전체보기" 1.4rem → 1.6rem 통일

## Test plan
- [ ] 권한요청 페이지에서 "요청 사유 (선택)" 텍스트가 동일 크기로 표시되는지 확인
- [ ] 알림 드롭다운 헤더에서 "알림"과 "전체보기"가 동일 크기로 표시되는지 확인

Closes #184