### PR TITLE
fix: 원청 제출 버튼 중복 제출 방지

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useApprovalDetail, useProcessApproval, useSubmitToReviewer } from '../../src/hooks/useApprovals';
+import { useDiagnosticDetail } from '../../src/hooks/useDiagnostics';
 import { useAiResult } from '../../src/hooks/useAiRun';
 import type { ApprovalStatus, DomainCode, RiskLevel } from '../../src/types/api.types';
 import { DOMAIN_LABELS } from '../../src/types/api.types';
@@ -70,6 +71,7 @@ export default function ApprovalDetailPage() {
 
   const { data: approval, isLoading, isError, error } = useApprovalDetail(approvalId);
   const diagnosticId = approval?.diagnostic?.diagnosticId ?? 0;
+  const { data: diagnostic } = useDiagnosticDetail(diagnosticId);
   const { data: aiResult } = useAiResult(diagnosticId);
   const processApprovalMutation = useProcessApproval();
   const submitToReviewerMutation = useSubmitToReviewer();
@@ -143,6 +145,7 @@ export default function ApprovalDetailPage() {
 
   const isWaiting = approval.status === 'WAITING';
   const isApproved = approval.status === 'APPROVED';
+  const canSubmitToReviewer = isApproved && diagnostic?.status === 'APPROVED';
 
   return (
     <DashboardLayout>
@@ -217,7 +220,7 @@ export default function ApprovalDetailPage() {
           </div>
         )}
 
-        {isApproved && (
+        {canSubmitToReviewer && (
           <div className="flex justify-end">
             <button
               onClick={handleSubmitToReviewer}


### PR DESCRIPTION
## Summary
- `useDiagnosticDetail` 훅으로 diagnostic 상태 조회
- `canSubmitToReviewer` 조건 추가: approval.status === 'APPROVED' && diagnostic.status === 'APPROVED'
- 이미 원청에 제출된 경우(diagnostic.status === 'REVIEWING') 버튼 숨김

## Test plan
- [x] 결재 승인 후 원청 제출 버튼 표시 확인
- [x] 원청 제출 후 다시 상세 진입 시 버튼 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)