### PR TITLE
fix: ESG 사이드 메뉴 역할별 화면 분기 복원

### DIFF
--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import type { DiagnosticStatus, DomainCode } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
@@ -27,18 +27,14 @@ type StatusFilter = DiagnosticStatus | 'ALL';
 
 export default function DiagnosticsListPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const initialDomainCode = searchParams.get('domainCode') || '';
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
-  const [domainFilter, setDomainFilter] = useState<string>(initialDomainCode);
   const [keyword, setKeyword] = useState('');
   const [searchInput, setSearchInput] = useState('');
   const [page, setPage] = useState(0);
 
   const { data, isLoading, isError, refetch } = useDiagnosticsList({
     status: statusFilter === 'ALL' ? undefined : statusFilter,
-    domainCode: domainFilter || undefined,
     keyword: keyword || undefined,
     page,
     size: 10,
@@ -56,13 +52,6 @@ export default function DiagnosticsListPage() {
     { key: 'APPROVED', label: '승인됨' },
     { key: 'REVIEWING', label: '심사중' },
     { key: 'COMPLETED', label: '완료' },
-  ];
-
-  const domainOptions: { value: string; label: string }[] = [
-    { value: '', label: '전체 도메인' },
-    { value: 'ESG', label: DOMAIN_LABELS.ESG },
-    { value: 'SAFETY', label: DOMAIN_LABELS.SAFETY },
-    { value: 'COMPLIANCE', label: DOMAIN_LABELS.COMPLIANCE },
   ];
 
   return (
@@ -97,17 +86,6 @@ export default function DiagnosticsListPage() {
               </button>
             ))}
           </div>
-
-          {/* 도메인 필터 */}
-          <select
-            value={domainFilter}
-            onChange={(e) => { setDomainFilter(e.target.value); setPage(0); }}
-            className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
-          >
-            {domainOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
-          </select>
 
           {/* 검색 */}
           <div className="flex gap-[8px] ml-auto">

--- a/shared/layout/Sidebar.tsx
+++ b/shared/layout/Sidebar.tsx
@@ -16,7 +16,7 @@ interface MenuItem {
 const DOMAIN_MENU_ITEMS: MenuItem[] = [
   { label: '안전보건', path: '/dashboard/safety', domainCode: 'SAFETY' },
   { label: '컴플라이언스', path: '/dashboard/compliance', domainCode: 'COMPLIANCE' },
-  { label: 'ESG', path: '/diagnostics?domainCode=ESG', domainCode: 'ESG' },
+  { label: 'ESG', path: '/dashboard/esg', domainCode: 'ESG' },
 ];
 
 export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
@@ -69,11 +69,8 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
         `}
       >
         {menuItems.map((item) => {
-          // 쿼리 파라미터가 있는 경로 처리 (예: /diagnostics?domainCode=ESG)
-          const [itemPath, itemQuery] = item.path.split('?');
-          const isActive = itemQuery
-            ? location.pathname === itemPath && location.search === `?${itemQuery}`
-            : item.path === '/dashboard'
+          const isActive =
+            item.path === '/dashboard'
               ? location.pathname === '/dashboard'
               : location.pathname.startsWith(item.path);
           return (


### PR DESCRIPTION
## 변경요약
- ESG 사이드 메뉴 경로를 `/dashboard/esg`로 복원하여 역할별 분기 지원
- DiagnosticsListPage에서 도메인 드롭다운 제거 (사이드 메뉴가 도메인별로 분리되어 있으므로 불필요)
- Sidebar의 불필요한 쿼리 파라미터 처리 로직 제거

## 관련이슈
- Closes #205

## 테스트방법
1. 결재자 계정으로 로그인
2. ESG 사이드 메뉴 클릭 시 "기안자 | 기안명 | 요청일 | 상태" 형식으로 표시되는지 확인
3. 기안자 계정으로 로그인
4. ESG 사이드 메뉴 클릭 시 기안 목록 화면으로 표시되는지 확인
5. 기안 목록 페이지(/diagnostics)에서 도메인 드롭다운이 제거되었는지 확인

## 명세준수
- [x] 결재자가 ESG 클릭 시 결재 목록 화면 표시
- [x] 기안자가 ESG 클릭 시 기안 목록 화면 표시
- [x] 도메인 드롭다운 제거

## 리뷰포인트
- 없음