### PR TITLE
feat: #246 기안 삭제 기능 추가

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   useDiagnosticDetail,
   useDiagnosticHistory,
   useSubmitDiagnostic,
+  useDeleteDiagnostic,
 } from '../../src/hooks/useDiagnostics';
 import { useAiResult } from '../../src/hooks/useAiRun';
 import type { DiagnosticStatus, DomainCode, RiskLevel } from '../../src/types/api.types';
@@ -79,8 +80,10 @@ export default function DiagnosticDetailPage() {
   const { data: history } = useDiagnosticHistory(diagnosticId);
   const { data: aiResult } = useAiResult(diagnosticId);
   const submitMutation = useSubmitDiagnostic();
+  const deleteMutation = useDeleteDiagnostic();
 
   const [showSubmitModal, setShowSubmitModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [approverId, setApproverId] = useState<number | ''>('');
   const [comment, setComment] = useState('');
 
@@ -102,6 +105,15 @@ export default function DiagnosticDetailPage() {
         },
       }
     );
+  };
+
+  const handleDelete = () => {
+    deleteMutation.mutate(diagnosticId, {
+      onSuccess: () => {
+        setShowDeleteModal(false);
+        navigate('/diagnostics');
+      },
+    });
   };
 
   if (isLoading) {
@@ -133,6 +145,7 @@ export default function DiagnosticDetailPage() {
   }
 
   const canSubmit = diagnostic.status === 'WRITING' || diagnostic.status === 'RETURNED';
+  const canDelete = diagnostic.status === 'WRITING';
 
   return (
     <DashboardLayout>
@@ -212,6 +225,14 @@ export default function DiagnosticDetailPage() {
 
         {/* 액션 버튼 */}
         <div className="flex justify-end gap-[12px]">
+          {canDelete && (
+            <button
+              onClick={() => setShowDeleteModal(true)}
+              className="px-[24px] py-[12px] rounded-[8px] border border-red-500 font-title-small text-red-500 hover:bg-red-50 transition-colors"
+            >
+              삭제
+            </button>
+          )}
           <button
             onClick={() => navigate(`/diagnostics/${diagnosticId}/files`)}
             className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-primary-main)] font-title-small text-[var(--color-primary-main)] hover:bg-blue-50 transition-colors"
@@ -280,6 +301,41 @@ export default function DiagnosticDetailPage() {
                 className="px-[20px] py-[10px] rounded-[8px] bg-[var(--color-primary-main)] font-title-small text-white hover:opacity-90 transition-colors disabled:opacity-50"
               >
                 {submitMutation.isPending ? '제출 중...' : '제출'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 삭제 확인 모달 */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-[16px] w-full max-w-[400px] mx-[16px] shadow-xl">
+            <div className="px-[24px] py-[20px] border-b border-[var(--color-border-default)]">
+              <h2 className="font-title-medium text-[var(--color-text-primary)]">
+                기안 삭제
+              </h2>
+            </div>
+
+            <div className="px-[24px] py-[20px]">
+              <p className="font-body-medium text-[var(--color-text-secondary)]">
+                이 기안을 삭제하시겠습니까? 삭제된 기안은 복구할 수 없습니다.
+              </p>
+            </div>
+
+            <div className="px-[24px] py-[16px] border-t border-[var(--color-border-default)] flex justify-end gap-[12px]">
+              <button
+                onClick={() => setShowDeleteModal(false)}
+                className="px-[20px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleteMutation.isPending}
+                className="px-[20px] py-[10px] rounded-[8px] bg-red-500 font-title-small text-white hover:bg-red-600 transition-colors disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? '삭제 중...' : '삭제'}
               </button>
             </div>
           </div>

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -98,3 +98,7 @@ export const getDiagnosticHistory = async (id: number): Promise<DiagnosticHistor
   );
   return response.data.data;
 };
+
+export const deleteDiagnostic = async (id: number): Promise<void> => {
+  await apiClient.delete(`/v1/diagnostics/${id}`);
+};

--- a/src/hooks/useDiagnostics.ts
+++ b/src/hooks/useDiagnostics.ts
@@ -72,3 +72,18 @@ export const useDiagnosticHistory = (id: number) => {
     enabled: id > 0,
   });
 };
+
+export const useDeleteDiagnostic = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: diagnosticsApi.deleteDiagnostic,
+    onSuccess: () => {
+      toast.success('기안이 삭제되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['diagnostics'] });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      handleApiError(error);
+    },
+  });
+};


### PR DESCRIPTION
## 변경 요약
- `deleteDiagnostic` API 함수 추가 (`DELETE /api/v1/diagnostics/{id}`)
- `useDeleteDiagnostic` 훅 추가
- `DiagnosticDetailPage`에 삭제 버튼 및 확인 모달 추가
- 작성 중(WRITING) 상태의 기안만 삭제 가능하도록 제한

## 관련 이슈
- Closes #246

## 테스트 방법
1. 기안자 계정으로 로그인
2. 상태가 "작성중"인 기안 상세 페이지로 이동
3. 삭제 버튼이 표시되는지 확인
4. 삭제 버튼 클릭 → 확인 모달 표시 확인
5. 삭제 확인 → 기안 삭제 및 목록 페이지로 이동 확인
6. 상태가 "제출됨" 등 다른 상태인 기안에서는 삭제 버튼이 표시되지 않는지 확인

## 명세 준수 체크
- [x] RESTful API 패턴 준수: `DELETE /api/v1/diagnostics/{id}`
- [x] 작성 중(WRITING) 상태만 삭제 가능 (비즈니스 로직)
- [x] 삭제 전 확인 모달로 실수 방지

## 리뷰 포인트
- 삭제 가능 상태를 WRITING만으로 제한하는 것이 적절한지
- 삭제 확인 모달 UX가 적절한지

## TODO/질문
- API 명세서에 DELETE /api/v1/diagnostics/{id} 엔드포인트가 명시되어 있지 않음 - 백엔드에서 해당 API가 구현되어 있는지 확인 필요
- 반려됨(RETURNED) 상태도 삭제 가능하게 할지 검토 필요