### PR TITLE
fix: #243 권한 없는 도메인 접근 차단

### DIFF
--- a/features/approvals/ApprovalsListPage.tsx
+++ b/features/approvals/ApprovalsListPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApprovals } from '../../src/hooks/useApprovals';
+import { useAccessibleDomainOptions } from '../../src/hooks/useDomainGuard';
 import type { ApprovalStatus } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
 import type { DomainCode } from '../../src/types/api.types';
@@ -22,6 +23,7 @@ type StatusFilter = ApprovalStatus | 'ALL';
 
 export default function ApprovalsListPage() {
   const navigate = useNavigate();
+  const { domainOptions: accessibleDomainOptions } = useAccessibleDomainOptions();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const [domainFilter, setDomainFilter] = useState<string>('');
   const [page, setPage] = useState(0);
@@ -44,11 +46,10 @@ export default function ApprovalsListPage() {
     { key: 'REJECTED', label: '반려' },
   ];
 
+  // 사용자가 접근 가능한 도메인만 필터 옵션으로 표시
   const domainOptions: { value: string; label: string }[] = [
     { value: '', label: '전체 도메인' },
-    { value: 'ESG', label: DOMAIN_LABELS.ESG },
-    { value: 'SAFETY', label: DOMAIN_LABELS.SAFETY },
-    { value: 'COMPLIANCE', label: DOMAIN_LABELS.COMPLIANCE },
+    ...accessibleDomainOptions,
   ];
 
   return (

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import { useApprovals } from '../../src/hooks/useApprovals';
 import { useReviews } from '../../src/hooks/useReviews';
 import { useAuthStore } from '../../src/store/authStore';
-import type { DiagnosticStatus, ApprovalStatus, ReviewStatus, DomainCode } from '../../src/types/api.types';
+import { useDomainGuard } from '../../src/hooks/useDomainGuard';
+import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 
@@ -62,8 +63,7 @@ function formatDate(dateString?: string): string {
 
 export default function DiagnosticsListPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const domainCode = searchParams.get('domainCode') as DomainCode | null;
+  const { validatedDomainCode: domainCode } = useDomainGuard();
   const { user } = useAuthStore();
 
   // 역할 결정

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useReviews, useBulkReport, useExportReviews } from '../../src/hooks/useReviews';
+import { useAccessibleDomainOptions } from '../../src/hooks/useDomainGuard';
 import type { ReviewStatus, RiskLevel, DomainCode } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
@@ -34,6 +35,7 @@ type RiskFilter = RiskLevel | 'ALL';
 
 export default function ReviewsListPage() {
   const navigate = useNavigate();
+  const { domainOptions: accessibleDomainOptions } = useAccessibleDomainOptions();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const [domainFilter, setDomainFilter] = useState('');
   const [riskFilter, setRiskFilter] = useState<RiskFilter>('ALL');
@@ -114,9 +116,9 @@ export default function ReviewsListPage() {
             className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
           >
             <option value="">전체 도메인</option>
-            <option value="ESG">{DOMAIN_LABELS.ESG}</option>
-            <option value="SAFETY">{DOMAIN_LABELS.SAFETY}</option>
-            <option value="COMPLIANCE">{DOMAIN_LABELS.COMPLIANCE}</option>
+            {accessibleDomainOptions.map((opt: { value: string; label: string }) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
           </select>
 
           <select

--- a/src/hooks/useDomainGuard.ts
+++ b/src/hooks/useDomainGuard.ts
@@ -1,0 +1,101 @@
+import { useEffect, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuthStore } from '../store/authStore';
+import type { DomainCode } from '../types/api.types';
+
+const VALID_DOMAIN_CODES: DomainCode[] = ['ESG', 'SAFETY', 'COMPLIANCE'];
+
+interface UseDomainGuardOptions {
+  redirectOnUnauthorized?: boolean;
+  redirectPath?: string;
+}
+
+interface UseDomainGuardResult {
+  /** URL에서 가져온 domainCode (검증 전) */
+  rawDomainCode: DomainCode | null;
+  /** 검증된 domainCode (권한 있는 경우에만) */
+  validatedDomainCode: DomainCode | undefined;
+  /** 사용자가 접근 가능한 도메인 목록 */
+  accessibleDomains: DomainCode[];
+  /** 현재 domainCode에 대한 접근 권한 여부 */
+  hasAccess: boolean;
+  /** 유효하지 않은 domainCode인지 여부 */
+  isInvalidDomainCode: boolean;
+}
+
+/**
+ * URL의 domainCode 쿼리 파라미터를 검증하고 사용자 권한을 체크하는 훅
+ *
+ * @param options.redirectOnUnauthorized - 권한 없을 때 리다이렉트 여부 (기본: true)
+ * @param options.redirectPath - 리다이렉트 경로 (기본: '/permission/request')
+ */
+export function useDomainGuard(options: UseDomainGuardOptions = {}): UseDomainGuardResult {
+  const { redirectOnUnauthorized = true, redirectPath = '/permission/request' } = options;
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { hasDomainAccess, getAccessibleDomains } = useAuthStore();
+
+  const rawDomainCode = searchParams.get('domainCode') as DomainCode | null;
+  const accessibleDomains = getAccessibleDomains();
+
+  const isInvalidDomainCode = useMemo(() => {
+    if (!rawDomainCode) return false;
+    return !VALID_DOMAIN_CODES.includes(rawDomainCode);
+  }, [rawDomainCode]);
+
+  const hasAccess = useMemo(() => {
+    if (!rawDomainCode) return true; // 도메인 지정 안 함 = 전체 조회
+    if (isInvalidDomainCode) return false;
+    return hasDomainAccess(rawDomainCode);
+  }, [rawDomainCode, isInvalidDomainCode, hasDomainAccess]);
+
+  const validatedDomainCode = useMemo(() => {
+    if (!rawDomainCode || isInvalidDomainCode || !hasAccess) {
+      return undefined;
+    }
+    return rawDomainCode;
+  }, [rawDomainCode, isInvalidDomainCode, hasAccess]);
+
+  useEffect(() => {
+    if (redirectOnUnauthorized && rawDomainCode && !hasAccess) {
+      navigate(redirectPath, { replace: true });
+    }
+  }, [redirectOnUnauthorized, rawDomainCode, hasAccess, navigate, redirectPath]);
+
+  return {
+    rawDomainCode,
+    validatedDomainCode,
+    accessibleDomains,
+    hasAccess,
+    isInvalidDomainCode,
+  };
+}
+
+/**
+ * 도메인 필터 옵션을 생성하는 유틸리티 훅
+ * 사용자가 접근 가능한 도메인만 필터 옵션으로 반환
+ */
+export function useAccessibleDomainOptions() {
+  const { getAccessibleDomains } = useAuthStore();
+  const accessibleDomains = getAccessibleDomains();
+
+  const domainOptions = useMemo(() => {
+    const DOMAIN_LABELS: Record<DomainCode, string> = {
+      ESG: 'ESG 실사',
+      SAFETY: '안전보건',
+      COMPLIANCE: '컴플라이언스',
+    };
+
+    return accessibleDomains.map((code: DomainCode) => ({
+      value: code,
+      label: DOMAIN_LABELS[code],
+    }));
+  }, [accessibleDomains]);
+
+  return {
+    accessibleDomains,
+    domainOptions,
+    hasSingleDomain: accessibleDomains.length === 1,
+    hasMultipleDomains: accessibleDomains.length > 1,
+  };
+}


### PR DESCRIPTION
## 변경 요약
- `useDomainGuard` 훅 추가: URL의 `domainCode` 쿼리 파라미터를 검증하고, 권한 없는 도메인 접근 시 `/permission/request`로 리다이렉트
- `useAccessibleDomainOptions` 훅 추가: 사용자가 접근 가능한 도메인만 필터 옵션으로 생성
- `DiagnosticsListPage`: `domainCode` 파라미터 검증 적용
- `ApprovalsListPage`, `ReviewsListPage`: 도메인 필터 셀렉트박스에 접근 가능한 도메인만 표시

## 관련 이슈
- Closes #243

## 테스트 방법
1. ESG 권한만 가진 사용자로 로그인
2. URL을 직접 `/diagnostics?domainCode=SAFETY`로 변경
3. `/permission/request` 페이지로 리다이렉트되는지 확인
4. `/approvals` 페이지에서 도메인 필터에 ESG만 표시되는지 확인

## 명세 준수 체크
- [x] `domainCode` 파라미터 검증 시 해당 도메인에 권한이 있어야 조회 가능 (FE_INTEGRATION_RULES.md)
- [x] 권한 없으면 접근 차단 (API_QUICK_REFERENCE.md: DOM002 에러 대응)

## 리뷰 포인트
- `useDomainGuard` 훅의 리다이렉트 로직이 적절한지
- 도메인 필터 옵션 생성 시 `useAccessibleDomainOptions` 훅 사용이 적절한지

## TODO/질문
- 백엔드에서 DOM002 에러 반환 시 프론트엔드에서 별도 에러 핸들링 필요한지 검토 필요