### PR TITLE
fix: #250 목록으로 버튼 domainCode 누락

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCreateDiagnostic } from '../../src/hooks/useDiagnostics';
@@ -17,6 +17,8 @@ const DOMAIN_OPTIONS: { value: DomainCode; label: string }[] = [
 
 export default function DiagnosticCreatePage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const domainCode = searchParams.get('domainCode');
   const createMutation = useCreateDiagnostic();
   const { data: campaigns = [], isLoading: campaignsLoading } = useCampaigns({ activeOnly: true });
   const isMountedRef = useRef(true);
@@ -92,7 +94,7 @@ export default function DiagnosticCreatePage() {
       <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[700px] mx-auto w-full">
         {/* 뒤로가기 */}
         <button
-          onClick={() => navigate('/diagnostics')}
+          onClick={() => navigate(domainCode ? `/diagnostics?domainCode=${domainCode}` : '/diagnostics')}
           className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
         >
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none">

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -108,10 +108,11 @@ export default function DiagnosticDetailPage() {
   };
 
   const handleDelete = () => {
+    const domainCode = diagnostic?.domain?.code;
     deleteMutation.mutate(diagnosticId, {
       onSuccess: () => {
         setShowDeleteModal(false);
-        navigate('/diagnostics');
+        navigate(domainCode ? `/diagnostics?domainCode=${domainCode}` : '/diagnostics');
       },
     });
   };
@@ -152,7 +153,7 @@ export default function DiagnosticDetailPage() {
       <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[900px] mx-auto w-full">
         {/* 뒤로가기 */}
         <button
-          onClick={() => navigate('/diagnostics')}
+          onClick={() => navigate(diagnostic.domain?.code ? `/diagnostics?domainCode=${diagnostic.domain.code}` : '/diagnostics')}
           className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
         >
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none">


### PR DESCRIPTION
## Summary
- 기안 상세/생성 페이지에서 '목록으로' 버튼 클릭 시 해당 도메인 목록으로 이동하도록 수정
- `DiagnosticDetailPage`: `diagnostic.domain.code`를 사용하여 쿼리 파라미터 추가
- `DiagnosticCreatePage`: URL 쿼리 파라미터에서 `domainCode` 유지

## Test plan
- [ ] 컴플라이언스 도메인에서 기안 상세 페이지 진입 후 '목록으로' 클릭 시 컴플라이언스 목록으로 이동하는지 확인
- [ ] 기안 삭제 후 해당 도메인 목록으로 이동하는지 확인
- [ ] 새 기안 생성 페이지에서 '목록으로' 클릭 시 이전 도메인 목록으로 이동하는지 확인

Closes #250