### PR TITLE
fix: #251 결재자 없는데 제출 버튼 존재

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -145,7 +145,9 @@ export default function DiagnosticDetailPage() {
     );
   }
 
-  const canSubmit = diagnostic.status === 'WRITING' || diagnostic.status === 'RETURNED';
+  // ESG 도메인만 결재자 워크플로우 존재
+  const hasApprovalWorkflow = diagnostic.domain?.code === 'ESG';
+  const canSubmit = hasApprovalWorkflow && (diagnostic.status === 'WRITING' || diagnostic.status === 'RETURNED');
   const canDelete = diagnostic.status === 'WRITING';
 
   return (


### PR DESCRIPTION
## Summary
- 컴플라이언스/안전보건 도메인은 결재자 워크플로우가 없으므로 '결재자에게 제출' 버튼 숨김
- ESG 도메인인 경우에만 버튼 표시되도록 조건 추가

## Test plan
- [ ] 컴플라이언스 도메인 기안에서 '결재자에게 제출' 버튼이 표시되지 않는지 확인
- [ ] 안전보건 도메인 기안에서 '결재자에게 제출' 버튼이 표시되지 않는지 확인
- [ ] ESG 도메인 기안에서 '결재자에게 제출' 버튼이 정상 표시되는지 확인

Closes #251