### PR TITLE
fix: 결재 상세에서 목록으로 이동 시 domainCode 추가 (#292)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -145,7 +145,7 @@ export default function ApprovalDetailPage() {
       <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[900px] mx-auto w-full">
         {/* 뒤로가기 */}
         <button
-          onClick={() => navigate('/approvals')}
+          onClick={() => navigate(approval.domainCode ? `/approvals?domainCode=${approval.domainCode}` : '/approvals')}
           className="flex items-center gap-[4px] font-body-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] w-fit"
         >
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none">


### PR DESCRIPTION
## Summary
- 결재 상세 페이지에서 '목록으로' 버튼 클릭 시 domainCode 쿼리 파라미터 추가
- `/approvals?domainCode=ESG` 형태로 이동하여 API 정상 호출 가능

## Related Issue
closes #292

## Test plan
- [x] 결재 상세 → 목록으로 버튼 클릭 시 URL에 domainCode 포함 확인
- [x] 결재 목록 페이지 API 정상 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)