### PR TITLE
fix: LoginPage hooks 호출 순서 수정

### DIFF
--- a/features/auth/LoginPage.tsx
+++ b/features/auth/LoginPage.tsx
@@ -148,13 +148,6 @@ export default function LoginPage() {
     return () => clearInterval(timer);
   }, [remainingSeconds]);
 
-  // 이미 인증된 사용자는 대시보드로 리다이렉트
-  if (isAuthenticated) {
-    return <Navigate to="/dashboard" replace />;
-  }
-
-  const isAccountLocked = lockState?.isLocked && !lockState.isPermanent && remainingSeconds > 0;
-
   const onSubmit = useCallback(async (data: LoginFormData) => {
     if (!executeRecaptcha) {
       console.error('reCAPTCHA not loaded');
@@ -165,9 +158,16 @@ export default function LoginPage() {
     loginMutation.mutate({ ...data, recaptchaToken });
   }, [executeRecaptcha, loginMutation]);
 
-  const handleSignup = () => {
+  const handleSignup = useCallback(() => {
     navigate('/signup/step1');
-  };
+  }, [navigate]);
+
+  // 이미 인증된 사용자는 대시보드로 리다이렉트
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  const isAccountLocked = lockState?.isLocked && !lockState.isPermanent && remainingSeconds > 0;
 
   return (
     <div className="bg-[var(--color-page-bg)] h-screen w-full flex flex-col overflow-hidden md:overflow-hidden overflow-y-auto">


### PR DESCRIPTION
## Summary
- LoginPage에서 React hooks 규칙 위반으로 인한 에러 수정
- 로그인 시 "Rendered fewer hooks than expected" 에러 해결

## Problem
`useCallback` hooks가 조건부 early return (`if (isAuthenticated)`) 이후에 호출되어 React hooks 규칙을 위반

## Solution
- `onSubmit` useCallback을 조건부 return 이전으로 이동
- `handleSignup`도 useCallback으로 변경하여 일관성 유지

## Test plan
- [ ] 로그인 페이지 접속 시 에러 없이 정상 렌더링 확인
- [ ] 로그인 기능 정상 동작 확인