### PR TITLE
fix: #258 수신자 목록으로 클릭 시 이동 오류 수정

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -51,7 +51,15 @@ function formatPeriod(dateStr: string): string {
   return `${d.getFullYear()}년 ${String(d.getMonth() + 1).padStart(2, '0')}월`;
 }
 
-function getDomainPath(domainCode?: string): string {
+function getListPath(userRole: string, domainCode?: string): string {
+  // 역할에 따라 목록 페이지 경로 반환
+  if (userRole === 'receiver') {
+    return '/reviews';
+  }
+  if (userRole === 'approver') {
+    return '/approvals';
+  }
+  // 기안자(drafter)는 도메인별 대시보드로 이동
   const domain = domainCode?.toLowerCase() || 'safety';
   return `/dashboard/${domain}`;
 }
@@ -67,10 +75,10 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
 
-  const domainPath = getDomainPath(review?.domainCode);
+  const listPath = getListPath(userRole, review?.domainCode);
 
   const handleBackToList = () => {
-    navigate(domainPath);
+    navigate(listPath);
   };
 
   const handleReject = () => {
@@ -80,7 +88,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const handleApprove = () => {
     submitReview.mutate(
       { id: reviewId, data: { decision: 'APPROVED' } },
-      { onSuccess: () => navigate(domainPath) }
+      { onSuccess: () => navigate(listPath) }
     );
   };
 
@@ -91,7 +99,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
       {
         onSuccess: () => {
           setShowRejectModal(false);
-          navigate(domainPath);
+          navigate(listPath);
         },
       }
     );
@@ -100,7 +108,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const handleSubmitToApprover = () => {
     submitReview.mutate(
       { id: reviewId, data: { decision: 'APPROVED' } },
-      { onSuccess: () => navigate(domainPath) }
+      { onSuccess: () => navigate(listPath) }
     );
   };
 


### PR DESCRIPTION
## 변경 요약
- `getDomainPath` 함수를 `getListPath`로 변경
- 역할(userRole)에 따라 적절한 목록 페이지로 이동하도록 수정:
  - **수신자(receiver)**: `/reviews` (심사 목록)
  - **결재자(approver)**: `/approvals` (결재 목록)
  - **기안자(drafter)**: `/dashboard/{domain}` (도메인별 대시보드)

## 관련 이슈
- Closes #258

## 테스트 방법
1. 수신자(REVIEWER) 계정으로 로그인
2. 심사 목록 → 심사 상세 페이지로 이동
3. "목록으로" 버튼 클릭
4. `/reviews` 페이지로 이동하는지 확인 (권한 관리 페이지가 아닌)
5. 결재자/기안자 계정으로도 동일하게 테스트

## 명세 준수 체크
- [x] 수신자: `/reviews`로 이동
- [x] 결재자: `/approvals`로 이동
- [x] 기안자: 도메인별 대시보드로 이동

## 리뷰 포인트
- 각 역할별 목록 페이지 경로가 적절한지
- 기안자의 경우 도메인 대시보드로 이동하는 것이 적절한지 (또는 `/diagnostics`가 더 적합한지)

## TODO/질문
- 기안자도 `/diagnostics`로 이동하는 것이 더 일관성 있을 수 있음