### PR TITLE
feat: 기안 생성 개선 및 ESG 메뉴 라우팅 변경

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -76,11 +76,13 @@ export default function DiagnosticCreatePage() {
   }, [selectedCampaignId, campaigns, setValue]);
 
   const onSubmit = async (data: DiagnosticCreateFormData) => {
+    // 중복 호출 방지
+    if (createMutation.isPending) return;
+
     createMutation.mutate(data, {
       onSuccess: (result) => {
         if (!isMountedRef.current) return;
-        const domainPath = data.domainCode.toLowerCase();
-        navigate(`/dashboard/${domainPath}/upload?diagnosticId=${result.diagnosticId}`);
+        navigate(`/diagnostics/${result.diagnosticId}`);
       },
     });
   };

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import type { DiagnosticStatus, DomainCode } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
@@ -27,8 +27,11 @@ type StatusFilter = DiagnosticStatus | 'ALL';
 
 export default function DiagnosticsListPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const initialDomainCode = searchParams.get('domainCode') || '';
+
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
-  const [domainFilter, setDomainFilter] = useState<string>('');
+  const [domainFilter, setDomainFilter] = useState<string>(initialDomainCode);
   const [keyword, setKeyword] = useState('');
   const [searchInput, setSearchInput] = useState('');
   const [page, setPage] = useState(0);

--- a/shared/layout/Sidebar.tsx
+++ b/shared/layout/Sidebar.tsx
@@ -16,7 +16,7 @@ interface MenuItem {
 const DOMAIN_MENU_ITEMS: MenuItem[] = [
   { label: '안전보건', path: '/dashboard/safety', domainCode: 'SAFETY' },
   { label: '컴플라이언스', path: '/dashboard/compliance', domainCode: 'COMPLIANCE' },
-  { label: 'ESG', path: '/dashboard/esg', domainCode: 'ESG' },
+  { label: 'ESG', path: '/diagnostics?domainCode=ESG', domainCode: 'ESG' },
 ];
 
 export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
@@ -69,7 +69,11 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
         `}
       >
         {menuItems.map((item) => {
-          const isActive = location.pathname === item.path;
+          // 쿼리 파라미터가 있는 경로 처리 (예: /diagnostics?domainCode=ESG)
+          const [itemPath, itemQuery] = item.path.split('?');
+          const isActive = itemQuery
+            ? location.pathname === itemPath && location.search === `?${itemQuery}`
+            : location.pathname === item.path;
           return (
             <div
               key={item.path}


### PR DESCRIPTION
## 변경요약
- 기안 생성 버튼 연타 방지 (isPending 체크 추가)
- 기안 생성 후 파일 업로드 페이지 대신 기안 상세 페이지로 이동
- ESG 사이드바 메뉴 클릭 시 `/dashboard/esg` 대신 `/diagnostics?domainCode=ESG`로 이동
- DiagnosticsListPage에서 URL 쿼리 파라미터(`domainCode`)로 도메인 필터 초기화

## 관련이슈
- Closes #177

## 테스트방법
1. 기안 생성 페이지에서 생성 버튼 연타 시 중복 호출 안되는지 확인
2. 기안 생성 후 기안 상세 페이지로 이동되는지 확인
3. ESG 사이드바 메뉴 클릭 시 기안 목록 페이지(ESG 필터링)로 이동되는지 확인

## 명세준수
- [x] 기안 생성 버튼 연타 방지
- [x] 기안 생성 후 기안 상세 페이지로 이동
- [x] ESG 메뉴가 기안 목록 페이지로 이동

## 리뷰포인트
- Sidebar의 isActive 로직이 쿼리 파라미터 포함 경로를 올바르게 처리하는지 확인 부탁드립니다

## TODO 질문
- 없음