### PR TITLE
fix: 슬롯별 분석 결과 verdict 텍스트 크기 증가 (#266)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -390,7 +390,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
         <span className="font-title-small text-[var(--color-text-primary)]">
           {displayName}
         </span>
-        <span className={`px-[8px] py-[2px] rounded text-xs font-medium border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[10px] py-[4px] rounded text-sm font-medium border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -411,7 +411,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
         <span className="font-title-small text-[var(--color-text-primary)]">
           {displayName}
         </span>
-        <span className={`px-[8px] py-[2px] rounded text-xs font-medium border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[10px] py-[4px] rounded text-sm font-medium border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -589,7 +589,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
     <div className="p-[16px] bg-[#f8f9fa] rounded-[12px]">
       <div className="flex items-center justify-between mb-[8px]">
         <span className="font-title-small text-[#212529]">{displayName}</span>
-        <span className={`px-[8px] py-[2px] rounded text-xs font-medium border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[10px] py-[4px] rounded text-sm font-medium border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- 슬롯별 분석 결과의 '확인', '수정 필요' 등 verdict 텍스트가 너무 작아서 가독성 개선
- `text-xs` → `text-sm`으로 변경
- 패딩도 `px-[8px] py-[2px]` → `px-[10px] py-[4px]`로 조정
- 기안자, 결재자, 수신자 모든 역할에서 일관되게 적용

## Test plan
- [ ] 기안자 역할로 진단 상세 페이지에서 슬롯별 분석 결과 텍스트 크기 확인
- [ ] 결재자 역할로 결재 상세 페이지에서 슬롯별 분석 결과 텍스트 크기 확인
- [ ] 수신자 역할로 문서 리뷰 페이지에서 슬롯별 분석 결과 텍스트 크기 확인

Closes #266