### PR TITLE
fix: 원청 제출 버튼 중복 클릭 방지

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -221,10 +221,10 @@ export default function ApprovalDetailPage() {
           <div className="flex justify-end">
             <button
               onClick={handleSubmitToReviewer}
-              disabled={submitToReviewerMutation.isPending}
+              disabled={submitToReviewerMutation.isPending || submitToReviewerMutation.isSuccess}
               className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors disabled:opacity-50"
             >
-              {submitToReviewerMutation.isPending ? '제출 중...' : '원청에 제출'}
+              {submitToReviewerMutation.isPending ? '제출 중...' : submitToReviewerMutation.isSuccess ? '제출 완료' : '원청에 제출'}
             </button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- 제출 성공 후 버튼 비활성화 (isSuccess 조건 추가)
- 버튼 텍스트: '제출 중...' → '제출 완료' → 리다이렉트

## Test plan
- [x] 원청에 제출 버튼 클릭 후 중복 클릭 불가 확인
- [x] 제출 완료 텍스트 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)