### PR TITLE
fix: #176 기안 생성 시 시작일/종료일 선택값 미반영 수정

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -57,7 +57,7 @@ export default function DiagnosticCreatePage() {
 
     // 도메인 자동 설정
     if (selectedCampaign.domainCode) {
-      setValue('domainCode', selectedCampaign.domainCode);
+      setValue('domainCode', selectedCampaign.domainCode, { shouldValidate: true, shouldDirty: true });
     }
 
     // 기간 자동 설정
@@ -70,8 +70,8 @@ export default function DiagnosticCreatePage() {
 
       const formatDate = (d: Date) => d.toISOString().split('T')[0];
 
-      setValue('periodStartDate', formatDate(periodStart));
-      setValue('periodEndDate', formatDate(periodEnd));
+      setValue('periodStartDate', formatDate(periodStart), { shouldValidate: true, shouldDirty: true });
+      setValue('periodEndDate', formatDate(periodEnd), { shouldValidate: true, shouldDirty: true });
     }
   }, [selectedCampaignId, campaigns, setValue]);
 


### PR DESCRIPTION
## 변경 요약
캠페인 선택 시 `react-hook-form`의 `setValue`로 자동 설정되는 날짜(periodStartDate, periodEndDate) 및 도메인(domainCode) 값에 `shouldValidate: true`, `shouldDirty: true` 옵션을 추가하여 폼 제출 시 값이 정상 반영되도록 수정.

### 원인
`react-hook-form`의 `setValue(field, value)`는 기본적으로 내부 폼 상태만 변경하고, validation 트리거와 dirty 플래그를 업데이트하지 않음. 이로 인해:
1. 캠페인 선택으로 자동 설정된 날짜가 폼 제출 시 validation에서 빈 문자열로 처리됨
2. `shouldDirty` 없이 설정된 값은 `formState.dirtyFields`에 반영되지 않아 일부 폼 라이브러리/미들웨어에서 무시될 수 있음

## 관련 이슈
Closes #176

## 테스트 방법
1. `/diagnostics/new` 페이지 접속
2. 캠페인을 선택하면 시작일/종료일이 자동 채워지는지 확인
3. 자동 채워진 상태에서 "기안 생성" 클릭 → API 요청 payload에 `periodStartDate`, `periodEndDate` 포함 확인
4. 날짜를 수동으로 변경 후 생성 → 변경된 날짜가 반영되는지 확인
5. 캠페인 미선택 상태에서 날짜를 직접 입력 후 생성 → 정상 동작 확인

## 명세 준수 체크
- [x] `periodStartDate`, `periodEndDate` 포맷: `YYYY-MM-DD` (기존 API 스펙 유지)
- [x] `DiagnosticCreateRequest` 인터페이스 변경 없음
- [x] Zod validation 스키마 변경 없음

## 리뷰 포인트
- `setValue`의 세 번째 인자 `{ shouldValidate: true, shouldDirty: true }` 추가만으로 해결
- 기존 컴포넌트 구조, API 인터페이스, validation 스키마 일체 변경 없음

## TODO / 질문
- 캠페인 API 응답에 `startDate`/`endDate`가 null인 경우 날짜 자동 설정이 스킵되는데, 이 케이스에 대한 UI 안내가 필요한지 확인 필요