### PR TITLE
fix: #178 파일 관리 버튼 비활성 상태 색상 수정

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -266,7 +266,7 @@ export default function DiagnosticDetailPage() {
         <div className="flex justify-end gap-[12px]">
           <button
             onClick={() => navigate(`/diagnostics/${diagnosticId}/files`)}
-            className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+            className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-primary-main)] font-title-small text-[var(--color-primary-main)] hover:bg-blue-50 transition-colors"
           >
             파일 관리
           </button>


### PR DESCRIPTION
## 변경 요약
- "파일 관리" 버튼이 회색(비활성처럼 보임)으로 표시되던 문제 수정
- 버튼 스타일을 "AI 분석 상세" 버튼과 동일하게 변경하여 클릭 가능한 상태임을 시각적으로 명확히 표현

## 관련 이슈
- Closes #178

## 변경 사항
| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| border | `border-[var(--color-border-default)]` | `border-[var(--color-primary-main)]` |
| text | `text-[var(--color-text-secondary)]` | `text-[var(--color-primary-main)]` |
| hover | `hover:bg-gray-50` | `hover:bg-blue-50` |

## 테스트 방법
1. 진단 상세 페이지(`/diagnostics/{id}`)로 이동
2. "파일 관리" 버튼이 파란색으로 표시되는지 확인
3. 버튼 호버 시 파란색 배경이 나타나는지 확인
4. 버튼 클릭 시 파일 관리 페이지로 정상 이동하는지 확인

## 명세 준수 체크리스트
- [x] 기존 디자인 시스템/테마 색상 사용 (`var(--color-primary-main)`)
- [x] 버튼 기능 변경 없음
- [x] 프로젝트의 다른 활성 버튼("AI 분석 상세")과 일관된 스타일

## 리뷰 포인트
- "AI 분석 상세" 버튼과 동일한 스타일을 적용한 것이 적절한지

## TODO / 질문
- 없음