### PR TITLE
fix: 재제출 버튼 모달 배경 투명도 수정 (#265)

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -438,7 +438,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
 
       {/* ESG Approve Modal */}
       {showApproveModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
           <div className="bg-white rounded-[20px] p-[32px] w-[700px] max-w-[90%]">
             <div className="flex items-center justify-between mb-[24px]">
               <h3 className="font-heading-small text-[#212529]">
@@ -511,7 +511,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
 
       {/* Reject Modal */}
       {showRejectModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
           <div className="bg-white rounded-[20px] p-[32px] w-[600px] max-w-[90%]">
             <div className="flex items-center justify-between mb-[24px]">
               <h3 className="font-heading-small text-[#212529]">


### PR DESCRIPTION
## Summary
- 수신자 역할에서 재제출 요청 버튼 클릭 시 모달 배경이 검정색으로 보이던 문제 수정
- 모달 배경을 `bg-black/40`으로 변경하여 프로젝트 내 다른 모달들과 일관성 유지
- ESG 승인 모달도 동일하게 적용

## Test plan
- [ ] 수신자 역할로 로그인 후 재제출 요청 버튼 클릭 시 모달 배경 확인
- [ ] ESG 도메인에서 결재자 역할로 승인 버튼 클릭 시 모달 배경 확인

Closes #265