### PR TITLE
feat: #236 파일 업로드 UI 개선 및 분석 결과 상세페이지 이동

### DIFF
--- a/features/approvals/ApprovalsListPage.tsx
+++ b/features/approvals/ApprovalsListPage.tsx
@@ -95,16 +95,15 @@ export default function ApprovalsListPage() {
               <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
                 <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
                 <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
                 <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기안자</th>
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제출일</th>
+                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">요청일</th>
                 <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
               </tr>
             </thead>
             <tbody>
               {isLoading && (
                 <tr>
-                  <td colSpan={6} className="text-center py-[60px]">
+                  <td colSpan={5} className="text-center py-[60px]">
                     <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
                   </td>
                 </tr>
@@ -112,7 +111,7 @@ export default function ApprovalsListPage() {
 
               {isError && (
                 <tr>
-                  <td colSpan={6} className="text-center py-[60px]">
+                  <td colSpan={5} className="text-center py-[60px]">
                     <p className="font-body-medium text-[var(--color-state-error-text)]">
                       결재 목록을 불러오는 데 실패했습니다.
                     </p>
@@ -122,7 +121,7 @@ export default function ApprovalsListPage() {
 
               {!isLoading && !isError && approvals.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="text-center py-[60px]">
+                  <td colSpan={5} className="text-center py-[60px]">
                     <p className="font-body-medium text-[var(--color-text-tertiary)]">
                       결재 내역이 없습니다.
                     </p>
@@ -137,19 +136,16 @@ export default function ApprovalsListPage() {
                   className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
                 >
                   <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
-                    {item.title}
+                    {item.diagnostic?.title}
                   </td>
                   <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
                     {DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
                   </td>
                   <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
-                    {item.companyName}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
-                    {item.drafterName}
+                    {item.requester?.name}
                   </td>
                   <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]">
-                    {new Date(item.submittedAt).toLocaleDateString('ko-KR')}
+                    {new Date(item.requestedAt).toLocaleDateString('ko-KR')}
                   </td>
                   <td className="px-[16px] py-[14px] text-center">
                     <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -5,9 +5,52 @@ import {
   useDiagnosticHistory,
   useSubmitDiagnostic,
 } from '../../src/hooks/useDiagnostics';
-import type { DiagnosticStatus, DomainCode } from '../../src/types/api.types';
+import { useAiResult } from '../../src/hooks/useAiRun';
+import type { DiagnosticStatus, DomainCode, RiskLevel } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
+import type { AiAnalysisResultResponse, SlotResultDetail } from '../../src/api/aiRun';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
+
+type Verdict = 'PASS' | 'WARN' | 'NEED_CLARIFY' | 'NEED_FIX';
+
+const VERDICT_LABELS: Record<Verdict, string> = {
+  PASS: '적합',
+  WARN: '경고',
+  NEED_CLARIFY: '확인 필요',
+  NEED_FIX: '수정 필요',
+};
+
+const VERDICT_STYLES: Record<Verdict, string> = {
+  PASS: 'bg-green-100 text-green-700 border-green-200',
+  WARN: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+  NEED_CLARIFY: 'bg-orange-100 text-orange-700 border-orange-200',
+  NEED_FIX: 'bg-red-100 text-red-700 border-red-200',
+};
+
+const RISK_LABELS: Record<RiskLevel, string> = {
+  LOW: '낮음',
+  MEDIUM: '중간',
+  HIGH: '높음',
+};
+
+const RISK_STYLES: Record<RiskLevel, string> = {
+  LOW: 'bg-green-50 text-green-700',
+  MEDIUM: 'bg-yellow-50 text-yellow-700',
+  HIGH: 'bg-red-50 text-red-700',
+};
+
+const REASON_LABELS: Record<string, string> = {
+  MISSING_SLOT: '필수 슬롯 누락',
+  HEADER_MISMATCH: '필수 헤더(컬럼) 누락',
+  EMPTY_TABLE: '표/데이터 행이 비어있음',
+  OCR_FAILED: 'OCR 판독 불가/텍스트 추출 실패',
+  WRONG_YEAR: '문서 대상 연도 불일치',
+  PARSE_FAILED: '파싱 실패',
+  DATE_MISMATCH: '기간 불일치',
+  UNIT_MISSING: '단위 누락',
+  EVIDENCE_MISSING: '근거문서 누락',
+  SIGNATURE_MISSING: '확인 서명란 미기재',
+};
 
 const STATUS_LABELS: Record<DiagnosticStatus, string> = {
   WRITING: '작성중',
@@ -34,6 +77,7 @@ export default function DiagnosticDetailPage() {
 
   const { data: diagnostic, isLoading, isError } = useDiagnosticDetail(diagnosticId);
   const { data: history } = useDiagnosticHistory(diagnosticId);
+  const { data: aiResult } = useAiResult(diagnosticId);
   const submitMutation = useSubmitDiagnostic();
 
   const [showSubmitModal, setShowSubmitModal] = useState(false);
@@ -106,7 +150,7 @@ export default function DiagnosticDetailPage() {
 
         {/* 제목 + 상태 */}
         <div className="flex items-start justify-between gap-[16px]">
-          <h1 className="font-heading-small text-[var(--color-text-primary)]">{diagnostic.campaign?.title || diagnostic.diagnosticCode}</h1>
+          <h1 className="font-heading-small text-[var(--color-text-primary)]">{diagnostic.title || diagnostic.summary || diagnostic.diagnosticCode}</h1>
           <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[diagnostic.status] || 'bg-gray-50 text-gray-700 border-gray-200'}`}>
             {diagnostic.statusLabel || STATUS_LABELS[diagnostic.status] || diagnostic.status}
           </span>
@@ -116,6 +160,7 @@ export default function DiagnosticDetailPage() {
         <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] p-[24px]">
           <h2 className="font-title-medium text-[var(--color-text-primary)] mb-[20px]">기안 정보</h2>
           <div className="grid grid-cols-2 gap-[20px]">
+            <InfoRow label="기안명" value={diagnostic.title || diagnostic.summary || diagnostic.diagnosticCode || '-'} />
             <InfoRow label="도메인" value={diagnostic.domain?.name || DOMAIN_LABELS[diagnostic.domain?.code as DomainCode] || '-'} />
             <InfoRow label="회사명" value={diagnostic.company?.companyName || '-'} />
             <InfoRow label="기안자" value={diagnostic.createdBy?.name || '-'} />
@@ -127,6 +172,11 @@ export default function DiagnosticDetailPage() {
             )}
           </div>
         </div>
+
+        {/* AI 분석 결과 */}
+        {aiResult && (
+          <AiResultSection result={aiResult} />
+        )}
 
         {/* 이력 */}
         {history && history.length > 0 && (
@@ -244,6 +294,111 @@ function InfoRow({ label, value, valueClassName }: { label: string; value: strin
     <div>
       <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">{label}</p>
       <p className={`font-body-medium ${valueClassName || 'text-[var(--color-text-primary)]'}`}>{value}</p>
+    </div>
+  );
+}
+
+function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
+  const verdict = result.verdict as Verdict;
+  const riskLevel = result.riskLevel as RiskLevel;
+  const details = result.details;
+
+  return (
+    <div className="bg-white rounded-[12px] border border-[var(--color-border-default)] overflow-hidden">
+      <div className="px-[24px] py-[20px] border-b border-[var(--color-border-default)]">
+        <h2 className="font-title-medium text-[var(--color-text-primary)]">
+          AI 분석 결과
+        </h2>
+      </div>
+
+      <div className="p-[24px] space-y-[24px]">
+        {/* 판정 결과 */}
+        <div className="flex items-center gap-[16px]">
+          <div className={`px-[16px] py-[10px] rounded-[8px] border ${VERDICT_STYLES[verdict]}`}>
+            <span className="font-title-medium">{VERDICT_LABELS[verdict]}</span>
+          </div>
+          <div className={`px-[12px] py-[6px] rounded-full ${RISK_STYLES[riskLevel]}`}>
+            <span className="font-title-xsmall">위험도: {RISK_LABELS[riskLevel]}</span>
+          </div>
+        </div>
+
+        {/* 요약 */}
+        <div>
+          <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">분석 요약</p>
+          <p className="font-body-medium text-[var(--color-text-primary)] leading-[1.6]">
+            {result.whySummary}
+          </p>
+        </div>
+
+        {/* 슬롯별 결과 */}
+        {details?.slot_results && details.slot_results.length > 0 && (
+          <div>
+            <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[12px]">
+              슬롯별 분석 결과
+            </p>
+            <div className="space-y-[12px]">
+              {details.slot_results.map((slotResult, index) => (
+                <SlotResultCard key={index} result={slotResult} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 분석 정보 */}
+        <div className="grid grid-cols-2 gap-[16px] pt-[16px] border-t border-[var(--color-border-default)]">
+          <div>
+            <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">도메인</p>
+            <p className="font-body-medium text-[var(--color-text-primary)]">
+              {DOMAIN_LABELS[result.domainCode as DomainCode] || result.domainCode}
+            </p>
+          </div>
+          <div>
+            <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">분석 일시</p>
+            <p className="font-body-medium text-[var(--color-text-primary)]">
+              {new Date(result.analyzedAt).toLocaleString('ko-KR')}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SlotResultCard({ result }: { result: SlotResultDetail }) {
+  const verdict = result.verdict as Verdict;
+  const displayName = result.display_name || result.slot_name;
+
+  return (
+    <div className="p-[16px] bg-gray-50 rounded-[12px]">
+      <div className="flex items-center justify-between mb-[8px]">
+        <span className="font-title-small text-[var(--color-text-primary)]">
+          {displayName}
+        </span>
+        <span className={`px-[8px] py-[2px] rounded text-xs font-medium border ${VERDICT_STYLES[verdict]}`}>
+          {VERDICT_LABELS[verdict]}
+        </span>
+      </div>
+
+      {result.reasons && result.reasons.length > 0 && (
+        <ul className="space-y-[4px] mt-[8px]">
+          {result.reasons.map((reason, index) => (
+            <li key={index} className="flex items-start gap-[6px] font-body-small text-[var(--color-text-secondary)]">
+              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[6px] flex-shrink-0" />
+              {REASON_LABELS[reason] || reason}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {result.file_names && result.file_names.length > 0 && (
+        <div className="mt-[8px] flex flex-wrap gap-[6px]">
+          {result.file_names.map((fileName, index) => (
+            <span key={index} className="px-[8px] py-[2px] bg-white text-xs text-gray-600 rounded border border-gray-200">
+              {fileName}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -19,6 +19,8 @@ export interface DiagnosticListItem {
 export interface DiagnosticDetail {
   diagnosticId: number;
   diagnosticCode: string;
+  title?: string;
+  summary?: string;
   domain: { domainId: number; code: string; name: string };
   campaign: { campaignId: number; campaignCode: string; title: string; disclosureStandards?: string[] };
   company: { companyId: number; companyName: string; industryCode?: string | null };


### PR DESCRIPTION
## 변경요약
- **파일 업로드 페이지 UI 개선**
  - 최종 제출 버튼을 우측 체크리스트 하단으로 이동
  - 파일 목록 접기/펼치기 토글 기능 추가 (헤더 클릭)
  - Add 버튼 클릭 시 파일 목록 자동 접힘
  - 분석 중 별도 스피너 섹션 제거 (버튼 내 스피너로 대체)
  - 미사용 컴포넌트/상수/타입 정리

- **AI 분석 결과 표시 위치 변경**
  - 파일 업로드 페이지 → 기안 상세 페이지로 이동
  - 분석 완료 시 상세 페이지로 자동 리다이렉트

- **기안명 표시 개선**
  - DiagnosticDetail 타입에 title, summary 필드 추가
  - 기안 정보에 '기안명' 행 추가
  - 표시 우선순위: title → summary → diagnosticCode

- **결재 목록 테이블 정리**
  - 회사명 컬럼 제거
  - 제출일 → 요청일 라벨 변경

## 관련이슈
- Closes #236
- Related to #228

## 테스트방법
1. 새 기안 생성 후 파일 업로드 페이지 진입
2. 파일 업로드 후 "업로드된 파일" 헤더 클릭하여 접기/펼치기 확인
3. Add 버튼 클릭 시 파일 목록 자동 접힘 확인
4. 최종 제출 버튼이 우측 체크리스트 아래에 위치하는지 확인
5. AI 분석 실행 후 기안 상세 페이지로 리다이렉트 확인
6. 기안 상세 페이지에서 AI 분석 결과 표시 확인
7. 기안 정보에 기안명이 올바르게 표시되는지 확인

## 명세준수 체크
- [x] 파일 업로드 UI 레이아웃 변경
- [x] AI 분석 결과 위치 이동
- [x] 기안명 필드 추가
- [x] 미사용 코드 정리

## 리뷰포인트
- 파일 목록 접기 UX가 적절한지
- 기안명 표시 우선순위(title → summary → diagnosticCode)가 적절한지

## TODO / 질문
- [ ] 백엔드: AI 분석 결과의 slot_results에 display_name 포함 필요
- [ ] 백엔드: DiagnosticDetail 응답에 title 필드 포함 필요