### PR TITLE
feat: #228 파일 업로드 페이지 UI 개선

### DIFF
--- a/src/api/aiRun.ts
+++ b/src/api/aiRun.ts
@@ -3,12 +3,16 @@ import type { BaseResponse } from '../types/api.types';
 
 export interface SlotStatus {
   slot_name: string;
+  display_name?: string;
   status: 'SUBMITTED' | 'MISSING';
 }
 
 export interface SlotHint {
   file_id: string;
   slot_name: string;
+  display_name?: string;
+  confidence?: number;
+  match_reason?: string;
 }
 
 export interface RunPreviewResponse {
@@ -28,6 +32,7 @@ export interface SlotResult {
 // 새 API 응답 타입
 export interface SlotResultDetail {
   slot_name: string;
+  display_name?: string;
   verdict: 'PASS' | 'WARN' | 'NEED_CLARIFY' | 'NEED_FIX';
   reasons: string[];
   file_ids: string[];
@@ -75,8 +80,11 @@ export const previewAiRun = async (
   return response.data.data;
 };
 
-export const submitAiRun = async (diagnosticId: number): Promise<void> => {
-  await apiClient.post(`/v1/ai/run/diagnostics/${diagnosticId}/submit`);
+export const submitAiRun = async (
+  diagnosticId: number,
+  slotHints: SlotHint[]
+): Promise<void> => {
+  await apiClient.post(`/v1/ai/run/diagnostics/${diagnosticId}/submit`, { slotHints });
 };
 
 export const getAiResult = async (diagnosticId: number): Promise<AiAnalysisResultResponse> => {

--- a/src/hooks/useAiRun.ts
+++ b/src/hooks/useAiRun.ts
@@ -19,8 +19,9 @@ export const useSubmitAiRun = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (diagnosticId: number) => aiRunApi.submitAiRun(diagnosticId),
-    onSuccess: (_, diagnosticId) => {
+    mutationFn: ({ diagnosticId, slotHints }: { diagnosticId: number; slotHints: aiRunApi.SlotHint[] }) =>
+      aiRunApi.submitAiRun(diagnosticId, slotHints),
+    onSuccess: (_, { diagnosticId }) => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.AI_RUN.RESULT(diagnosticId) });
     },
     onError: (error: AxiosError<ErrorResponse>) => {
@@ -29,17 +30,13 @@ export const useSubmitAiRun = () => {
   });
 };
 
-export const useAiResult = (diagnosticId: number, enabled = true) => {
+export const useAiResult = (diagnosticId: number, polling = false) => {
   return useQuery({
     queryKey: QUERY_KEYS.AI_RUN.RESULT(diagnosticId),
     queryFn: () => aiRunApi.getAiResult(diagnosticId),
-    enabled,
-    refetchInterval: (query) => {
-      if (query?.state?.error || !query?.state?.data) {
-        return 5000;
-      }
-      return false;
-    },
+    enabled: diagnosticId > 0,
+    // polling 파라미터가 true일 때만 5초마다 재시도
+    refetchInterval: polling ? 5000 : false,
     retry: false,
   });
 };


### PR DESCRIPTION
## 변경 요약
- 파일 삭제 시 업로드된 파일 리스트 및 체크리스트 즉시 갱신
- 체크리스트에 각 슬롯에 매칭된 파일명 표시 (`↳ 파일명.pdf`)
- `display_name` 필드 추가 및 슬롯명 대신 우선 표시

## 관련 이슈
- Closes #228
- Related #229 (백엔드 수정 필요)

## 테스트 방법
1. 파일 업로드 페이지 접속
2. 파일 업로드 후 "Add" 버튼 클릭 → 체크리스트에 매칭된 파일명 표시 확인
3. 파일 삭제 → 리스트 및 체크리스트 즉시 갱신 확인
4. "최종 제출" → 분석 결과에서 슬롯명이 display_name으로 표시되는지 확인

## 명세 준수 체크
- [x] `SlotStatus`에 `display_name` 필드 추가
- [x] `SlotHint`에 `display_name`, `confidence`, `match_reason` 필드 추가
- [x] `SlotResultDetail`에 `display_name` 필드 추가
- [x] Preview API 응답의 `display_name` 활용

## 리뷰 포인트
- `handleDeleteFile`에서 `callPreview` 재호출 시점이 적절한지
- `slotDisplayNames` 매핑 생성 로직

## TODO / 질문
- [ ] 백엔드: Preview API에서 파일 삭제 후 슬롯 상태가 `SUBMITTED` → `MISSING`으로 변경되어야 함 (#228)
- [ ] 백엔드: AI Server 호출 시 domain 소문자 변환 확인 필요 (#229)