### PR TITLE
fix: #252 ESG 기안 생성 후 리다이렉트 안됨

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -84,7 +84,12 @@ export default function DiagnosticCreatePage() {
     createMutation.mutate(data, {
       onSuccess: (result) => {
         if (!isMountedRef.current) return;
-        navigate(`/diagnostics/${result.diagnosticId}`);
+        // 상세 페이지로 이동, diagnosticId가 없으면 목록 페이지로 fallback
+        if (result?.diagnosticId) {
+          navigate(`/diagnostics/${result.diagnosticId}`);
+        } else {
+          navigate(domainCode ? `/diagnostics?domainCode=${domainCode}` : '/diagnostics');
+        }
       },
     });
   };


### PR DESCRIPTION
## Summary
- 기안 생성 후 `diagnosticId`가 없는 경우 목록 페이지로 fallback 처리
- 정상: 기안 상세 페이지(`/diagnostics/{id}`)로 이동
- 비정상: 해당 도메인 목록 페이지로 이동

## Test plan
- [ ] ESG 도메인에서 기안 생성 후 상세 페이지로 이동하는지 확인
- [ ] API 응답에 diagnosticId가 없는 경우 목록 페이지로 이동하는지 확인

Closes #252