### PR TITLE
fix: #180 사이드 메뉴 active 상태를 URL pathname 기반으로 동기화

### DIFF
--- a/shared/layout/Sidebar.tsx
+++ b/shared/layout/Sidebar.tsx
@@ -69,7 +69,10 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
         `}
       >
         {menuItems.map((item) => {
-          const isActive = location.pathname === item.path;
+          const isActive =
+            item.path === '/dashboard'
+              ? location.pathname === '/dashboard'
+              : location.pathname.startsWith(item.path);
           return (
             <div
               key={item.path}


### PR DESCRIPTION
## 변경 요약
- 사이드 메뉴 active 상태가 URL pathname과 동기화되도록 수정
- `startsWith`를 사용하여 하위 경로에서도 상위 메뉴가 active 상태 유지
- 홈 메뉴(`/dashboard`)는 정확한 매칭 유지

## 관련 이슈
- Closes #180

## 테스트 방법
1. `/dashboard/safety` 페이지 접속 → '안전보건' 메뉴 active 확인
2. `/dashboard/safety/upload` 페이지 접속 → '안전보건' 메뉴 active 확인
3. 브라우저 뒤로가기 → 이전 페이지의 메뉴가 active 상태로 복원 확인
4. 페이지 새로고침 → 현재 URL에 맞는 메뉴 active 확인
5. `/dashboard` 접속 시 '홈'만 active 확인 (다른 메뉴와 중복 없음)

## 명세 준수 체크
- [x] 뒤로가기 시 이전 페이지와 메뉴 상태가 정상 복원됨
- [x] URL 변경 시 사이드 메뉴 active 상태가 자동 동기화됨
- [x] 새로고침 후에도 현재 URL에 맞는 메뉴가 active 상태
- [x] 기존 메뉴 구조 유지
- [x] 불필요한 state 추가 없음 (URL을 single source of truth로 사용)

## 리뷰 포인트
- `startsWith` 사용 시 `/dashboard`가 모든 하위 경로에 매칭되는 것을 방지하기 위해 홈 메뉴는 정확한 매칭(`===`) 사용

## TODO / 질문
- 없음