### PR TITLE
infra: #199 Dockerfile 및 .dockerignore 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+dist
+.git
+.gitignore
+.vscode
+.idea
+.env
+.env.*
+*.md
+docker-compose*
+Dockerfile
+.dockerignore
+tests
+playwright-report
+test-results
+nul
+src/nul

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,33 @@
-# 1단계: 빌드 (Node.js 환경)
-FROM node:20-alpine AS build
+# 1단계: 빌드
+FROM node:22-alpine AS build
 WORKDIR /app
 
-# pnpm 설치
-RUN npm install -g pnpm
+COPY package.json package-lock.json ./
+RUN npm ci
 
-# 의존성 파일 복사 및 설치 (캐시 활용을 위해 먼저 복사)
-COPY pnpm-lock.yaml pnpm-workspace.yaml* package.json ./
-RUN pnpm install
-
-# 전체 소스 복사
 COPY . .
+RUN npm run build
 
-# [핵심 수정] 
-# 1. tsc(타입체크)를 건너뛰기 위해 pnpm run build 대신 vite build를 직접 호출합니다.
-# 2. --emptyOutDir를 추가하여 깔끔하게 빌드합니다.
-# 3. 파일 참조 에러가 있어도 빌드 프로세스가 멈추지 않도록 설정하거나, 팀원에게 수정을 요청해야 합니다.
-RUN pnpm exec vite build --emptyOutDir
-
-# 2단계: 실행 (Nginx 환경)
+# 2단계: 실행
 FROM nginx:stable-alpine
 
-# 빌드 결과물(dist)을 Nginx 웹 서버 경로로 복사
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# [중요] React Router(SPA) 새로고침 에러 방지 설정
-# 사용자가 페이지 내에서 새로고침했을 때 404가 뜨는 것을 방지합니다.
-RUN echo 'server { \
-    listen 80; \
-    location / { \
-        root /usr/share/nginx/html; \
-        index index.html index.htm; \
-        try_files $uri $uri/ /index.html; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+# SPA 라우팅 지원
+RUN printf 'server {\n\
+    listen 80;\n\
+    server_name _;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / {\n\
+        try_files $uri $uri/ /index.html;\n\
+    }\n\
+    location /api/ {\n\
+        proxy_pass http://backend:8080;\n\
+        proxy_set_header Host $host;\n\
+        proxy_set_header X-Real-IP $remote_addr;\n\
+    }\n\
+}\n' > /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## 변경 요약
- 기존 pnpm 기반 Dockerfile을 npm 기반으로 재작성 (프로젝트 실제 lockfile: package-lock.json)
- Node 22-alpine 멀티스테이지 빌드 → Nginx stable-alpine 서빙
- .dockerignore 신규 생성 (테스트/환경파일/IDE 설정 제외)

## 관련 이슈
Closes #199

## 테스트 방법
```bash
docker build -t smartchain-frontend .
docker run -p 3000:80 smartchain-frontend
# http://localhost:3000 접속 확인
```

## 명세 준수 체크
- [x] 멀티스테이지 빌드 (빌드 이미지 ≠ 런타임 이미지)
- [x] SPA try_files 설정
- [x] /api/ 리버스 프록시 설정
- [x] .dockerignore에 민감 파일(.env) 제외

## 리뷰 포인트
- nginx의 `proxy_pass http://backend:8080` — docker-compose 네트워크에서 backend 서비스명에 맞게 조정 필요
- `npm run build`는 내부적으로 `tsc && vite build` 실행

## TODO / 질문
- docker-compose.yml 필요 시 별도 이슈로 추가