### PR TITLE
fix: 알림 위치 및 표시 시간 조정 (#263)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -357,7 +357,7 @@ export default function App() {
       <BrowserRouter>
         <AppRoutes />
       </BrowserRouter>
-      <Toaster position="top-right" richColors />
+      <Toaster position="top-right" richColors offset={72} duration={3000} />
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- `offset: 72px` 추가하여 알림이 헤더를 가리지 않도록 조정
- `duration: 3000ms`로 변경하여 표시 시간 단축 (기본 4초 → 3초)

## Related Issue
closes #263

## Test plan
- [x] 알림 표시 시 헤더가 가려지지 않는지 확인
- [x] 알림 표시 시간이 3초인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)