### PR TITLE
fix: 파일명 가이드 형식 변경 (#264)

### DIFF
--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -824,7 +824,7 @@ export default function DiagnosticFilesPage() {
                   파일명 가이드
                 </p>
                 <p className="font-body-small text-[var(--color-text-secondary)]">
-                  협력사명_기간_자료명 (예: ABC건설_202601_TBM일지.pdf)
+                  날짜_협력사명_자료명 (예: 20260109_ABC건설_TBM일지.pdf)
                 </p>
               </div>
             </div>

--- a/features/documents/FileUploadPage.tsx
+++ b/features/documents/FileUploadPage.tsx
@@ -188,7 +188,7 @@ export default function FileUploadPage() {
                     파일명 가이드:
                   </p>
                   <p className="font-body-small text-[#495057]">
-                    협력사명_기간_자료명 (예: ABC건설_202601_TBM일지.pdf)
+                    날짜_협력사명_자료명 (예: 20260109_ABC건설_TBM일지.pdf)
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
파일명 가이드 형식 변경:
- 변경 전: `협력사명_기간_자료명` (예: ABC건설_202601_TBM일지.pdf)
- 변경 후: `날짜_협력사명_자료명` (예: 20260109_ABC건설_TBM일지.pdf)

## Changed Files
- `features/diagnostics/DiagnosticFilesPage.tsx`
- `features/documents/FileUploadPage.tsx`

## Related Issue
closes #264

## Test plan
- [x] 파일 업로드 페이지에서 변경된 가이드 확인
- [x] 기안 파일 관리 페이지에서 변경된 가이드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)