### PR TITLE
feat: #275 보완 요청 모달에 AI clarifications 초안 적용

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -86,6 +86,14 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
   };
 
   const handleReject = () => {
+    // AI 분석 결과의 clarifications를 초안으로 사용
+    const clarifications = aiResult?.details?.clarifications;
+    if (clarifications && clarifications.length > 0) {
+      const draft = clarifications
+        .map((c) => c.message)
+        .join('\n\n---\n\n');
+      setRejectReason(draft);
+    }
     setShowRejectModal(true);
   };
 


### PR DESCRIPTION
## 변경 요약
- 보완 요청 모달을 열 때 AI 분석 결과의 `clarifications` 배열을 초안 텍스트로 자동 입력
- 여러 clarification이 있을 경우 `---` 구분선으로 연결

## 관련 이슈
- Closes #275

## 테스트 방법
1. 결재자(approver) 또는 수신자(receiver) 계정으로 로그인
2. AI 분석 결과가 있는 진단 문서의 리뷰 페이지로 이동
3. "반려 및 보완 요청" 또는 "재제출 요청" 버튼 클릭
4. 모달 창의 텍스트 영역에 AI clarifications 메시지가 초안으로 입력되어 있는지 확인
5. clarification이 여러 개인 경우 `---` 구분선으로 구분되어 표시되는지 확인

## 명세 준수 체크
- [x] `aiResult.details.clarifications` 배열의 message들을 초안으로 사용
- [x] 여러 메시지가 있을 경우 구분선으로 연결

## 리뷰 포인트
- clarification 메시지가 이미 협력사에게 보내기 좋은 형식으로 포맷되어 있어 그대로 사용
- 사용자가 필요시 초안을 수정/보완할 수 있음

## TODO / 질문
- 없음