### PR TITLE
feat: #220 로그인 페이지 reCAPTCHA v3 적용

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 ## 추후 백엔드 도메인 배포 후 변경 필요
 VITE_API_BASE_URL = /api
+
+## Google reCAPTCHA v3
+VITE_RECAPTCHA_SITE_KEY = 6LcC-V8sAAAAAFhN10ugVCyiXScCetSfYHpoR4r5

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
 import { Toaster } from 'sonner';
 import { useAuthStore } from './src/store/authStore';
 import { useMe } from './src/hooks/useAuth';
@@ -342,11 +343,16 @@ function AppRoutes() {
 
 export default function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
-      <Toaster position="top-right" richColors />
-    </QueryClientProvider>
+    <GoogleReCaptchaProvider
+      reCaptchaKey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
+      language="ko"
+    >
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+        <Toaster position="top-right" richColors />
+      </QueryClientProvider>
+    </GoogleReCaptchaProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "motion": "^10.17.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-google-recaptcha-v3": "^1.11.0",
         "react-hook-form": "7.55.0",
         "react-router-dom": "^6.22.0",
         "recharts": "^2.12.0",
@@ -4775,6 +4776,21 @@
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
       "license": "MIT"
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5695,6 +5711,19 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-google-recaptcha-v3": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.11.0.tgz",
+      "integrity": "sha512-kLQqpz/77m8+trpBwzqcxNtvWZYoZ/YO6Vm2cVTHW8hs80BWUfDpC7RDwuAvpswwtSYApWfaSpIDFWAIBNIYxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.3 || ^17.0 || ^18.0 || ^19.0",
+        "react-dom": "^17.0 || ^18.0 || ^19.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "motion": "^10.17.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-google-recaptcha-v3": "^1.11.0",
     "react-hook-form": "7.55.0",
     "react-router-dom": "^6.22.0",
     "recharts": "^2.12.0",

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -139,6 +139,7 @@ export interface RegisterResponse {
 export interface LoginRequest {
   email: string;
   password: string;
+  recaptchaToken: string;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## 변경 요약
로그인 페이지에 Google reCAPTCHA v3를 적용하여 봇 공격 방지 기능 추가

### 주요 변경사항
- `react-google-recaptcha-v3` 패키지 설치
- `App.tsx`: `GoogleReCaptchaProvider`로 앱 전체 감싸기
- `LoginPage.tsx`: `useGoogleReCaptcha` 훅으로 토큰 생성 및 로그인 요청에 포함
- `api.types.ts`: `LoginRequest`에 `recaptchaToken` 필드 추가
- `.env`: `VITE_RECAPTCHA_SITE_KEY` 환경변수 추가

## 관련 이슈
- Closes #220

## 테스트 방법
1. 로컬에서 `npm run dev` 실행
2. 로그인 페이지 접속 (`/login`)
3. 이메일/비밀번호 입력 후 로그인 버튼 클릭
4. 개발자 도구 Network 탭에서 `/v1/auth/login` 요청 확인
5. Request Body에 `recaptchaToken` 필드가 포함되어 있는지 확인
6. 우측 하단에 reCAPTCHA 뱃지가 표시되는지 확인

## 명세 준수 체크
- [x] reCAPTCHA v3 invisible 방식 적용
- [x] 한국어 설정 (`language="ko"`)
- [x] action 값 `"login"` 으로 설정
- [x] `LoginRequest` 타입에 `recaptchaToken` 필드 추가
- [ ] 백엔드 토큰 검증 로직 (백엔드 작업 필요)

## 리뷰 포인트
1. `useCallback` 사용이 적절한지 확인 부탁드립니다
2. reCAPTCHA 로드 실패 시 에러 핸들링 추가 필요 여부
3. `.env` 파일에 사이트 키 직접 커밋 괜찮은지 (공개 키이므로 보안 이슈 없음)

## TODO / 질문
- [ ] **백엔드 팀 작업 필요**: `/v1/auth/login` API에서 `recaptchaToken` 검증 로직 구현
  - Google siteverify API 호출
  - `action` 값이 `"login"`인지 확인
  - `score` 임계값 설정 (권장: 0.5 이상)
  - Secret Key: Google reCAPTCHA Admin에서 확인
- [ ] reCAPTCHA 뱃지 숨김 처리 필요 시 개인정보처리방침에 reCAPTCHA 사용 명시 필요