### PR TITLE
feat: #209 기안 생성 시 활성 캠페인만 필터링

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -18,7 +18,7 @@ const DOMAIN_OPTIONS: { value: DomainCode; label: string }[] = [
 export default function DiagnosticCreatePage() {
   const navigate = useNavigate();
   const createMutation = useCreateDiagnostic();
-  const { data: campaigns = [], isLoading: campaignsLoading } = useCampaigns();
+  const { data: campaigns = [], isLoading: campaignsLoading } = useCampaigns({ activeOnly: true });
   const isMountedRef = useRef(true);
 
   useEffect(() => {

--- a/src/api/campaigns.ts
+++ b/src/api/campaigns.ts
@@ -15,6 +15,7 @@ export interface Campaign {
   targetCompanyCount?: number;
   submittedCount?: number;
   progressRate?: number;
+  isActive?: boolean;
 }
 
 interface CampaignsResponse {
@@ -22,8 +23,14 @@ interface CampaignsResponse {
   totalCount: number;
 }
 
-export const getCampaigns = async (): Promise<Campaign[]> => {
-  const response = await apiClient.get<BaseResponse<CampaignsResponse>>('/v1/campaigns');
+export interface GetCampaignsParams {
+  activeOnly?: boolean;
+}
+
+export const getCampaigns = async (params?: GetCampaignsParams): Promise<Campaign[]> => {
+  const response = await apiClient.get<BaseResponse<CampaignsResponse>>('/v1/campaigns', {
+    params: params,
+  });
   return response.data.data.campaigns;
 };
 

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import * as campaignsApi from '../api/campaigns';
+import type { GetCampaignsParams } from '../api/campaigns';
 
-export const useCampaigns = () => {
+export const useCampaigns = (params?: GetCampaignsParams) => {
   return useQuery({
-    queryKey: ['campaigns'],
-    queryFn: campaignsApi.getCampaigns,
+    queryKey: ['campaigns', params],
+    queryFn: () => campaignsApi.getCampaigns(params),
   });
 };
 


### PR DESCRIPTION
## 변경요약
기안자가 새 기안을 생성할 때 완료된(비활성) 캠페인이 선택 목록에 표시되지 않도록 수정

### 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `src/api/campaigns.ts` | `isActive` 필드 추가, `activeOnly` 파라미터 지원 |
| `src/hooks/useCampaigns.ts` | `params` 인자 추가, queryKey에 params 포함 |
| `features/diagnostics/DiagnosticCreatePage.tsx` | `useCampaigns({ activeOnly: true })` 호출 |

## 관련이슈
- Closes #209

## 테스트방법
1. 기안 생성 페이지(`/diagnostics/new`)로 이동
2. 캠페인 선택 드롭다운 확인
3. 완료된(비활성) 캠페인이 목록에 표시되지 않는지 확인
4. 네트워크 탭에서 `GET /api/v1/campaigns?activeOnly=true` 요청 확인

## 명세준수 체크
- [x] 백엔드 API 변경사항 반영 (`activeOnly` 파라미터)
- [x] `isActive` 필드 타입 추가
- [x] 기존 캠페인 조회 로직 호환성 유지 (params 옵셔널)

## 리뷰포인트
- `useCampaigns` hook의 queryKey에 params를 포함시켜 캐싱을 분리했습니다
- 다른 곳에서 `useCampaigns()`를 파라미터 없이 호출하면 기존과 동일하게 전체 캠페인 조회

## TODO / 질문
- [ ] 캠페인 관리 페이지에서도 활성/비활성 필터 UI가 필요한지 확인 필요
- [ ] `isActive` 필드를 캠페인 목록 UI에 표시할 필요가 있는지 검토