### PR TITLE
fix: #175 도메인/기간 필드 자동선택 수정 비활성화

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -152,15 +152,16 @@ export default function DiagnosticCreatePage() {
             {/* 도메인 */}
             <div>
               <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
-                도메인 <span className="text-red-500">*</span>
+                도메인 <span className="text-[var(--color-text-tertiary)]">(자동선택)</span>
               </label>
               <select
                 {...register('domainCode')}
-                className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] bg-white ${
+                disabled
+                className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] bg-gray-50 cursor-not-allowed ${
                   errors.domainCode ? 'border-red-500' : 'border-[var(--color-border-default)]'
                 }`}
               >
-                <option value="">도메인을 선택하세요</option>
+                <option value="">캠페인 선택 시 자동선택</option>
                 {DOMAIN_OPTIONS.map((opt) => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
@@ -174,12 +175,14 @@ export default function DiagnosticCreatePage() {
             <div className="grid grid-cols-2 gap-[16px]">
               <div>
                 <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
-                  기안 시작일 <span className="text-red-500">*</span>
+                  기안 시작일 <span className="text-[var(--color-text-tertiary)]">(자동선택)</span>
                 </label>
                 <input
                   type="date"
                   {...register('periodStartDate')}
-                  className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] ${
+                  disabled
+                  placeholder="캠페인 선택 시 자동선택"
+                  className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] bg-gray-50 cursor-not-allowed ${
                     errors.periodStartDate ? 'border-red-500' : 'border-[var(--color-border-default)]'
                   }`}
                 />
@@ -190,12 +193,14 @@ export default function DiagnosticCreatePage() {
 
               <div>
                 <label className="font-title-xsmall text-[var(--color-text-secondary)] mb-[8px] block">
-                  기안 종료일 <span className="text-red-500">*</span>
+                  기안 종료일 <span className="text-[var(--color-text-tertiary)]">(자동선택)</span>
                 </label>
                 <input
                   type="date"
                   {...register('periodEndDate')}
-                  className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-primary-main)] ${
+                  disabled
+                  placeholder="캠페인 선택 시 자동선택"
+                  className={`w-full px-[12px] py-[10px] rounded-[8px] border font-body-medium text-[var(--color-text-primary)] bg-gray-50 cursor-not-allowed ${
                     errors.periodEndDate ? 'border-red-500' : 'border-[var(--color-border-default)]'
                   }`}
                 />


### PR DESCRIPTION
## 변경요약
- 기안 생성 페이지에서 도메인/기간 필드를 수정 불가능하게 변경
- 캠페인 선택 시 자동으로 채워지는 도메인, 시작일, 종료일 필드에 `disabled` 속성 추가
- 라벨에 "(자동선택)" 표시 추가
- 비활성화 스타일 적용 (bg-gray-50, cursor-not-allowed)

## 관련이슈
- Closes #175

## 테스트방법
1. 기안자 역할로 로그인
2. 새 기안 생성 페이지로 이동
3. 캠페인 선택 시 도메인/기간이 자동으로 채워지는지 확인
4. 도메인/기간 필드가 수정 불가능한지 확인 (클릭해도 변경 안됨)
5. 필드 라벨에 "(자동선택)" 표시 확인

## 명세준수 체크
- [x] 캠페인 선택 시 도메인 자동선택
- [x] 캠페인 선택 시 기간 자동선택 (4개월 단위, 1일~말일)
- [x] 도메인/기간 필드 수정 비활성화

## 리뷰포인트
- disabled 필드의 시각적 스타일이 적절한지 확인 부탁드립니다

## TODO/질문
- 없음