### PR TITLE
feat: #241 기안 리스트 제목 칼럼 추가 (기안자/수신자 뷰)

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -100,7 +100,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
     if (isLoading) {
       return (
         <tr>
-          <td colSpan={4} className="py-[48px] text-center">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-[48px] text-center">
             <div className="flex justify-center">
               <div className="animate-spin rounded-full h-[32px] w-[32px] border-b-2 border-[#003087]" />
             </div>
@@ -112,7 +112,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
     if (isError) {
       return (
         <tr>
-          <td colSpan={4} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
             데이터를 불러오는데 실패했습니다.
           </td>
         </tr>
@@ -124,7 +124,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+            <td colSpan={5} className="py-[48px] text-center text-[#868e96] font-body-medium">
               등록된 기안이 없습니다.
             </td>
           </tr>
@@ -137,7 +137,10 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
           onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.summary || '-'}
+            {item.title || item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.diagnosticCode || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
@@ -198,7 +201,7 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+            <td colSpan={5} className="py-[48px] text-center text-[#868e96] font-body-medium">
               심사 대상이 없습니다.
             </td>
           </tr>
@@ -211,6 +214,9 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
           onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.diagnostic?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
@@ -256,6 +262,11 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
             <table className="w-full">
               <thead>
                 <tr className="border-b border-[#dee2e6]">
+                  {(userRole === 'drafter' || userRole === 'receiver') && (
+                    <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
+                      제목
+                    </th>
+                  )}
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                     {userRole === 'approver' ? '기안자' : '협력사 명'}
                   </th>

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -100,7 +100,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
     if (isLoading) {
       return (
         <tr>
-          <td colSpan={4} className="py-[48px] text-center">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-[48px] text-center">
             <div className="flex justify-center">
               <div className="animate-spin rounded-full h-[32px] w-[32px] border-b-2 border-[#003087]" />
             </div>
@@ -112,7 +112,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
     if (isError) {
       return (
         <tr>
-          <td colSpan={4} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
             데이터를 불러오는데 실패했습니다.
           </td>
         </tr>
@@ -124,7 +124,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+            <td colSpan={5} className="py-[48px] text-center text-[#868e96] font-body-medium">
               등록된 기안이 없습니다.
             </td>
           </tr>
@@ -137,7 +137,10 @@ export default function ESGPage({ userRole }: ESGPageProps) {
           onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.summary || '-'}
+            {item.title || item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.diagnosticCode || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
@@ -198,7 +201,7 @@ export default function ESGPage({ userRole }: ESGPageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+            <td colSpan={5} className="py-[48px] text-center text-[#868e96] font-body-medium">
               심사 대상이 없습니다.
             </td>
           </tr>
@@ -211,6 +214,9 @@ export default function ESGPage({ userRole }: ESGPageProps) {
           onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.diagnostic?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
@@ -256,6 +262,11 @@ export default function ESGPage({ userRole }: ESGPageProps) {
             <table className="w-full">
               <thead>
                 <tr className="border-b border-[#dee2e6]">
+                  {(userRole === 'drafter' || userRole === 'receiver') && (
+                    <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
+                      제목
+                    </th>
+                  )}
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                     {userRole === 'approver' ? '기안자' : '협력사 명'}
                   </th>

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -343,7 +343,7 @@ export default function HomePage({ userRole }: HomePageProps) {
     if (isLoading) {
       return (
         <tr>
-          <td colSpan={4} className="py-8">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-8">
             <LoadingSkeleton />
           </td>
         </tr>
@@ -353,7 +353,7 @@ export default function HomePage({ userRole }: HomePageProps) {
     if (isError) {
       return (
         <tr>
-          <td colSpan={4}>
+          <td colSpan={userRole === 'approver' ? 4 : 5}>
             <ErrorState message="데이터를 불러오는데 실패했습니다." onRetry={() => refetch()} />
           </td>
         </tr>
@@ -366,7 +366,7 @@ export default function HomePage({ userRole }: HomePageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4}>
+            <td colSpan={5}>
               <EmptyState message="등록된 기안이 없습니다." />
             </td>
           </tr>
@@ -379,7 +379,10 @@ export default function HomePage({ userRole }: HomePageProps) {
           onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.summary || '-'}
+            {item.title || item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.diagnosticCode || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
@@ -406,6 +409,7 @@ export default function HomePage({ userRole }: HomePageProps) {
           <tr>
             <td colSpan={4}>
               <EmptyState message="대기 중인 결재가 없습니다." />
+
             </td>
           </tr>
         );
@@ -442,7 +446,7 @@ export default function HomePage({ userRole }: HomePageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4}>
+            <td colSpan={5}>
               <EmptyState message="심사 대상이 없습니다." />
             </td>
           </tr>
@@ -455,6 +459,9 @@ export default function HomePage({ userRole }: HomePageProps) {
           onClick={() => handleReviewClick(item.reviewId, item.domainCode)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.diagnostic?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
@@ -549,6 +556,11 @@ export default function HomePage({ userRole }: HomePageProps) {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-[#dee2e6]">
+                    {(userRole === 'drafter' || userRole === 'receiver') && (
+                      <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
+                        제목
+                      </th>
+                    )}
                     <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                       {userRole === 'drafter' ? '회사명' : '협력사 명'}
                     </th>

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -100,7 +100,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
     if (isLoading) {
       return (
         <tr>
-          <td colSpan={4} className="py-[48px] text-center">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-[48px] text-center">
             <div className="flex justify-center">
               <div className="animate-spin rounded-full h-[32px] w-[32px] border-b-2 border-[#003087]" />
             </div>
@@ -112,7 +112,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
     if (isError) {
       return (
         <tr>
-          <td colSpan={4} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="py-[48px] text-center text-[#b91c1c] font-body-medium">
             데이터를 불러오는데 실패했습니다.
           </td>
         </tr>
@@ -124,7 +124,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+            <td colSpan={5} className="py-[48px] text-center text-[#868e96] font-body-medium">
               등록된 기안이 없습니다.
             </td>
           </tr>
@@ -137,7 +137,10 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
           onClick={() => handleDiagnosticClick(item.diagnosticId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
-            {item.summary || '-'}
+            {item.title || item.summary || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
+            {item.diagnosticCode || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
@@ -198,7 +201,7 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="py-[48px] text-center text-[#868e96] font-body-medium">
+            <td colSpan={5} className="py-[48px] text-center text-[#868e96] font-body-medium">
               심사 대상이 없습니다.
             </td>
           </tr>
@@ -211,6 +214,9 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
           onClick={() => handleReviewClick(item.reviewId)}
         >
           <td className="py-[16px] px-[16px] font-body-small text-[#212529]">
+            {item.diagnostic?.title || '-'}
+          </td>
+          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.company?.companyName || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
@@ -256,6 +262,11 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
             <table className="w-full">
               <thead>
                 <tr className="border-b border-[#dee2e6]">
+                  {(userRole === 'drafter' || userRole === 'receiver') && (
+                    <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
+                      제목
+                    </th>
+                  )}
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                     {userRole === 'approver' ? '기안자' : '협력사 명'}
                   </th>

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -179,6 +179,7 @@ export default function DiagnosticsListPage() {
     if (userRole === 'reviewer') {
       return (
         <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
+          <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
           <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
           <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
           <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제출일</th>
@@ -202,7 +203,7 @@ export default function DiagnosticsListPage() {
     if (isLoading) {
       return (
         <tr>
-          <td colSpan={4} className="text-center py-[60px]">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="text-center py-[60px]">
             <div className="inline-block w-[32px] h-[32px] border-[3px] border-[var(--color-primary-main)] border-t-transparent rounded-full animate-spin" />
           </td>
         </tr>
@@ -212,7 +213,7 @@ export default function DiagnosticsListPage() {
     if (isError) {
       return (
         <tr>
-          <td colSpan={4} className="text-center py-[60px]">
+          <td colSpan={userRole === 'approver' ? 4 : 5} className="text-center py-[60px]">
             <p className="font-body-medium text-[var(--color-state-error-text)]">
               데이터를 불러오는 데 실패했습니다.
             </p>
@@ -263,7 +264,7 @@ export default function DiagnosticsListPage() {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={4} className="text-center py-[60px]">
+            <td colSpan={5} className="text-center py-[60px]">
               <p className="font-body-medium text-[var(--color-text-tertiary)]">
                 심사 대상이 없습니다.
               </p>
@@ -278,6 +279,9 @@ export default function DiagnosticsListPage() {
           className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
         >
           <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
+            {item.diagnostic?.title || '-'}
+          </td>
+          <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
             {item.company?.companyName || '-'}
           </td>
           <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
@@ -315,7 +319,7 @@ export default function DiagnosticsListPage() {
         className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
       >
         <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]">
-          {item.summary || item.campaign?.title || '-'}
+          {item.title || item.summary || '-'}
         </td>
         <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]">
           {item.campaign?.title || '-'}

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -4,6 +4,7 @@ import type { BaseResponse, PagedData, DiagnosticStatus } from '../types/api.typ
 export interface DiagnosticListItem {
   diagnosticId: number;
   diagnosticCode: string;
+  title?: string;
   domain: { domainId: number; code: string; name: string };
   campaign: { campaignId: number; campaignCode: string; title: string };
   summary: string;

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -15,6 +15,7 @@ export interface ReviewListItem {
   diagnostic: {
     diagnosticId: number;
     diagnosticCode: string;
+    title?: string;
   };
   company: {
     companyId: number;


### PR DESCRIPTION
## 변경 요약
- 기안자 뷰: `summary` → `title || summary`로 제목 표시 변경, `diagnosticCode` 칼럼 추가
- 수신자(심사자) 뷰: "제목" 칼럼 신규 추가 (`diagnostic.title`)
- `ReviewListItem.diagnostic` 타입에 `title?: string` 필드 추가
- `DiagnosticListItem` 타입에 `title?: string` 필드 추가
- 결재자 뷰는 기존 "기안명" 칼럼에서 이미 title을 표시하므로 변경 없음

### 변경 파일
| 파일 | 변경 내용 |
|---|---|
| `src/api/reviews.ts` | `ReviewListItem.diagnostic`에 `title` 필드 추가 |
| `src/api/diagnostics.ts` | `DiagnosticListItem`에 `title` 필드 추가 |
| `features/dashboard/HomePage.tsx` | 수신자 뷰 제목 칼럼 추가 |
| `features/dashboard/ESGPage.tsx` | 동일 |
| `features/dashboard/CompliancePage.tsx` | 동일 |
| `features/dashboard/SafetyPage.tsx` | 동일 |
| `features/diagnostics/DiagnosticsListPage.tsx` | 수신자(reviewer) 뷰 제목 칼럼 추가 |

## 관련 이슈
- closes #241

## 테스트 방법
1. **기안자 계정**으로 로그인 → 대시보드/ESG/안전보건/컴플라이언스 페이지에서 기안 리스트에 "제목" 칼럼이 표시되는지 확인
2. **수신자(심사자) 계정**으로 로그인 → 동일 페이지에서 "제목" 칼럼이 첫 번째 칼럼으로 표시되는지 확인
3. **결재자 계정**으로 로그인 → 기존과 동일하게 "기안명" 칼럼에 title이 표시되는지 확인
4. 빈 리스트/로딩/에러 상태에서 colSpan이 올바르게 적용되는지 확인

## 명세 준수 체크
- [x] 기안자 뷰에 제목 칼럼 추가
- [x] 수신자 뷰에 제목 칼럼 추가
- [x] 결재자 뷰는 기존 유지
- [x] colSpan 값 역할별 동적 조정
- [x] TypeScript 타입 에러 없음

## 리뷰 포인트
- 수신자 뷰의 `diagnostic.title`은 백엔드 `/v1/reviews` API 응답에 포함되어야 실제 표시됨 (현재 미포함 시 `-` 표시)
- 기안자 뷰의 `diagnosticCode` 칼럼이 추가된 것은 기존 변경사항에 포함된 내용

## TODO / 질문
- [ ] 백엔드 `/v1/reviews` API 응답의 `diagnostic` 객체에 `title` 필드 추가 요청 필요
- [ ] 결재자 뷰에도 별도 "제목" 칼럼 분리가 필요한지 확인