### PR TITLE
fix: #259 재제출 요청 후 역할별 올바른 페이지로 이동

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -55,7 +55,13 @@ function formatPeriod(dateStr: string): string {
   return `${d.getFullYear()}년 ${String(d.getMonth() + 1).padStart(2, '0')}월`;
 }
 
-function getListPath(domainCode?: string): string {
+function getListPath(userRole: string, domainCode?: string): string {
+  if (userRole === 'receiver') {
+    return '/reviews';
+  }
+  if (userRole === 'approver') {
+    return '/approvals';
+  }
   const domain = domainCode?.toUpperCase() || 'ESG';
   return `/diagnostics?domainCode=${domain}`;
 }
@@ -73,7 +79,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
 
-  const listPath = getListPath(review?.domainCode);
+  const listPath = getListPath(userRole, review?.domainCode);
 
   const handleBackToList = () => {
     navigate(listPath);


### PR DESCRIPTION
## 변경 요약
- `DocumentReviewPage`의 `getListPath` 함수가 `userRole`을 고려하지 않아 심사자(receiver)가 재제출 요청 후 잘못된 페이지로 이동하던 문제 수정
- 역할별 올바른 목록 페이지로 이동하도록 수정:
  - `receiver` → `/reviews` (심사 목록)
  - `approver` → `/approvals` (결재 목록)
  - `drafter` → `/diagnostics?domainCode={domain}` (기안 목록)

## 관련 이슈
Closes #259

## 테스트 방법
1. REVIEWER 역할로 로그인
2. ESG 도메인의 심사 상세 페이지 접근 (`/dashboard/esg/review/{id}`)
3. "재제출 요청 (Request Resubmission)" 버튼 클릭
4. 보완 요청 사유 입력 후 "보완 요청 전송" 클릭
5. **기대 결과**: `/reviews` (심사 목록) 페이지로 이동
6. **이전 동작**: `/diagnostics?domainCode=ESG` 또는 권한 관리 페이지로 잘못 이동

## 명세 준수 체크
- [x] `docs/service_flow.md`: 수신자(심사자)가 보완요청 후 심사 목록으로 돌아가야 함
- [x] 각 역할별 올바른 목록 페이지로 이동

## 리뷰 포인트
- `getListPath` 함수에 `userRole` 파라미터가 추가됨
- 기존 동작에 영향 없이 역할별 분기 처리만 추가

## TODO / 질문
- 없음