### PR TITLE
fix: #249 도메인 접근 권한 없을 때 대시보드로 리다이렉트

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -83,7 +83,7 @@ function DomainProtectedRoute({ children, domainCode }: DomainProtectedRouteProp
   }
 
   if (!hasDomainAccess(domainCode)) {
-    return <Navigate to="/permission/request" replace />;
+    return <Navigate to="/dashboard" replace />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- `DomainProtectedRoute`에서 `hasDomainAccess`가 false일 때 `/permission/request` 대신 `/dashboard`로 리다이렉트

## 변경 사항
- 도메인 접근 권한이 없는 사용자는 대시보드로 이동하여 접근 가능한 도메인 확인 가능

## Test plan
- [ ] 특정 도메인 권한이 없는 사용자가 해당 도메인 페이지 접근 시 대시보드로 리다이렉트 확인

Closes #249