### PR TITLE
fix: #248 중복 파일 업로드 차단

### DIFF
--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useDiagnosticDetail } from '../../src/hooks/useDiagnostics';
 import { useDiagnosticFiles, useParsingResult, useDeleteFile } from '../../src/hooks/useFiles';
 import { useJobPolling, useRetryJob } from '../../src/hooks/useJobs';
@@ -607,6 +608,16 @@ export default function DiagnosticFilesPage() {
 
   const handleFilesUpload = async (files: File[]) => {
     for (const file of files) {
+      // 중복 파일 체크: 기존 파일 및 업로드 중인 파일과 이름 비교
+      const existingFileNames = (existingFiles || []).map(f => f.fileName);
+      const uploadingFileNames = newlyUploadedFiles.map(f => f.name);
+      const allFileNames = [...existingFileNames, ...uploadingFileNames];
+
+      if (allFileNames.includes(file.name)) {
+        toast.error(`"${file.name}" 파일이 이미 존재합니다.`);
+        continue;
+      }
+
       const tempId = Date.now();
 
       // Add file with uploading status


### PR DESCRIPTION
## 변경 요약
- 파일 업로드 시 중복 파일 체크 로직 추가
- 기존 업로드된 파일 + 현재 업로드 중인 파일과 이름 비교
- 중복 파일 발견 시 토스트 에러 메시지 표시 후 해당 파일 업로드 건너뛰기
- 중복 파일로 인한 무한 로딩 문제 해결

## 관련 이슈
- Closes #248

## 테스트 방법
1. 기안자 계정으로 로그인
2. 기안 상세 → 파일 관리 페이지로 이동
3. 파일 업로드 (예: `test.pdf`)
4. 동일한 이름의 파일 (`test.pdf`) 다시 업로드 시도
5. `"test.pdf" 파일이 이미 존재합니다.` 토스트 메시지 표시 확인
6. 무한 로딩 없이 정상 동작 확인

## 명세 준수 체크
- [x] 중복 파일 업로드 시 사용자에게 명확한 피드백 제공
- [x] 기존 파일 목록과 업로드 중인 파일 모두 체크

## 리뷰 포인트
- 파일명 비교 로직이 적절한지 (대소문자 구분 여부 등)
- 에러 메시지가 사용자 친화적인지

## TODO/질문
- 파일명 대소문자 구분 없이 비교해야 할지? (현재는 대소문자 구분)
- 백엔드에서도 중복 파일 체크를 하는지 확인 필요