### PR TITLE
fix: 승인 상태명 통일 (#255)

### DIFF
--- a/docs/API_SPECIFICATION.md
+++ b/docs/API_SPECIFICATION.md
@@ -401,7 +401,7 @@ GET /api/v1/diagnostics
 - `WRITING` - 작성중
 - `SUBMITTED` - 제출됨
 - `RETURNED` - 반려됨
-- `APPROVED` - 내부승인
+- `APPROVED` - 승인됨
 - `REVIEWING` - 심사중
 - `COMPLETED` - 완료
 

--- a/docs/STATUS_AND_ERROR_CODES.md
+++ b/docs/STATUS_AND_ERROR_CODES.md
@@ -53,7 +53,7 @@ WRITING → SUBMITTED → RETURNED (반려 시)
 | `WRITING` | 작성중 | 기안자가 진단 작성 중 | SUBMITTED |
 | `SUBMITTED` | 제출됨 | 결재자에게 제출됨 | RETURNED, APPROVED |
 | `RETURNED` | 반려됨 | 결재자가 반려함 | WRITING |
-| `APPROVED` | 내부승인 | 결재자가 승인함 | REVIEWING |
+| `APPROVED` | 승인됨 | 결재자가 승인함 | REVIEWING |
 | `REVIEWING` | 심사중 | 원청에서 심사 중 | COMPLETED |
 | `COMPLETED` | 완료 | 심사 완료 | (최종 상태) |
 


### PR DESCRIPTION
## Summary
- 문서 내 '내부승인' 워딩을 '승인됨'으로 통일
- STATUS_AND_ERROR_CODES.md, API_SPECIFICATION.md 수정

## Related Issue
closes #255

## Test plan
- [x] 문서 내 상태명 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)