### PR TITLE
fix: #244 새로고침 시 빈 화면 문제 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
@@ -91,9 +92,28 @@ function DomainProtectedRoute({ children, domainCode }: DomainProtectedRouteProp
 
 function AppRoutes() {
   const { user } = useAuthStore();
+  const [isHydrated, setIsHydrated] = useState(useAuthStore.persist.hasHydrated());
+
+  // Wait for persist hydration to complete
+  useEffect(() => {
+    const unsubscribe = useAuthStore.persist.onFinishHydration(() => {
+      setIsHydrated(true);
+    });
+
+    return unsubscribe;
+  }, []);
 
   // Fetch user info on app load if authenticated
   useMe();
+
+  // Show loading until hydration is complete
+  if (!isHydrated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#f8f9fa]">
+        <div className="w-[32px] h-[32px] border-[3px] border-[#2563eb] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
 
   const getUserRoleForLegacy = (): 'receiver' | 'drafter' | 'approver' => {
     if (!user?.role) return 'drafter';


### PR DESCRIPTION
## Summary
- Zustand persist hydration이 완료되기 전에 라우트가 렌더링되어 인증 상태가 초기값으로 처리되는 문제 수정
- AppRoutes에서 persist hydration 완료를 기다린 후 라우트 렌더링
- hydration 중에는 로딩 스피너 표시

## Test plan
- [ ] `/diagnostics/{id}/files` 페이지에서 새로고침 테스트
- [ ] 기안자 역할로 로그인 후 새로고침 시 빈 화면 발생하지 않는지 확인
- [ ] 다른 페이지에서도 새로고침 정상 동작 확인

Closes #244