### PR TITLE
fix: 원청 제출 후 리다이렉트 추가 (#257)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -106,7 +106,11 @@ export default function ApprovalDetailPage() {
   };
 
   const handleSubmitToReviewer = () => {
-    submitToReviewerMutation.mutate(approvalId);
+    submitToReviewerMutation.mutate(approvalId, {
+      onSuccess: () => {
+        navigate(approval?.domainCode ? `/approvals?domainCode=${approval.domainCode}` : '/approvals');
+      },
+    });
   };
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- 원청 제출 성공 시 결재 목록 페이지로 리다이렉트 추가
- domainCode 쿼리 파라미터 포함하여 이동

## Related Issue
closes #257

## Test plan
- [x] 결재 승인 후 '원청에 제출' 버튼 클릭
- [x] 제출 성공 시 결재 목록 페이지로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)