### PR TITLE
fix: DocumentReviewPage 뒤로가기 도메인 동적 처리

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -51,6 +51,11 @@ function formatPeriod(dateStr: string): string {
   return `${d.getFullYear()}년 ${String(d.getMonth() + 1).padStart(2, '0')}월`;
 }
 
+function getDomainPath(domainCode?: string): string {
+  const domain = domainCode?.toLowerCase() || 'safety';
+  return `/dashboard/${domain}`;
+}
+
 export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps) {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
@@ -62,8 +67,10 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
 
+  const domainPath = getDomainPath(review?.domainCode);
+
   const handleBackToList = () => {
-    navigate('/dashboard/safety');
+    navigate(domainPath);
   };
 
   const handleReject = () => {
@@ -73,7 +80,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const handleApprove = () => {
     submitReview.mutate(
       { id: reviewId, data: { decision: 'APPROVED' } },
-      { onSuccess: () => navigate('/dashboard/safety') }
+      { onSuccess: () => navigate(domainPath) }
     );
   };
 
@@ -84,7 +91,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
       {
         onSuccess: () => {
           setShowRejectModal(false);
-          navigate('/dashboard/safety');
+          navigate(domainPath);
         },
       }
     );
@@ -93,7 +100,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const handleSubmitToApprover = () => {
     submitReview.mutate(
       { id: reviewId, data: { decision: 'APPROVED' } },
-      { onSuccess: () => navigate('/dashboard/safety') }
+      { onSuccess: () => navigate(domainPath) }
     );
   };
 


### PR DESCRIPTION
## Summary
- DocumentReviewPage에서 뒤로가기가 무조건 `/dashboard/safety`로 고정되어 있던 문제 수정
- `review.domainCode`를 사용하여 해당 도메인 페이지로 이동하도록 변경

## Changes
- `getDomainPath` 헬퍼 함수 추가
- `handleBackToList`, `handleApprove`, `handleRequestFix`, `handleSubmitToApprover`에서 동적 도메인 경로 사용

## Test plan
- [ ] safety 도메인 review 페이지에서 뒤로가기 시 `/dashboard/safety`로 이동 확인
- [ ] compliance 도메인 review 페이지에서 뒤로가기 시 `/dashboard/compliance`로 이동 확인
- [ ] esg 도메인 review 페이지에서 뒤로가기 시 `/dashboard/esg`로 이동 확인