### PR TITLE
fix: 안전/컴플라이언스 도메인 심사자 제출 기능 추가

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -143,7 +143,7 @@ export default function DiagnosticDetailPage() {
 
   // ESG 도메인만 결재자 워크플로우 존재
   const hasApprovalWorkflow = diagnostic.domain?.code === 'ESG';
-  const canSubmit = hasApprovalWorkflow && (diagnostic.status === 'WRITING' || diagnostic.status === 'RETURNED');
+  const canSubmit = diagnostic.status === 'WRITING' || diagnostic.status === 'RETURNED';
   const canDelete = diagnostic.status === 'WRITING';
 
   return (
@@ -243,7 +243,7 @@ export default function DiagnosticDetailPage() {
               onClick={() => setShowSubmitModal(true)}
               className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
             >
-              결재자에게 제출
+              {hasApprovalWorkflow ? '결재자에게 제출' : '심사자에게 제출'}
             </button>
           )}
         </div>
@@ -261,7 +261,7 @@ export default function DiagnosticDetailPage() {
 
             <div className="px-[24px] py-[20px] flex flex-col gap-[16px]">
               <p className="font-body-medium text-[var(--color-text-secondary)]">
-                기안을 결재자에게 제출하시겠습니까?
+                {hasApprovalWorkflow ? '기안을 결재자에게 제출하시겠습니까?' : '기안을 심사자에게 제출하시겠습니까?'}
               </p>
 
               <div>


### PR DESCRIPTION
## Summary
- `canSubmit` 조건에서 `hasApprovalWorkflow` 조건 제거
- 모든 도메인에서 기안 제출 가능하도록 수정
- 도메인별 버튼/모달 텍스트 분기:
  - ESG: "결재자에게 제출"
  - 안전/컴플라이언스: "심사자에게 제출"

## Root Cause
기존 코드에서 `canSubmit = hasApprovalWorkflow && ...`로 되어 있어서 ESG 도메인에서만 제출 버튼이 표시되었음

## Test plan
- [x] 안전 도메인에서 기안 작성 후 제출 버튼 표시 확인
- [x] 컴플라이언스 도메인에서 기안 작성 후 제출 버튼 표시 확인
- [x] 제출 후 심사자 목록에 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)