### PR TITLE
feat: 도메인별 사이드 메뉴 통일 및 역할별 화면 분기

### DIFF
--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
-import type { DiagnosticStatus, DomainCode } from '../../src/types/api.types';
+import { useApprovals } from '../../src/hooks/useApprovals';
+import { useReviews } from '../../src/hooks/useReviews';
+import { useAuthStore } from '../../src/store/authStore';
+import type { DiagnosticStatus, ApprovalStatus, ReviewStatus, DomainCode } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 
@@ -23,26 +26,119 @@ const STATUS_STYLES: Record<DiagnosticStatus, string> = {
   COMPLETED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
 };
 
+const APPROVAL_STATUS_LABELS: Record<ApprovalStatus, string> = {
+  WAITING: '대기',
+  APPROVED: '승인',
+  REJECTED: '반려',
+};
+
+const APPROVAL_STATUS_STYLES: Record<ApprovalStatus, string> = {
+  WAITING: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REJECTED: 'bg-red-50 text-red-700 border-red-200',
+};
+
+const REVIEW_STATUS_LABELS: Record<ReviewStatus, string> = {
+  REVIEWING: '검토중',
+  APPROVED: '적합',
+  REVISION_REQUIRED: '보완필요',
+};
+
+const REVIEW_STATUS_STYLES: Record<ReviewStatus, string> = {
+  REVIEWING: 'bg-blue-50 text-blue-700 border-blue-200',
+  APPROVED: 'bg-green-50 text-green-700 border-green-200',
+  REVISION_REQUIRED: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+};
+
 type StatusFilter = DiagnosticStatus | 'ALL';
+type ApprovalStatusFilter = ApprovalStatus | 'ALL';
+type ReviewStatusFilter = ReviewStatus | 'ALL';
+
+function formatDate(dateString?: string): string {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+}
 
 export default function DiagnosticsListPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const domainCode = searchParams.get('domainCode') as DomainCode | null;
+  const { user } = useAuthStore();
 
+  // 역할 결정
+  const getUserRole = (): 'drafter' | 'approver' | 'reviewer' => {
+    if (!user?.role?.code) return 'drafter';
+    if (user.role.code === 'APPROVER') return 'approver';
+    if (user.role.code === 'REVIEWER') return 'reviewer';
+    return 'drafter';
+  };
+
+  const userRole = getUserRole();
+
+  // 기안자용 상태
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const [keyword, setKeyword] = useState('');
   const [searchInput, setSearchInput] = useState('');
   const [page, setPage] = useState(0);
 
-  const { data, isLoading, isError, refetch } = useDiagnosticsList({
-    status: statusFilter === 'ALL' ? undefined : statusFilter,
-    keyword: keyword || undefined,
-    page,
-    size: 10,
-  });
+  // 결재자용 상태
+  const [approvalStatusFilter, setApprovalStatusFilter] = useState<ApprovalStatusFilter>('ALL');
 
-  const diagnostics = data?.content || [];
-  const pageInfo = data?.page;
-  const totalPages = pageInfo?.totalPages || 0;
+  // 심사자용 상태
+  const [reviewStatusFilter, setReviewStatusFilter] = useState<ReviewStatusFilter>('ALL');
+
+  // 데이터 조회
+  const diagnosticsQuery = useDiagnosticsList(
+    userRole === 'drafter'
+      ? {
+          status: statusFilter === 'ALL' ? undefined : statusFilter,
+          domainCode: domainCode || undefined,
+          keyword: keyword || undefined,
+          page,
+          size: 10,
+        }
+      : undefined
+  );
+
+  const approvalsQuery = useApprovals(
+    userRole === 'approver'
+      ? {
+          status: approvalStatusFilter === 'ALL' ? undefined : approvalStatusFilter,
+          domainCode: domainCode || undefined,
+          page,
+          size: 10,
+        }
+      : undefined
+  );
+
+  const reviewsQuery = useReviews(
+    userRole === 'reviewer'
+      ? {
+          status: reviewStatusFilter === 'ALL' ? undefined : reviewStatusFilter,
+          domainCode: domainCode || undefined,
+          page,
+          size: 10,
+        }
+      : undefined
+  );
+
+  const isLoading =
+    (userRole === 'drafter' && diagnosticsQuery.isLoading) ||
+    (userRole === 'approver' && approvalsQuery.isLoading) ||
+    (userRole === 'reviewer' && reviewsQuery.isLoading);
+
+  const isError =
+    (userRole === 'drafter' && diagnosticsQuery.isError) ||
+    (userRole === 'approver' && approvalsQuery.isError) ||
+    (userRole === 'reviewer' && reviewsQuery.isError);
+
+  const getPageTitle = () => {
+    if (domainCode) {
+      return DOMAIN_LABELS[domainCode] || domainCode;
+    }
+    return '기안 관리';
+  };
 
   const statusTabs: { key: StatusFilter; label: string }[] = [
     { key: 'ALL', label: '전체' },
@@ -54,136 +150,314 @@ export default function DiagnosticsListPage() {
     { key: 'COMPLETED', label: '완료' },
   ];
 
+  const approvalStatusTabs: { key: ApprovalStatusFilter; label: string }[] = [
+    { key: 'ALL', label: '전체' },
+    { key: 'WAITING', label: '대기' },
+    { key: 'APPROVED', label: '승인' },
+    { key: 'REJECTED', label: '반려' },
+  ];
+
+  const reviewStatusTabs: { key: ReviewStatusFilter; label: string }[] = [
+    { key: 'ALL', label: '전체' },
+    { key: 'REVIEWING', label: '검토중' },
+    { key: 'APPROVED', label: '적합' },
+    { key: 'REVISION_REQUIRED', label: '보완필요' },
+  ];
+
+  const renderTableHeader = () => {
+    if (userRole === 'approver') {
+      return (
+        <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기안자</th>
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기안명</th>
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">요청일</th>
+          <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
+        </tr>
+      );
+    }
+
+    if (userRole === 'reviewer') {
+      return (
+        <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제출일</th>
+          <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
+        </tr>
+      );
+    }
+
+    // 기안자
+    return (
+      <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+        <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
+        <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">캠페인</th>
+        <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기간</th>
+        <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
+      </tr>
+    );
+  };
+
+  const renderTableBody = () => {
+    if (isLoading) {
+      return (
+        <tr>
+          <td colSpan={4} className="text-center py-[60px]">
+            <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
+          </td>
+        </tr>
+      );
+    }
+
+    if (isError) {
+      return (
+        <tr>
+          <td colSpan={4} className="text-center py-[60px]">
+            <p className="font-body-medium text-[var(--color-state-error-text)]">
+              데이터를 불러오는 데 실패했습니다.
+            </p>
+          </td>
+        </tr>
+      );
+    }
+
+    if (userRole === 'approver') {
+      const items = approvalsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="text-center py-[60px]">
+              <p className="font-body-medium text-[var(--color-text-tertiary)]">
+                대기 중인 결재가 없습니다.
+              </p>
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.approvalId}
+          onClick={() => navigate(`/approvals/${item.approvalId}`)}
+          className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
+        >
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
+            {item.requester?.name || '-'}
+          </td>
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+            {item.diagnostic?.title || '-'}
+          </td>
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
+            {formatDate(item.requestedAt)}
+          </td>
+          <td className="px-[16px] py-[14px] text-center">
+            <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${APPROVAL_STATUS_STYLES[item.status]}`}>
+              {item.statusLabel || APPROVAL_STATUS_LABELS[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    if (userRole === 'reviewer') {
+      const items = reviewsQuery.data?.content || [];
+      if (items.length === 0) {
+        return (
+          <tr>
+            <td colSpan={4} className="text-center py-[60px]">
+              <p className="font-body-medium text-[var(--color-text-tertiary)]">
+                심사 대상이 없습니다.
+              </p>
+            </td>
+          </tr>
+        );
+      }
+      return items.map((item) => (
+        <tr
+          key={item.reviewId}
+          onClick={() => navigate(`/reviews/${item.reviewId}`)}
+          className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
+        >
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
+            {item.company?.companyName || '-'}
+          </td>
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+            {item.domainName || item.domainCode}
+          </td>
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
+            {formatDate(item.submittedAt)}
+          </td>
+          <td className="px-[16px] py-[14px] text-center">
+            <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${REVIEW_STATUS_STYLES[item.status]}`}>
+              {REVIEW_STATUS_LABELS[item.status]}
+            </span>
+          </td>
+        </tr>
+      ));
+    }
+
+    // 기안자
+    const items = diagnosticsQuery.data?.content || [];
+    if (items.length === 0) {
+      return (
+        <tr>
+          <td colSpan={4} className="text-center py-[60px]">
+            <p className="font-body-medium text-[var(--color-text-tertiary)]">
+              기안 내역이 없습니다.
+            </p>
+          </td>
+        </tr>
+      );
+    }
+    return items.map((item) => (
+      <tr
+        key={item.diagnosticId}
+        onClick={() => navigate(`/diagnostics/${item.diagnosticId}`)}
+        className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
+      >
+        <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
+          {item.summary || item.campaign?.title || '-'}
+        </td>
+        <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
+          {item.campaign?.title || '-'}
+        </td>
+        <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
+          {item.period?.startDate && item.period?.endDate
+            ? `${item.period.startDate} ~ ${item.period.endDate}`
+            : '-'}
+        </td>
+        <td className="px-[16px] py-[14px] text-center">
+          <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status] || 'bg-gray-50 text-gray-700 border-gray-200'}`}>
+            {item.statusLabel || STATUS_LABELS[item.status] || item.status}
+          </span>
+        </td>
+      </tr>
+    ));
+  };
+
+  const renderStatusTabs = () => {
+    if (userRole === 'approver') {
+      return (
+        <div className="flex flex-wrap gap-[8px]">
+          {approvalStatusTabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => { setApprovalStatusFilter(tab.key); setPage(0); }}
+              className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+                approvalStatusFilter === tab.key
+                  ? 'bg-[var(--color-primary-main)] text-white'
+                  : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      );
+    }
+
+    if (userRole === 'reviewer') {
+      return (
+        <div className="flex flex-wrap gap-[8px]">
+          {reviewStatusTabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => { setReviewStatusFilter(tab.key); setPage(0); }}
+              className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+                reviewStatusFilter === tab.key
+                  ? 'bg-[var(--color-primary-main)] text-white'
+                  : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      );
+    }
+
+    // 기안자
+    return (
+      <div className="flex flex-wrap gap-[8px]">
+        {statusTabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => { setStatusFilter(tab.key); setPage(0); }}
+            className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
+              statusFilter === tab.key
+                ? 'bg-[var(--color-primary-main)] text-white'
+                : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  const getTotalPages = () => {
+    if (userRole === 'approver') {
+      return approvalsQuery.data?.page?.totalPages || 0;
+    }
+    if (userRole === 'reviewer') {
+      return reviewsQuery.data?.page?.totalPages || 0;
+    }
+    return diagnosticsQuery.data?.page?.totalPages || 0;
+  };
+
+  const totalPages = getTotalPages();
+
   return (
     <DashboardLayout>
       <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[1200px] mx-auto w-full">
         {/* 헤더 */}
         <div className="flex items-center justify-between">
-          <h1 className="font-heading-small text-[var(--color-text-primary)]">기안 관리</h1>
-          <button
-            onClick={() => navigate('/diagnostics/new')}
-            className="px-[20px] py-[10px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
-          >
-            + 새 기안 생성
-          </button>
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{getPageTitle()}</h1>
+          {userRole === 'drafter' && (
+            <button
+              onClick={() => navigate('/diagnostics/new')}
+              className="px-[20px] py-[10px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+            >
+              + 새 기안 생성
+            </button>
+          )}
         </div>
 
         {/* 필터 영역 */}
         <div className="flex flex-wrap items-center gap-[12px]">
-          {/* 상태 탭 */}
-          <div className="flex flex-wrap gap-[8px]">
-            {statusTabs.map((tab) => (
-              <button
-                key={tab.key}
-                onClick={() => { setStatusFilter(tab.key); setPage(0); }}
-                className={`px-[16px] py-[8px] rounded-full font-title-xsmall transition-colors ${
-                  statusFilter === tab.key
-                    ? 'bg-[var(--color-primary-main)] text-white'
-                    : 'bg-[var(--color-surface-primary)] text-[var(--color-text-secondary)] hover:bg-gray-200'
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
+          {renderStatusTabs()}
 
-          {/* 검색 */}
-          <div className="flex gap-[8px] ml-auto">
-            <input
-              type="text"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') { setKeyword(searchInput); setPage(0); }
-              }}
-              placeholder="검색어를 입력하세요"
-              className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white w-[240px]"
-            />
-            <button
-              onClick={() => { setKeyword(searchInput); setPage(0); }}
-              className="px-[16px] py-[8px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-xsmall hover:opacity-90 transition-colors"
-            >
-              검색
-            </button>
-          </div>
+          {/* 검색 (기안자만) */}
+          {userRole === 'drafter' && (
+            <div className="flex gap-[8px] ml-auto">
+              <input
+                type="text"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { setKeyword(searchInput); setPage(0); }
+                }}
+                placeholder="검색어를 입력하세요"
+                className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white w-[240px]"
+              />
+              <button
+                onClick={() => { setKeyword(searchInput); setPage(0); }}
+                className="px-[16px] py-[8px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-xsmall hover:opacity-90 transition-colors"
+              >
+                검색
+              </button>
+            </div>
+          )}
         </div>
 
         {/* 테이블 */}
         <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기간</th>
-                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
-              </tr>
+              {renderTableHeader()}
             </thead>
             <tbody>
-              {isLoading && (
-                <tr>
-                  <td colSpan={5} className="text-center py-[60px]">
-                    <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
-                  </td>
-                </tr>
-              )}
-
-              {isError && (
-                <tr>
-                  <td colSpan={5} className="text-center py-[60px]">
-                    <div className="flex flex-col items-center gap-[12px]">
-                      <p className="font-body-medium text-[var(--color-state-error-text)]">
-                        기안 목록을 불러오는 데 실패했습니다.
-                      </p>
-                      <button
-                        onClick={() => refetch()}
-                        className="font-title-xsmall text-[var(--color-primary-main)] hover:underline"
-                      >
-                        다시 시도
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              )}
-
-              {!isLoading && !isError && diagnostics.length === 0 && (
-                <tr>
-                  <td colSpan={5} className="text-center py-[60px]">
-                    <p className="font-body-medium text-[var(--color-text-tertiary)]">
-                      기안 내역이 없습니다.
-                    </p>
-                  </td>
-                </tr>
-              )}
-
-              {diagnostics.map((item) => (
-                <tr
-                  key={item.diagnosticId}
-                  onClick={() => navigate(`/diagnostics/${item.diagnosticId}`)}
-                  className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
-                >
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
-                    {item.summary || item.campaign?.title || '-'}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
-                    {item.domain?.name || DOMAIN_LABELS[item.domain?.code as DomainCode] || '-'}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
-                    {item.campaign?.title || '-'}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
-                    {item.period?.startDate && item.period?.endDate
-                      ? `${item.period.startDate} ~ ${item.period.endDate}`
-                      : '-'}
-                  </td>
-                  <td className="px-[16px] py-[14px] text-center">
-                    <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status] || 'bg-gray-50 text-gray-700 border-gray-200'}`}>
-                      {item.statusLabel || STATUS_LABELS[item.status] || item.status}
-                    </span>
-                  </td>
-                </tr>
-              ))}
+              {renderTableBody()}
             </tbody>
           </table>
         </div>

--- a/shared/layout/Sidebar.tsx
+++ b/shared/layout/Sidebar.tsx
@@ -14,9 +14,9 @@ interface MenuItem {
 }
 
 const DOMAIN_MENU_ITEMS: MenuItem[] = [
-  { label: '안전보건', path: '/dashboard/safety', domainCode: 'SAFETY' },
-  { label: '컴플라이언스', path: '/dashboard/compliance', domainCode: 'COMPLIANCE' },
-  { label: 'ESG', path: '/dashboard/esg', domainCode: 'ESG' },
+  { label: '안전보건', path: '/diagnostics?domainCode=SAFETY', domainCode: 'SAFETY' },
+  { label: '컴플라이언스', path: '/diagnostics?domainCode=COMPLIANCE', domainCode: 'COMPLIANCE' },
+  { label: 'ESG', path: '/diagnostics?domainCode=ESG', domainCode: 'ESG' },
 ];
 
 export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
@@ -69,8 +69,11 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
         `}
       >
         {menuItems.map((item) => {
-          const isActive =
-            item.path === '/dashboard'
+          // 쿼리 파라미터가 있는 경로 처리 (예: /diagnostics?domainCode=SAFETY)
+          const [itemPath, itemQuery] = item.path.split('?');
+          const isActive = itemQuery
+            ? location.pathname === itemPath && location.search === `?${itemQuery}`
+            : item.path === '/dashboard'
               ? location.pathname === '/dashboard'
               : location.pathname.startsWith(item.path);
           return (


### PR DESCRIPTION
## 변경요약
- 모든 도메인(안전보건, 컴플라이언스, ESG) 사이드 메뉴가 `/diagnostics?domainCode=XXX` 형태로 통일
- DiagnosticsListPage에서 사용자 역할에 따른 화면 분기 처리:
  - **기안자(DRAFTER)**: 기안 목록 (제목 | 캠페인 | 기간 | 상태)
  - **결재자(APPROVER)**: 결재 목록 (기안자 | 기안명 | 요청일 | 상태)
  - **심사자(REVIEWER)**: 심사 목록 (회사명 | 도메인 | 제출일 | 상태)
- URL의 `domainCode` 파라미터로 도메인별 데이터 필터링
- 페이지 타이틀이 도메인명으로 동적 표시 (ESG, 안전보건, 컴플라이언스)

## 관련이슈
- #205

## 테스트방법
1. **기안자 계정**으로 로그인 → ESG 사이드 메뉴 클릭 → 기안 목록 화면 확인
2. **결재자 계정**으로 로그인 → 안전보건 사이드 메뉴 클릭 → "기안자 | 기안명 | 요청일 | 상태" 형식 확인
3. **심사자 계정**으로 로그인 → 컴플라이언스 사이드 메뉴 클릭 → 심사 목록 화면 확인
4. 각 도메인 메뉴 클릭 시 해당 도메인 데이터만 필터링되는지 확인

## 명세준수
- [x] 모든 도메인 메뉴가 DiagnosticsListPage로 라우팅
- [x] 결재자가 ESG 클릭 시 결재 목록 화면 표시
- [x] 기안자가 ESG 클릭 시 기안 목록 화면 표시
- [x] 도메인별 데이터 필터링

## 리뷰포인트
- DiagnosticsListPage가 역할별로 다른 API를 호출하는 구조가 적절한지 확인 부탁드립니다