### PR TITLE
feat: #223 계정 잠금 (접근통제) 기능 구현

### DIFF
--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -12,6 +12,8 @@ export const ERROR_HANDLERS: Record<string, ErrorConfig> = {
   A002: { action: 'silent' },
   A003: { action: 'toast', customMessage: '이메일 또는 비밀번호를 확인해주세요' },
   A004: { action: 'toast' },
+  A005: { action: 'toast', customMessage: '계정이 영구 잠금되었습니다. 관리자에게 문의해주세요.' },
+  A006: { action: 'silent' }, // LoginPage에서 직접 처리
 
   // Permission
   PERM_001: { action: 'redirect', redirectTo: '/dashboard', customMessage: '해당 리소스에 대한 접근 권한이 없습니다' },
@@ -154,6 +156,11 @@ export const LOGIN_ERROR_MESSAGES: Record<string, string> = {
   // 토큰 관련
   A001: '인증 정보가 유효하지 않습니다. 다시 로그인해주세요.',
   A002: '로그인 세션이 만료되었습니다. 다시 로그인해주세요.',
+
+  // 계정 잠금
+  A005: '계정이 영구 잠금되었습니다. 관리자에게 문의해주세요.',
+  A006: '계정이 일시 잠금되었습니다.',
+  ACCOUNT_LOCKED: '계정이 잠금되었습니다.',
 
   // 서버 오류 (500)
   S001: '서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.',

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -25,6 +25,14 @@ export interface ErrorResponse {
   status: number;
   code: string;
   message: string;
+  data?: AccountLockData;
+}
+
+/** 계정 잠금 데이터 */
+export interface AccountLockData {
+  lockedUntil?: string;
+  remainingMinutes?: number;
+  remainingAttempts?: number;
 }
 
 /** 페이지 정보 */
@@ -148,6 +156,8 @@ export interface LoginResponse {
   tokenType: string;
   expiresIn: number;
   user: UserInfoDto;
+  remainingAttempts?: number;
+  warningMessage?: string;
 }
 
 export interface UserInfoDto {
@@ -371,6 +381,8 @@ export const ERROR_CODES = {
 
   // 403 Forbidden
   ACCESS_DENIED: 'A004',
+  ACCOUNT_LOCKED_PERMANENT: 'A005',
+  ACCOUNT_LOCKED_TEMPORARY: 'A006',
   PERMISSION_DENIED_RESOURCE: 'PERM_001',
   PERMISSION_DENIED_ACTION: 'PERM_002',
 

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,7 +1,57 @@
 import { AxiosError } from 'axios';
 import { toast } from 'sonner';
-import type { ErrorResponse } from '../types/api.types';
+import type { ErrorResponse, AccountLockData } from '../types/api.types';
 import { ERROR_HANDLERS, LOGIN_ERROR_MESSAGES } from '../constants/errorCodes';
+
+/** 계정 잠금 상태 */
+export interface AccountLockState {
+  isLocked: boolean;
+  isPermanent: boolean;
+  lockedUntil?: Date;
+  remainingMinutes?: number;
+  message: string;
+}
+
+/**
+ * 에러 응답에서 계정 잠금 상태 추출
+ */
+export const getAccountLockState = (error: AxiosError<ErrorResponse>): AccountLockState | null => {
+  const errorData = error.response?.data;
+  const errorCode = errorData?.code;
+
+  if (errorCode === 'A005') {
+    return {
+      isLocked: true,
+      isPermanent: true,
+      message: LOGIN_ERROR_MESSAGES.A005,
+    };
+  }
+
+  if (errorCode === 'A006') {
+    const lockData = errorData?.data as AccountLockData | undefined;
+    return {
+      isLocked: true,
+      isPermanent: false,
+      lockedUntil: lockData?.lockedUntil ? new Date(lockData.lockedUntil) : undefined,
+      remainingMinutes: lockData?.remainingMinutes,
+      message: LOGIN_ERROR_MESSAGES.A006,
+    };
+  }
+
+  return null;
+};
+
+/**
+ * 남은 잠금 시간 포맷팅
+ */
+export const formatLockTime = (minutes: number): string => {
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return mins > 0 ? `${hours}시간 ${mins}분` : `${hours}시간`;
+  }
+  return `${minutes}분`;
+};
 
 export const handleApiError = (error: AxiosError<ErrorResponse>): void => {
   const errorData = error.response?.data;


### PR DESCRIPTION
## 변경 요약
- `src/constants/errorCodes.ts`: A005(영구잠금), A006(임시잠금) 에러 코드 추가
- `src/utils/errorHandler.ts`: 계정 잠금 상태 추출 및 시간 포맷팅 함수 추가
- `src/types/api.types.ts`: AccountLockData 타입 및 LoginResponse 확장
- `features/auth/LoginPage.tsx`: 잠금 상태 UI 및 카운트다운 구현

## 관련 이슈
- Closes #223

## 테스트 방법
1. 로그인 5회 실패 시 임시 잠금 UI 확인
   - 잠금 알림 박스 (amber 색상) 표시
   - 남은 시간 카운트다운 확인
   - 로그인 버튼 비활성화 확인
2. 로그인 10회 실패 시 영구 잠금 UI 확인
   - 잠금 알림 박스 (red 색상) 표시
   - 관리자 문의 안내 확인

## 명세 준수 체크
- [x] 에러 코드 추가: A005 (영구잠금), A006 (임시잠금)
- [x] 에러 메시지 추가
- [x] LoginPage.tsx 잠금 상태 UI
- [x] 남은 잠금 시간 표시
- [x] 잠금 해제 안내 메시지
- [x] 타입 추가 (AccountLockData, LoginResponse 확장)

## 리뷰 포인트
1. 잠금 카운트다운 UX가 적절한지 검토 부탁드립니다
2. 영구 잠금 시 관리자 연락처 노출 방식 검토 부탁드립니다

## TODO / 질문
- [ ] 잠금 해제 시 자동 리프레시 여부 논의 필요
- [ ] 남은 시도 횟수 경고 메시지 표시 여부 (백엔드 응답에 포함 시)