### PR TITLE
fix: #261 대시보드/기안관리 컬럼명 통일

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -140,13 +140,12 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
             {item.title || item.summary || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.diagnosticCode || '-'}
-          </td>
-          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.createdAt)}
+            {item.period?.startDate && item.period?.endDate
+              ? `${item.period.startDate} ~ ${item.period.endDate}`
+              : '-'}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
@@ -268,13 +267,10 @@ export default function CompliancePage({ userRole }: CompliancePageProps) {
                     </th>
                   )}
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '기안자' : '협력사 명'}
+                    {userRole === 'approver' ? '기안자' : userRole === 'drafter' ? '캠페인' : '협력사 명'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '기안명' : userRole === 'drafter' ? '캠페인' : '기간'}
-                  </th>
-                  <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '요청일' : '제출일'}
+                    {userRole === 'approver' ? '기안명' : '기간'}
                   </th>
                   <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                     상태

--- a/features/dashboard/ESGPage.tsx
+++ b/features/dashboard/ESGPage.tsx
@@ -140,13 +140,12 @@ export default function ESGPage({ userRole }: ESGPageProps) {
             {item.title || item.summary || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.diagnosticCode || '-'}
-          </td>
-          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.createdAt)}
+            {item.period?.startDate && item.period?.endDate
+              ? `${item.period.startDate} ~ ${item.period.endDate}`
+              : '-'}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
@@ -268,13 +267,10 @@ export default function ESGPage({ userRole }: ESGPageProps) {
                     </th>
                   )}
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '기안자' : '협력사 명'}
+                    {userRole === 'approver' ? '기안자' : userRole === 'drafter' ? '캠페인' : '협력사 명'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '기안명' : userRole === 'drafter' ? '캠페인' : '기간'}
-                  </th>
-                  <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '요청일' : '제출일'}
+                    {userRole === 'approver' ? '기안명' : '기간'}
                   </th>
                   <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                     상태

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -366,7 +366,7 @@ export default function HomePage({ userRole }: HomePageProps) {
       if (items.length === 0) {
         return (
           <tr>
-            <td colSpan={5}>
+            <td colSpan={4}>
               <EmptyState message="등록된 기안이 없습니다." />
             </td>
           </tr>
@@ -382,13 +382,12 @@ export default function HomePage({ userRole }: HomePageProps) {
             {item.title || item.summary || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.diagnosticCode || '-'}
-          </td>
-          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.createdAt)}
+            {item.period?.startDate && item.period?.endDate
+              ? `${item.period.startDate} ~ ${item.period.endDate}`
+              : '-'}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
@@ -562,13 +561,10 @@ export default function HomePage({ userRole }: HomePageProps) {
                       </th>
                     )}
                     <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                      {userRole === 'drafter' ? '회사명' : '협력사 명'}
+                      {userRole === 'drafter' ? '캠페인' : '협력사 명'}
                     </th>
                     <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                      {userRole === 'drafter' ? '기안명' : '기간'}
-                    </th>
-                    <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                      제출일
+                      기간
                     </th>
                     <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                       상태

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -140,13 +140,12 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
             {item.title || item.summary || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {item.diagnosticCode || '-'}
-          </td>
-          <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
             {item.campaign?.title || '-'}
           </td>
           <td className="py-[16px] px-[16px] font-body-small text-[#495057]">
-            {formatDate(item.createdAt)}
+            {item.period?.startDate && item.period?.endDate
+              ? `${item.period.startDate} ~ ${item.period.endDate}`
+              : '-'}
           </td>
           <td className="py-[16px] px-[16px] text-center">
             <span
@@ -268,13 +267,10 @@ export default function SafetyPage({ userRole }: SafetyPageProps) {
                     </th>
                   )}
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '기안자' : '협력사 명'}
+                    {userRole === 'approver' ? '기안자' : userRole === 'drafter' ? '캠페인' : '협력사 명'}
                   </th>
                   <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '기안명' : userRole === 'drafter' ? '캠페인' : '기간'}
-                  </th>
-                  <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                    {userRole === 'approver' ? '요청일' : '제출일'}
+                    {userRole === 'approver' ? '기안명' : '기간'}
                   </th>
                   <th className="text-center py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
                     상태


### PR DESCRIPTION
## 변경 요약
- 대시보드 페이지들의 기안자(drafter) 테이블 컬럼명을 기안관리(DiagnosticsListPage)와 동일하게 통일
- **변경 전**: 회사명/기안명/제출일/상태 또는 제목/협력사 명/캠페인/제출일/상태 (5개 컬럼)
- **변경 후**: 제목/캠페인/기간/상태 (4개 컬럼)

### 수정 파일
- `HomePage.tsx`
- `SafetyPage.tsx`
- `ESGPage.tsx`
- `CompliancePage.tsx`

## 관련 이슈
- Closes #261

## 테스트 방법
1. 기안자(DRAFTER) 계정으로 로그인
2. 대시보드 페이지 확인 (/, /dashboard/safety, /dashboard/esg, /dashboard/compliance)
3. 테이블 헤더가 "제목/캠페인/기간/상태" 순서로 표시되는지 확인
4. 기안관리(/diagnostics) 페이지의 테이블 헤더와 동일한지 비교

## 명세 준수 체크
- [x] 대시보드 컬럼명: 제목/캠페인/기간/상태
- [x] 기안관리 컬럼명: 제목/캠페인/기간/상태
- [x] 두 페이지 간 컬럼명 일치

## 리뷰 포인트
- 결재자/수신자의 컬럼명은 기존과 동일하게 유지됨
- 기간 데이터 표시 형식: `시작일 ~ 종료일`

## TODO/질문
- 없음