### PR TITLE
feat: #179 로고 클릭 시 홈으로 이동

### DIFF
--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import svgPaths from '../../imports/svg-h10djjhihc';
 import { useLogout } from '../../src/hooks/useAuth';
 import { useNotifications, useUnreadCount, useMarkAsRead } from '../../src/hooks/useNotifications';
@@ -160,11 +160,11 @@ export default function Header({ userName, userRole, onToggleSidebar, showMenuBu
         )}
 
         {/* Logo */}
-        <div className="shrink-0">
+        <Link to="/dashboard" className="shrink-0 cursor-pointer">
           <p className="font-heading-small text-white">
             SmartChain
           </p>
-        </div>
+        </Link>
 
         {/* Divider */}
         <div className="hidden md:block h-[24px] w-px bg-white/30" />


### PR DESCRIPTION
## 변경 요약
- 헤더의 로고(SmartChain)를 클릭하면 홈(/dashboard)으로 이동하도록 Link 추가
- cursor: pointer 스타일 적용으로 클릭 가능함을 시각적으로 표시

## 관련 이슈
- closes #179

## 테스트 방법
1. 로그인 후 아무 페이지로 이동
2. 헤더의 "SmartChain" 로고 위에 마우스 올리면 커서가 pointer로 변경되는지 확인
3. 로고 클릭 시 /dashboard 페이지로 이동하는지 확인

## 명세 준수 체크
- [x] 로고 클릭 시 홈 페이지로 정상 이동
- [x] 커서가 pointer로 변경되어 클릭 가능함을 표시
- [x] 기존 로고 디자인 유지
- [x] react-router-dom의 Link 컴포넌트 사용

## 리뷰 포인트
- Header.tsx에서 div를 Link로 변경하여 라우팅 구현

## TODO/질문
- 없음