### PR TITLE
feat: #196 파싱 결과 API 응답 스펙 변경 대응 및 진단 파일 목록 조회 연동

### DIFF
--- a/features/diagnostics/DiagnosticAiAnalysisPage.tsx
+++ b/features/diagnostics/DiagnosticAiAnalysisPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useDiagnosticDetail } from '../../src/hooks/useDiagnostics';
+import { useDiagnosticFiles } from '../../src/hooks/useFiles';
 import {
   useAiPreview,
   useSubmitAiRun,
@@ -52,6 +53,7 @@ export default function DiagnosticAiAnalysisPage() {
   const diagnosticId = Number(id);
 
   const { data: diagnostic, isLoading: isDiagnosticLoading } = useDiagnosticDetail(diagnosticId);
+  const { data: files } = useDiagnosticFiles(diagnosticId);
   const previewMutation = useAiPreview();
   const submitMutation = useSubmitAiRun();
   const { data: aiResult, isLoading: isResultLoading, isError: isResultError } = useAiResult(diagnosticId);
@@ -60,12 +62,14 @@ export default function DiagnosticAiAnalysisPage() {
   const [showSubmitModal, setShowSubmitModal] = useState(false);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
 
-  // Trigger preview on mount
+  // Trigger preview with parsed files only
+  const parsedFileIds = files?.filter(f => f.parsingStatus === 'SUCCESS').map(f => f.fileId) || [];
+
   useEffect(() => {
-    if (diagnosticId > 0) {
-      previewMutation.mutate({ diagnosticId, fileIds: [] });
+    if (diagnosticId > 0 && parsedFileIds.length > 0) {
+      previewMutation.mutate({ diagnosticId, fileIds: parsedFileIds });
     }
-  }, [diagnosticId]);
+  }, [diagnosticId, parsedFileIds.length]);
 
   // Poll for result when analyzing
   useEffect(() => {
@@ -85,6 +89,7 @@ export default function DiagnosticAiAnalysisPage() {
   };
 
   const previewData = previewMutation.data;
+  const requiredSlotStatus = previewData?.requiredSlotStatus || [];
   const hasMissingRequiredSlots = previewData?.missingRequiredSlots && previewData.missingRequiredSlots.length > 0;
 
   if (isDiagnosticLoading) {
@@ -196,15 +201,15 @@ export default function DiagnosticAiAnalysisPage() {
                           제출 완료
                         </span>
                         <span className="font-title-small text-[var(--color-text-primary)]">
-                          {previewData.requiredSlotStatus.filter(s => s.submitted).length} / {previewData.requiredSlotStatus.length}
+                          {requiredSlotStatus.filter(s => s.submitted).length} / {requiredSlotStatus.length}
                         </span>
                       </div>
                       <div className="h-[8px] bg-gray-200 rounded-full overflow-hidden">
                         <div
                           className="h-full bg-[var(--color-primary-main)] transition-all"
                           style={{
-                            width: `${previewData.requiredSlotStatus.length > 0
-                              ? (previewData.requiredSlotStatus.filter(s => s.submitted).length / previewData.requiredSlotStatus.length) * 100
+                            width: `${requiredSlotStatus.length > 0
+                              ? (requiredSlotStatus.filter(s => s.submitted).length / requiredSlotStatus.length) * 100
                               : 0}%`
                           }}
                         />
@@ -213,7 +218,7 @@ export default function DiagnosticAiAnalysisPage() {
 
                     {/* 슬롯 목록 */}
                     <div className="space-y-[8px]">
-                      {previewData.requiredSlotStatus.map((slot: SlotStatus, index: number) => (
+                      {requiredSlotStatus.map((slot: SlotStatus, index: number) => (
                         <SlotItem key={index} slot={slot} />
                       ))}
                     </div>
@@ -345,18 +350,20 @@ export default function DiagnosticAiAnalysisPage() {
                 분석에는 시간이 걸릴 수 있으며, 완료되면 결과가 표시됩니다.
               </p>
 
-              {previewData && (
+              {files && files.length > 0 && (
                 <div className="mt-[16px] p-[12px] bg-gray-50 rounded-[8px]">
                   <p className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px]">
-                    분석 대상
+                    분석 대상 ({parsedFileIds.length}개 파일)
                   </p>
-                  <div className="flex items-center justify-between">
-                    <span className="font-body-medium text-[var(--color-text-primary)]">
-                      {DOMAIN_LABELS[domainCode]}
-                    </span>
-                    <span className="font-body-small text-[var(--color-text-tertiary)]">
-                      {previewData.requiredSlotStatus.filter(s => s.submitted).length}개 항목 준비됨
-                    </span>
+                  <div className="space-y-[6px] max-h-[200px] overflow-y-auto">
+                    {files.filter(f => f.parsingStatus === 'SUCCESS').map(f => (
+                      <div key={f.fileId} className="flex items-center gap-[8px] px-[8px] py-[6px] bg-white rounded-[6px]">
+                        <svg className="w-[16px] h-[16px] text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                        <span className="font-body-small text-[var(--color-text-primary)] truncate">{f.fileName}</span>
+                      </div>
+                    ))}
                   </div>
                 </div>
               )}

--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -593,6 +593,10 @@ function ParsingResultView({ diagnosticId, fileId }: { diagnosticId: number; fil
     );
   }
 
+  const metaInfo = parsingResult.metaInfo ? (() => {
+    try { return JSON.parse(parsingResult.metaInfo); } catch { return null; }
+  })() : null;
+
   return (
     <div className="space-y-[20px]">
       {/* 파일 정보 */}
@@ -601,47 +605,64 @@ function ParsingResultView({ diagnosticId, fileId }: { diagnosticId: number; fil
         <p className="font-body-medium text-[var(--color-text-primary)]">{parsingResult.fileName}</p>
       </div>
 
-      <div>
-        <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">파싱 완료</p>
-        <p className="font-body-medium text-[var(--color-text-primary)]">
-          {new Date(parsingResult.parsedAt).toLocaleString('ko-KR')}
-        </p>
+      <div className="flex items-center gap-[12px]">
+        <div>
+          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">상태</p>
+          <span className={`px-[8px] py-[2px] rounded text-xs font-medium ${
+            parsingResult.parsingStatus === 'SUCCESS'
+              ? 'bg-green-100 text-green-700'
+              : 'bg-red-100 text-red-700'
+          }`}>
+            {parsingResult.parsingStatus === 'SUCCESS' ? '성공' : parsingResult.parsingStatus}
+          </span>
+        </div>
+        <div>
+          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">파싱 완료</p>
+          <p className="font-body-medium text-[var(--color-text-primary)]">
+            {new Date(parsingResult.completedAt).toLocaleString('ko-KR')}
+          </p>
+        </div>
       </div>
 
-      {/* 슬롯 힌트 */}
-      {parsingResult.slotHints && parsingResult.slotHints.length > 0 && (
+      {/* 메타 정보 */}
+      {metaInfo && (
         <div>
-          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">감지된 항목</p>
+          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">분석 정보</p>
           <div className="space-y-[8px]">
-            {parsingResult.slotHints.map((hint, index) => (
-              <div
-                key={index}
-                className="flex items-center justify-between px-[12px] py-[8px] bg-gray-50 rounded-[8px]"
-              >
-                <span className="font-body-small text-[var(--color-text-primary)]">
-                  {hint.slotName}
-                </span>
-                <span className={`font-title-xsmall ${
-                  hint.confidence >= 0.8 ? 'text-green-600' :
-                  hint.confidence >= 0.5 ? 'text-yellow-600' : 'text-red-600'
-                }`}>
-                  {Math.round(hint.confidence * 100)}%
+            {metaInfo.slotHintCount != null && (
+              <div className="flex items-center justify-between px-[12px] py-[8px] bg-gray-50 rounded-[8px]">
+                <span className="font-body-small text-[var(--color-text-primary)]">감지된 슬롯</span>
+                <span className="font-title-xsmall text-[var(--color-text-primary)]">{metaInfo.slotHintCount}개</span>
+              </div>
+            )}
+            {metaInfo.missingRequiredSlots != null && (
+              <div className="flex items-center justify-between px-[12px] py-[8px] bg-gray-50 rounded-[8px]">
+                <span className="font-body-small text-[var(--color-text-primary)]">누락 필수 슬롯</span>
+                <span className={`font-title-xsmall ${metaInfo.missingRequiredSlots > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                  {metaInfo.missingRequiredSlots}개
                 </span>
               </div>
-            ))}
+            )}
           </div>
         </div>
       )}
 
-      {/* 추출된 텍스트 */}
-      {parsingResult.extractedText && (
+      {/* 파싱된 텍스트 */}
+      {parsingResult.parsedText && (
         <div>
-          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">추출된 내용</p>
+          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">파싱 결과</p>
           <div className="p-[12px] bg-gray-50 rounded-[8px] max-h-[200px] overflow-y-auto">
             <p className="font-body-small text-[var(--color-text-secondary)] whitespace-pre-wrap">
-              {parsingResult.extractedText}
+              {parsingResult.parsedText}
             </p>
           </div>
+        </div>
+      )}
+
+      {/* 에러 메시지 */}
+      {parsingResult.errorMessage && (
+        <div className="p-[12px] bg-red-50 rounded-[8px]">
+          <p className="font-body-small text-red-600">{parsingResult.errorMessage}</p>
         </div>
       )}
     </div>

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -20,9 +20,19 @@ export interface UploadFileResponse {
 export interface ParsingResultResponse {
   fileId: number;
   fileName: string;
-  parsedAt: string;
-  slotHints: Array<{ slotName: string; confidence: number }>;
-  extractedText?: string;
+  parsingStatus: string;
+  parsedValue: unknown | null;
+  parsedText: string | null;
+  metaInfo: string | null;
+  errorMessage: string | null;
+  completedAt: string;
+}
+
+export interface EvidenceFile {
+  fileId: number;
+  fileName: string;
+  fileSize: number;
+  parsingStatus: string;
 }
 
 export interface UploadOptions {
@@ -52,6 +62,13 @@ export const uploadFile = async (
         }
       },
     }
+  );
+  return response.data.data;
+};
+
+export const getDiagnosticFiles = async (diagnosticId: number): Promise<EvidenceFile[]> => {
+  const response = await apiClient.get<BaseResponse<EvidenceFile[]>>(
+    `/v1/diagnostics/${diagnosticId}/files`
   );
   return response.data.data;
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -40,6 +40,7 @@ export const QUERY_KEYS = {
     STATUS: (jobId: string) => ['jobs', 'status', jobId] as const,
   },
   FILES: {
+    LIST: (diagnosticId: number) => ['files', 'list', diagnosticId] as const,
     PARSING_RESULT: (diagnosticId: number, fileId: number) =>
       ['files', 'parsingResult', diagnosticId, fileId] as const,
   },

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -22,6 +22,14 @@ export const useUploadFile = () => {
   });
 };
 
+export const useDiagnosticFiles = (diagnosticId: number) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.FILES.LIST(diagnosticId),
+    queryFn: () => filesApi.getDiagnosticFiles(diagnosticId),
+    enabled: diagnosticId > 0,
+  });
+};
+
 export const useParsingResult = (diagnosticId: number, fileId: number) => {
   return useQuery({
     queryKey: QUERY_KEYS.FILES.PARSING_RESULT(diagnosticId, fileId),


### PR DESCRIPTION
## 변경 요약
- `ParsingResultResponse` 타입을 백엔드 스펙에 맞게 수정 (`parsedAt`→`completedAt`, `slotHints`→`metaInfo`, `extractedText`→`parsedText`)
- `EvidenceFile` 타입 및 `getDiagnosticFiles` API 함수 추가
- `useDiagnosticFiles` 훅, `FILES.LIST` 쿼리 키 추가
- DiagnosticFilesPage: `metaInfo` JSON 파싱, 상태 뱃지, 에러 메시지 표시
- DiagnosticAiAnalysisPage: 파싱 성공 파일만 필터링하여 AI 분석 프리뷰 전달, 분석 대상 파일 목록 UI 개선

## 관련 이슈
- Closes #196

## 테스트 방법
1. 기안 상세 → 파일 업로드 후 파싱 결과 확인 (성공/실패 상태 뱃지, metaInfo, 에러 메시지 표시)
2. AI 분석 페이지 진입 시 파싱 성공 파일만 프리뷰에 포함되는지 확인
3. 분석 실행 모달에서 분석 대상 파일 목록이 정상 표시되는지 확인

## 명세 준수 체크
- [x] `ParsingResultResponse` 필드가 백엔드 응답 스펙과 일치
- [x] `GET /v1/diagnostics/{id}/files` 엔드포인트 연동
- [x] 파싱 상태(`parsingStatus`)에 따른 분기 처리

## 리뷰 포인트
- `metaInfo`가 JSON 문자열로 내려오는 구조인데, 프론트에서 `JSON.parse` 처리가 적절한지
- `parsedFileIds.length`를 useEffect 의존성으로 사용한 부분 — 배열 내용 변경 시 정상 동작 여부

## TODO / 질문
- [ ] `metaInfo` 스키마가 확정되면 타입 정의 추가 필요
- [ ] 파싱 실패 파일에 대한 재시도 UX 필요 여부 논의