### PR TITLE
fix: #235 reCAPTCHA 전역 적용 제거 및 로그인 후 흰 화면 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
 import { Toaster } from 'sonner';
 import { useAuthStore } from './src/store/authStore';
 import { useMe } from './src/hooks/useAuth';
@@ -334,16 +333,11 @@ function AppRoutes() {
 
 export default function App() {
   return (
-    <GoogleReCaptchaProvider
-      reCaptchaKey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
-      language="ko"
-    >
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
-        <Toaster position="top-right" richColors />
-      </QueryClientProvider>
-    </GoogleReCaptchaProvider>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+      <Toaster position="top-right" richColors />
+    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## 변경 요약
- `GoogleReCaptchaProvider`를 `App.tsx`에서 제거하고 `LoginPage.tsx`에서만 적용
- 로그인 후 흰 화면 문제 해결: 동기 `<Navigate>` 대신 `useEffect` 비동기 리다이렉트 방식으로 변경

## 관련 이슈
- Closes #235

## 테스트 방법
1. **reCAPTCHA 범위 확인**
   - 로그인 페이지 접속 → 개발자 도구 Network 탭에서 recaptcha 스크립트 로드 확인
   - 대시보드 등 다른 페이지 접속 → recaptcha 스크립트가 로드되지 않음 확인

2. **로그인 후 리다이렉트 확인**
   - 로그인 페이지에서 정상 로그인
   - 흰 화면 없이 대시보드로 바로 이동하는지 확인
   - 새로고침 없이 정상 표시되는지 확인

3. **이미 로그인된 상태에서 /login 접속**
   - 로그인 상태에서 직접 /login URL 접속
   - 자동으로 대시보드로 리다이렉트되는지 확인

## 명세 준수 체크
- [x] reCAPTCHA는 로그인/회원가입 페이지에서만 적용
- [x] 로그인 성공 시 대시보드로 정상 이동
- [x] 기존 로그인 기능 정상 동작

## 리뷰 포인트
1. `LoginForm` 컴포넌트 분리 및 `GoogleReCaptchaProvider` 래핑 구조가 적절한지
2. `useEffect` 조건 `isAuthenticated && !loginMutation.isPending`이 모든 케이스를 커버하는지

## TODO / 질문
- [ ] 회원가입 페이지에서도 reCAPTCHA가 필요한 경우 동일한 패턴으로 적용 필요