### PR TITLE
fix: #247 파일 삭제 시 슬롯 체크 해제 안됨

### DIFF
--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -690,9 +690,9 @@ export default function DiagnosticFilesPage() {
       }
       // 파일 목록 쿼리 갱신
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.FILES.LIST(diagnosticId) });
-      // 삭제된 파일을 제외한 나머지 파일로 preview 재호출
+      // 삭제된 파일을 제외한 나머지 파일로 preview 재호출 (완료 대기)
       const remainingFileIds = allCompletedFileIds.filter(id => id !== fileId);
-      callPreview(remainingFileIds);
+      await previewMutation.mutateAsync({ diagnosticId, fileIds: remainingFileIds });
     } catch {
       // Error handled by mutation
     }


### PR DESCRIPTION
## Summary
- 파일 삭제 후 preview API 호출 시 `mutateAsync`를 사용하여 응답 완료를 기다린 후 슬롯 상태가 업데이트되도록 수정
- 기존 `callPreview` (비동기 mutation)에서 `previewMutation.mutateAsync`로 변경

## Test plan
- [ ] 기안자 역할로 파일 업로드 후 삭제 테스트
- [ ] 파일 삭제 시 해당 슬롯의 체크 상태가 즉시 해제되는지 확인
- [ ] 여러 파일 연속 삭제 시에도 슬롯 상태가 올바르게 업데이트되는지 확인

Closes #247