### PR TITLE
fix: #210 로그인/회원가입 페이지 푸터 추가 및 반응형 개선

### DIFF
--- a/features/auth/LoginPage.tsx
+++ b/features/auth/LoginPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../shared/components/Button';
 import { Input } from '../../shared/components/Input';
 import { LogoWithSubtitle } from '../../shared/components/Logo';
 import PrivacyPolicyModal from '../../shared/components/PrivacyPolicyModal';
+import Footer from '../../shared/layout/Footer';
 import type { AxiosError } from 'axios';
 import { useLogin } from '../../src/hooks/useAuth';
 import { useAuthStore } from '../../src/store/authStore';
@@ -54,8 +55,8 @@ function LoginBackground() {
 
 function HDLogo() {
   return (
-    <div className="relative shrink-0 w-full flex justify-center pb-8">
-      <div className="flex gap-[8px] items-center justify-center p-[24px]">
+    <div className="relative shrink-0 w-full flex justify-center pb-4">
+      <div className="flex gap-[8px] items-center justify-center p-4">
           <div className="h-[28.001px] w-[23.96px] relative" style={{ maskImage: `url('${imgGroup}')`, WebkitMaskImage: `url('${imgGroup}')`, maskRepeat: 'no-repeat', WebkitMaskRepeat: 'no-repeat' }}>
              <svg className="block size-full" fill="none" preserveAspectRatio="none" viewBox="0 0 23.96 28.001">
               <g>
@@ -75,12 +76,12 @@ function HDLogo() {
 
 function LoginLeftPanel() {
   return (
-    <div className="bg-[var(--color-surface-primary)] flex-1 hidden lg:flex flex-col relative overflow-hidden rounded-t-[20px] lg:rounded-l-[20px] lg:rounded-tr-none">
+    <div className="bg-[var(--color-surface-primary)] flex-1 hidden lg:flex flex-col relative overflow-hidden rounded-l-[20px]">
         <LoginBackground />
 
         {/* Content */}
-        <div className="relative z-10 flex-1 flex flex-col justify-center items-center p-12 text-center">
-            <p className="font-body-large leading-[1.6] text-black mb-8">
+        <div className="relative z-10 flex-1 flex flex-col justify-center items-center p-6 text-center">
+            <p className="font-body-large leading-[1.6] text-black mb-4">
                 임직원, 협력회사, 지역사회 등 이해관계자 모두와
                 <br aria-hidden="true" />
                 더 나은 미래를 함께 만들어 갑니다.
@@ -125,83 +126,86 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="bg-[var(--color-page-bg)] min-h-screen w-full flex items-center justify-center p-4 lg:p-[72px]">
-      <div className="bg-white flex flex-col lg:flex-row w-full max-w-[1776px] min-h-[80vh] lg:h-[936px] rounded-[20px] shadow-lg overflow-hidden">
-        <LoginLeftPanel />
+    <div className="bg-[var(--color-page-bg)] h-screen w-full flex flex-col overflow-hidden md:overflow-hidden overflow-y-auto">
+      {/* Main Content */}
+      <div className="flex-1 flex items-center justify-center p-4 md:p-8 lg:p-12 min-h-0">
+        <div className="bg-white flex flex-col lg:flex-row w-full max-w-[1400px] h-full max-h-[700px] rounded-[20px] shadow-lg overflow-hidden">
+          <LoginLeftPanel />
 
-        {/* Right Panel - Login Form */}
-        <div className="flex-1 w-full p-8 lg:p-12 flex flex-col justify-center items-center h-full">
-            <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-[400px] flex flex-col gap-[24px] items-center">
-                <div className="w-full flex flex-col gap-[40px] items-start">
-                    {/* Title */}
-                    <div className="w-full flex justify-center lg:justify-start">
-                         <LogoWithSubtitle />
-                    </div>
+          {/* Right Panel - Login Form */}
+          <div className="flex-1 w-full p-6 md:p-8 flex flex-col justify-center items-center">
+              <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-[360px] flex flex-col gap-4 items-center">
+                  <div className="w-full flex flex-col gap-6 items-start">
+                      {/* Title */}
+                      <div className="w-full flex justify-center lg:justify-start">
+                           <LogoWithSubtitle />
+                      </div>
 
-                    {/* Form Fields */}
-                    <div className="w-full flex flex-col gap-[24px]">
-                    <div className="w-full">
-                      <Input
-                        label="이메일"
-                        type="email"
-                        placeholder="이메일을 입력해주세요."
-                        containerClassName="w-full"
-                        {...register('email')}
-                      />
-                      {errors.email && (
-                        <p className="text-red-500 font-detail-small mt-1">{errors.email.message}</p>
+                      {/* Form Fields */}
+                      <div className="w-full flex flex-col gap-4">
+                      <div className="w-full">
+                        <Input
+                          label="이메일"
+                          type="email"
+                          placeholder="이메일을 입력해주세요."
+                          containerClassName="w-full"
+                          {...register('email')}
+                        />
+                        {errors.email && (
+                          <p className="text-red-500 font-detail-small mt-1">{errors.email.message}</p>
+                        )}
+                      </div>
+                      <div className="w-full">
+                        <Input
+                          label="비밀번호"
+                          type="password"
+                          placeholder="비밀번호를 입력해주세요."
+                          containerClassName="w-full"
+                          {...register('password')}
+                        />
+                        {errors.password && (
+                          <p className="text-red-500 font-detail-small mt-1">{errors.password.message}</p>
+                        )}
+                      </div>
+                      {loginMutation.isError && (
+                        <p className="text-red-500 font-body-small">
+                          {getLoginErrorMessage(loginMutation.error as AxiosError<ErrorResponse>)}
+                        </p>
                       )}
-                    </div>
-                    <div className="w-full">
-                      <Input
-                        label="비밀번호"
-                        type="password"
-                        placeholder="비밀번호를 입력해주세요."
-                        containerClassName="w-full"
-                        {...register('password')}
-                      />
-                      {errors.password && (
-                        <p className="text-red-500 font-detail-small mt-1">{errors.password.message}</p>
-                      )}
-                    </div>
-                    {loginMutation.isError && (
-                      <p className="text-red-500 font-body-small">
-                        {getLoginErrorMessage(loginMutation.error as AxiosError<ErrorResponse>)}
-                      </p>
-                    )}
-                    <p className="font-detail-medium leading-none text-[var(--color-text-tertiary)] text-right w-full cursor-pointer hover:text-[var(--color-primary-main)]">
-                        아이디 찾기 / 비밀번호 초기화
-                    </p>
-                    </div>
+                      </div>
 
-                    {/* Buttons */}
-                    <div className="w-full flex flex-col gap-[12px]">
-                    <Button
-                      type="submit"
-                      variant="primary"
-                      size="large"
-                      className="w-full font-title-small"
-                      disabled={loginMutation.isPending}
-                    >
-                        {loginMutation.isPending ? '로그인 중...' : '로그인'}
-                    </Button>
-                    <Button type="button" variant="secondary" size="large" className="w-full font-title-small" onClick={handleSignup}>
-                        회원가입
-                    </Button>
-                    </div>
-                </div>
+                      {/* Buttons */}
+                      <div className="w-full flex flex-col gap-3">
+                      <Button
+                        type="submit"
+                        variant="primary"
+                        size="large"
+                        className="w-full font-title-small"
+                        disabled={loginMutation.isPending}
+                      >
+                          {loginMutation.isPending ? '로그인 중...' : '로그인'}
+                      </Button>
+                      <Button type="button" variant="secondary" size="large" className="w-full font-title-small" onClick={handleSignup}>
+                          회원가입
+                      </Button>
+                      </div>
+                  </div>
 
-                <button
-                  type="button"
-                  onClick={() => setShowPrivacy(true)}
-                  className="font-body-small leading-none text-[var(--color-text-tertiary)] cursor-pointer hover:text-[var(--color-primary-main)] mt-auto pt-8"
-                >
-                    개인정보 처리방침
-                </button>
-                <PrivacyPolicyModal isOpen={showPrivacy} onClose={() => setShowPrivacy(false)} />
-            </form>
+                  <button
+                    type="button"
+                    onClick={() => setShowPrivacy(true)}
+                    className="font-body-small leading-none text-[var(--color-text-tertiary)] cursor-pointer hover:text-[var(--color-primary-main)] pt-4"
+                  >
+                      개인정보 처리방침
+                  </button>
+                  <PrivacyPolicyModal isOpen={showPrivacy} onClose={() => setShowPrivacy(false)} />
+              </form>
+          </div>
         </div>
       </div>
+
+      {/* Footer */}
+      <Footer />
     </div>
   );
 }

--- a/features/auth/SignupStep1Page.tsx
+++ b/features/auth/SignupStep1Page.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { Logo } from '../../shared/components/Logo';
 import { Checkbox, RadioButton } from '../../shared/components/FormControls';
 import { Button } from '../../shared/components/Button';
+import Footer from '../../shared/layout/Footer';
 
 export default function SignupStep1Page() {
   const navigate = useNavigate();
@@ -19,9 +20,11 @@ export default function SignupStep1Page() {
   };
 
   return (
-    <div className="bg-[var(--color-page-bg)] h-screen w-full flex items-center justify-center p-4 lg:p-[70px] overflow-hidden">
-      <div className="w-full max-w-[1776px] max-h-full shadow-[var(--shadow-card)]">
-        <div className="bg-white rounded-[var(--radius-card)] w-full max-h-[calc(100vh-32px)] lg:max-h-[calc(100vh-140px)] overflow-y-auto">
+    <div className="bg-[var(--color-page-bg)] h-screen w-full flex flex-col overflow-hidden md:overflow-hidden overflow-y-auto">
+      {/* Main Content */}
+      <div className="flex-1 flex items-center justify-center p-4 md:p-6 lg:p-10 min-h-0">
+        <div className="w-full max-w-[1400px] h-full max-h-[600px] shadow-[var(--shadow-card)]">
+          <div className="bg-white rounded-[var(--radius-card)] w-full h-full overflow-y-auto">
           <div className="overflow-clip rounded-[inherit] size-full">
             <div className="flex items-start p-3 lg:p-[24px] relative w-full">
               <div className="flex-1 min-h-px min-w-px rounded-[var(--radius-card)]">
@@ -152,7 +155,11 @@ export default function SignupStep1Page() {
             </div>
           </div>
         </div>
+        </div>
       </div>
+
+      {/* Footer */}
+      <Footer />
     </div>
   );
 }

--- a/features/auth/SignupStep2Page.tsx
+++ b/features/auth/SignupStep2Page.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { Logo } from '../../shared/components/Logo';
 import { Input } from '../../shared/components/Input';
 import { Button } from '../../shared/components/Button';
+import Footer from '../../shared/layout/Footer';
 import { useRegister, useCheckEmail, useSendVerification, useVerifyEmail } from '../../src/hooks/useAuth';
 import { registerSchema, type RegisterFormData } from '../../src/validation/auth';
 
@@ -148,9 +149,11 @@ export default function SignupStep2Page() {
   const isVerificationLoading = checkEmailMutation.isPending || sendVerificationMutation.isPending;
 
   return (
-    <div className="bg-[var(--color-page-bg)] h-screen w-full flex items-center justify-center p-4 lg:p-[70px] overflow-hidden">
-      <div className="w-full max-w-[1776px] max-h-full shadow-[var(--shadow-card)]">
-        <div className="bg-white rounded-[var(--radius-card)] w-full max-h-[calc(100vh-32px)] lg:max-h-[calc(100vh-140px)] overflow-y-auto">
+    <div className="bg-[var(--color-page-bg)] h-screen w-full flex flex-col overflow-hidden md:overflow-hidden overflow-y-auto">
+      {/* Main Content */}
+      <div className="flex-1 flex items-center justify-center p-4 md:p-6 lg:p-10 min-h-0">
+        <div className="w-full max-w-[1400px] h-full max-h-[650px] shadow-[var(--shadow-card)]">
+          <div className="bg-white rounded-[var(--radius-card)] w-full h-full overflow-y-auto">
           <div className="flex flex-col items-end justify-end overflow-clip rounded-[inherit] size-full">
             <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col items-end justify-end p-3 lg:p-[24px] relative size-full">
               {/* Main Content */}
@@ -340,7 +343,11 @@ export default function SignupStep2Page() {
             </form>
           </div>
         </div>
+        </div>
       </div>
+
+      {/* Footer */}
+      <Footer />
     </div>
   );
 }

--- a/features/onboarding/OnboardingPage.tsx
+++ b/features/onboarding/OnboardingPage.tsx
@@ -60,7 +60,7 @@ export default function OnboardingPage() {
           backgroundSize: '400% 400%',
         }}
       >
-        <div className="container mx-auto px-6 py-20 relative z-10">
+        <div className="container mx-auto px-6 py-30 relative z-10">
           <div className="max-w-4xl mx-auto text-center">
             <div className="ob-fade-in-up mb-8">
               <div className="inline-block bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full border border-white/20 mb-8">

--- a/features/onboarding/onboarding.css
+++ b/features/onboarding/onboarding.css
@@ -336,7 +336,7 @@
 
 @media (min-width: 769px) {
   .ob-btn-header {
-    padding: 1.8rem 3.6rem;
+    padding: 1.2rem 2.4rem;
     font-size: 1.8rem;
   }
 }


### PR DESCRIPTION
## Summary
- 로그인/회원가입 페이지에 공통 푸터 컴포넌트 추가
- "아이디 찾기 / 비밀번호 초기화" 텍스트 제거
- 태블릿(768px) 이상 해상도에서 스크롤 없이 전체 화면에 맞춰 표시
- 모바일(768px 미만)에서만 스크롤 허용
- 온보딩 페이지 패딩 및 버튼 스타일 조정

## Changes
### Auth Pages
- `features/auth/LoginPage.tsx`
  - Footer 컴포넌트 import 및 추가
  - 레이아웃 변경: `min-h-screen` → `h-screen flex-col`
  - 카드 최대 높이 700px로 제한
  - 패딩 및 간격 축소로 컴팩트한 레이아웃 구성
  - "아이디 찾기 / 비밀번호 초기화" 텍스트 제거

- `features/auth/SignupStep1Page.tsx`
  - Footer 컴포넌트 import 및 추가
  - 레이아웃 변경: `flex items-center justify-center` → `flex flex-col`
  - 카드 최대 높이 600px로 제한

- `features/auth/SignupStep2Page.tsx`
  - Footer 컴포넌트 import 및 추가
  - 레이아웃 변경: `flex items-center justify-center` → `flex flex-col`
  - 카드 최대 높이 650px로 제한

### Onboarding
- `features/onboarding/OnboardingPage.tsx`: 상단 패딩 조정
- `features/onboarding/onboarding.css`: 헤더 버튼 패딩 축소

## Test Plan
- [ ] 로그인 페이지 1920x1080 해상도에서 스크롤 없이 표시 확인
- [ ] 로그인 페이지 768px 해상도에서 스크롤 없이 표시 확인
- [ ] 회원가입 1단계/2단계 페이지 768px+ 해상도에서 스크롤 없이 표시 확인
- [ ] 모바일(375px)에서 스크롤 정상 동작 확인
- [ ] 푸터 "개인정보 처리방침" 클릭 시 모달 정상 표시 확인
- [ ] "아이디 찾기 / 비밀번호 초기화" 텍스트 제거 확인

Closes #210