### PR TITLE
fix: 상태 레이블 BE enum 기준 통일 (#274)

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../src/hooks/useDiagnostics';
 import { useAiResult } from '../../src/hooks/useAiRun';
 import type { DiagnosticStatus, DomainCode, RiskLevel } from '../../src/types/api.types';
-import { DOMAIN_LABELS } from '../../src/types/api.types';
+import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.types';
 import type { AiAnalysisResultResponse, SlotResultDetail } from '../../src/api/aiRun';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 
@@ -51,15 +51,6 @@ const REASON_LABELS: Record<string, string> = {
   UNIT_MISSING: '단위 누락',
   EVIDENCE_MISSING: '근거문서 누락',
   SIGNATURE_MISSING: '확인 서명란 미기재',
-};
-
-const STATUS_LABELS: Record<DiagnosticStatus, string> = {
-  WRITING: '작성중',
-  SUBMITTED: '제출됨',
-  RETURNED: '반려됨',
-  APPROVED: '승인됨',
-  REVIEWING: '심사중',
-  COMPLETED: '완료',
 };
 
 const STATUS_STYLES: Record<DiagnosticStatus, string> = {
@@ -164,7 +155,7 @@ export default function DiagnosticDetailPage() {
         <div className="flex items-start justify-between gap-[16px]">
           <h1 className="font-heading-small text-[var(--color-text-primary)]">{diagnostic.title || diagnostic.summary || diagnostic.diagnosticCode}</h1>
           <span className={`shrink-0 inline-block px-[12px] py-[6px] rounded-full font-title-xsmall border ${STATUS_STYLES[diagnostic.status] || 'bg-gray-50 text-gray-700 border-gray-200'}`}>
-            {diagnostic.statusLabel || STATUS_LABELS[diagnostic.status] || diagnostic.status}
+            {diagnostic.statusLabel || DIAGNOSTIC_STATUS_LABELS[diagnostic.status] || diagnostic.status}
           </span>
         </div>
 
@@ -201,7 +192,7 @@ export default function DiagnosticDetailPage() {
                   className="flex items-start gap-[12px] pb-[16px] border-b border-[var(--color-border-default)] last:border-b-0 last:pb-0"
                 >
                   <span className={`shrink-0 inline-block px-[8px] py-[2px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
-                    {STATUS_LABELS[item.status]}
+                    {DIAGNOSTIC_STATUS_LABELS[item.status]}
                   </span>
                   <div className="flex-1 min-w-0">
                     <p className="font-body-medium text-[var(--color-text-primary)]">

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -6,17 +6,8 @@ import { useReviews } from '../../src/hooks/useReviews';
 import { useAuthStore } from '../../src/store/authStore';
 import { useDomainGuard } from '../../src/hooks/useDomainGuard';
 import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
-import { DOMAIN_LABELS } from '../../src/types/api.types';
+import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS, REVIEW_STATUS_LABELS } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
-
-const STATUS_LABELS: Record<DiagnosticStatus, string> = {
-  WRITING: '작성중',
-  SUBMITTED: '제출됨',
-  RETURNED: '반려됨',
-  APPROVED: '승인됨',
-  REVIEWING: '심사중',
-  COMPLETED: '완료',
-};
 
 const STATUS_STYLES: Record<DiagnosticStatus, string> = {
   WRITING: 'bg-gray-50 text-gray-700 border-gray-200',
@@ -37,12 +28,6 @@ const APPROVAL_STATUS_STYLES: Record<ApprovalStatus, string> = {
   WAITING: 'bg-yellow-50 text-yellow-700 border-yellow-200',
   APPROVED: 'bg-green-50 text-green-700 border-green-200',
   REJECTED: 'bg-red-50 text-red-700 border-red-200',
-};
-
-const REVIEW_STATUS_LABELS: Record<ReviewStatus, string> = {
-  REVIEWING: '검토중',
-  APPROVED: '적합',
-  REVISION_REQUIRED: '보완필요',
 };
 
 const REVIEW_STATUS_STYLES: Record<ReviewStatus, string> = {
@@ -331,7 +316,7 @@ export default function DiagnosticsListPage() {
         </td>
         <td className="px-[16px] py-[14px] text-center">
           <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status] || 'bg-gray-50 text-gray-700 border-gray-200'}`}>
-            {item.statusLabel || STATUS_LABELS[item.status] || item.status}
+            {item.statusLabel || DIAGNOSTIC_STATUS_LABELS[item.status] || item.status}
           </span>
         </td>
       </tr>

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -3,14 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useReviews, useBulkReport, useExportReviews } from '../../src/hooks/useReviews';
 import { useAccessibleDomainOptions } from '../../src/hooks/useDomainGuard';
 import type { ReviewStatus, RiskLevel, DomainCode } from '../../src/types/api.types';
-import { DOMAIN_LABELS } from '../../src/types/api.types';
+import { DOMAIN_LABELS, REVIEW_STATUS_LABELS } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
-
-const STATUS_LABELS: Record<ReviewStatus, string> = {
-  REVIEWING: '심사중',
-  APPROVED: '승인',
-  REVISION_REQUIRED: '보완요청',
-};
 
 const STATUS_STYLES: Record<ReviewStatus, string> = {
   REVIEWING: 'bg-blue-50 text-blue-700 border-blue-200',
@@ -252,7 +246,7 @@ export default function ReviewsListPage() {
                   </td>
                   <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
                     <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
-                      {STATUS_LABELS[item.status]}
+                      {REVIEW_STATUS_LABELS[item.status]}
                     </span>
                   </td>
                 </tr>

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -419,6 +419,21 @@ export const REQUEST_STATUS_LABELS: Record<RequestStatus, string> = {
   REJECTED: '승인 반려',
 };
 
+export const DIAGNOSTIC_STATUS_LABELS: Record<DiagnosticStatus, string> = {
+  WRITING: '작성중',
+  SUBMITTED: '제출됨',
+  RETURNED: '반려됨',
+  APPROVED: '승인됨',
+  REVIEWING: '심사중',
+  COMPLETED: '완료',
+};
+
+export const REVIEW_STATUS_LABELS: Record<ReviewStatus, string> = {
+  REVIEWING: '심사중',
+  APPROVED: '승인',
+  REVISION_REQUIRED: '보완요청',
+};
+
 export const ROLE_LABELS: Record<RoleCode, string> = {
   GUEST: '게스트',
   DRAFTER: '기안자',


### PR DESCRIPTION
## Summary
- `api.types.ts`에 상태 레이블 상수 중앙화:
  - `DIAGNOSTIC_STATUS_LABELS`: 작성중, 제출됨, 반려됨, 승인됨, 심사중, 완료
  - `REVIEW_STATUS_LABELS`: 심사중, 승인, 보완요청
- 각 페이지에서 로컬 정의 제거하고 중앙 상수 import 사용

## Changed Files
- `src/types/api.types.ts`: 상수 추가
- `features/diagnostics/DiagnosticsListPage.tsx`: 중앙 상수 사용
- `features/diagnostics/DiagnosticDetailPage.tsx`: 중앙 상수 사용
- `features/reviews/ReviewsListPage.tsx`: 중앙 상수 사용

## Related Issue
closes #274

## Test plan
- [x] 기안 목록에서 상태 레이블 정상 표시 확인
- [x] 기안 상세에서 상태 레이블 정상 표시 확인
- [x] 심사 목록에서 상태 레이블 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)