### PR TITLE
fix: 슬롯별 분석 결과 UI 가독성 개선 (#266)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -46,9 +46,9 @@ const RISK_LABELS: Record<RiskLevel, string> = {
 };
 
 const RISK_STYLES: Record<RiskLevel, string> = {
-  LOW: 'bg-green-50 text-green-700',
-  MEDIUM: 'bg-yellow-50 text-yellow-700',
-  HIGH: 'bg-red-50 text-red-700',
+  LOW: 'bg-[#dcfce7] text-[#15803d]',
+  MEDIUM: 'bg-[#fef9c3] text-[#a16207]',
+  HIGH: 'bg-[#fee2e2] text-[#dc2626]',
 };
 
 const REASON_LABELS: Record<string, string> = {
@@ -333,8 +333,8 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
           <div className={`px-[16px] py-[10px] rounded-[8px] border ${VERDICT_STYLES[verdict]}`}>
             <span className="font-title-medium">{VERDICT_LABELS[verdict]}</span>
           </div>
-          <div className={`px-[12px] py-[6px] rounded-full ${RISK_STYLES[riskLevel]}`}>
-            <span className="font-title-xsmall">위험도: {RISK_LABELS[riskLevel]}</span>
+          <div className={`px-[14px] py-[8px] rounded-full ${RISK_STYLES[riskLevel]}`}>
+            <span className="font-title-small font-semibold">위험도: {RISK_LABELS[riskLevel]}</span>
           </div>
         </div>
 
@@ -385,21 +385,21 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const displayName = result.display_name || result.slot_name;
 
   return (
-    <div className="p-[16px] bg-gray-50 rounded-[12px]">
-      <div className="flex items-center justify-between mb-[8px]">
-        <span className="font-title-small text-[var(--color-text-primary)]">
+    <div className="p-[20px] bg-gray-50 rounded-[12px]">
+      <div className="flex items-center justify-between mb-[12px]">
+        <span className="font-title-medium text-[var(--color-text-primary)]">
           {displayName}
         </span>
-        <span className={`px-[10px] py-[4px] rounded text-sm font-medium border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[12px] py-[6px] rounded-[6px] text-base font-semibold border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>
 
       {result.reasons && result.reasons.length > 0 && (
-        <ul className="space-y-[4px] mt-[8px]">
+        <ul className="space-y-[8px] mt-[12px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[6px] font-body-medium text-[var(--color-text-secondary)]">
-              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[8px] flex-shrink-0" />
+            <li key={index} className="flex items-start gap-[8px] text-[17px] text-[var(--color-text-secondary)]">
+              <span className="w-[5px] h-[5px] bg-gray-400 rounded-full mt-[10px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
           ))}
@@ -407,9 +407,9 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       )}
 
       {result.file_names && result.file_names.length > 0 && (
-        <div className="mt-[8px] flex flex-wrap gap-[6px]">
+        <div className="mt-[12px] flex flex-wrap gap-[8px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[10px] py-[4px] bg-white text-sm text-gray-600 rounded border border-gray-200">
+            <span key={index} className="px-[12px] py-[6px] bg-white text-base text-gray-700 rounded-[6px] border border-gray-200">
               {fileName}
             </span>
           ))}

--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -398,8 +398,8 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.reasons && result.reasons.length > 0 && (
         <ul className="space-y-[4px] mt-[8px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[6px] font-body-small text-[var(--color-text-secondary)]">
-              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[6px] flex-shrink-0" />
+            <li key={index} className="flex items-start gap-[6px] font-body-medium text-[var(--color-text-secondary)]">
+              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[8px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
           ))}
@@ -409,7 +409,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.file_names && result.file_names.length > 0 && (
         <div className="mt-[8px] flex flex-wrap gap-[6px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[8px] py-[2px] bg-white text-xs text-gray-600 rounded border border-gray-200">
+            <span key={index} className="px-[10px] py-[4px] bg-white text-sm text-gray-600 rounded border border-gray-200">
               {fileName}
             </span>
           ))}

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -35,9 +35,9 @@ const RISK_LABELS: Record<RiskLevel, string> = {
 };
 
 const RISK_STYLES: Record<RiskLevel, string> = {
-  LOW: 'bg-green-50 text-green-700',
-  MEDIUM: 'bg-yellow-50 text-yellow-700',
-  HIGH: 'bg-red-50 text-red-700',
+  LOW: 'bg-[#dcfce7] text-[#15803d]',
+  MEDIUM: 'bg-[#fef9c3] text-[#a16207]',
+  HIGH: 'bg-[#fee2e2] text-[#dc2626]',
 };
 
 const REASON_LABELS: Record<string, string> = {
@@ -354,8 +354,8 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
           <div className={`px-[16px] py-[10px] rounded-[8px] border ${VERDICT_STYLES[verdict]}`}>
             <span className="font-title-medium">{VERDICT_LABELS[verdict]}</span>
           </div>
-          <div className={`px-[12px] py-[6px] rounded-full ${RISK_STYLES[riskLevel]}`}>
-            <span className="font-title-xsmall">위험도: {RISK_LABELS[riskLevel]}</span>
+          <div className={`px-[14px] py-[8px] rounded-full ${RISK_STYLES[riskLevel]}`}>
+            <span className="font-title-small font-semibold">위험도: {RISK_LABELS[riskLevel]}</span>
           </div>
         </div>
 
@@ -406,21 +406,21 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const displayName = result.display_name || result.slot_name;
 
   return (
-    <div className="p-[16px] bg-gray-50 rounded-[12px]">
-      <div className="flex items-center justify-between mb-[8px]">
-        <span className="font-title-small text-[var(--color-text-primary)]">
+    <div className="p-[20px] bg-gray-50 rounded-[12px]">
+      <div className="flex items-center justify-between mb-[12px]">
+        <span className="font-title-medium text-[var(--color-text-primary)]">
           {displayName}
         </span>
-        <span className={`px-[10px] py-[4px] rounded text-sm font-medium border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[12px] py-[6px] rounded-[6px] text-base font-semibold border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>
 
       {result.reasons && result.reasons.length > 0 && (
-        <ul className="space-y-[4px] mt-[8px]">
+        <ul className="space-y-[8px] mt-[12px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[6px] font-body-medium text-[var(--color-text-secondary)]">
-              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[8px] flex-shrink-0" />
+            <li key={index} className="flex items-start gap-[8px] text-[17px] text-[var(--color-text-secondary)]">
+              <span className="w-[5px] h-[5px] bg-gray-400 rounded-full mt-[10px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
           ))}
@@ -428,9 +428,9 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       )}
 
       {result.file_names && result.file_names.length > 0 && (
-        <div className="mt-[8px] flex flex-wrap gap-[6px]">
+        <div className="mt-[12px] flex flex-wrap gap-[8px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[10px] py-[4px] bg-white text-sm text-gray-600 rounded border border-gray-200">
+            <span key={index} className="px-[12px] py-[6px] bg-white text-base text-gray-700 rounded-[6px] border border-gray-200">
               {fileName}
             </span>
           ))}

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -419,8 +419,8 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.reasons && result.reasons.length > 0 && (
         <ul className="space-y-[4px] mt-[8px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[6px] font-body-small text-[var(--color-text-secondary)]">
-              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[6px] flex-shrink-0" />
+            <li key={index} className="flex items-start gap-[6px] font-body-medium text-[var(--color-text-secondary)]">
+              <span className="w-[4px] h-[4px] bg-gray-400 rounded-full mt-[8px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
           ))}
@@ -430,7 +430,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.file_names && result.file_names.length > 0 && (
         <div className="mt-[8px] flex flex-wrap gap-[6px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[8px] py-[2px] bg-white text-xs text-gray-600 rounded border border-gray-200">
+            <span key={index} className="px-[10px] py-[4px] bg-white text-sm text-gray-600 rounded border border-gray-200">
               {fileName}
             </span>
           ))}

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -597,8 +597,8 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.reasons && result.reasons.length > 0 && (
         <ul className="space-y-[4px] mt-[8px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[6px] font-body-small text-[#868e96]">
-              <span className="w-[4px] h-[4px] bg-[#adb5bd] rounded-full mt-[6px] flex-shrink-0" />
+            <li key={index} className="flex items-start gap-[6px] font-body-medium text-[#868e96]">
+              <span className="w-[4px] h-[4px] bg-[#adb5bd] rounded-full mt-[8px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
           ))}
@@ -608,7 +608,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.file_names && result.file_names.length > 0 && (
         <div className="mt-[8px] flex flex-wrap gap-[6px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[8px] py-[2px] bg-white text-xs text-[#495057] rounded border border-[#dee2e6]">
+            <span key={index} className="px-[10px] py-[4px] bg-white text-sm text-[#495057] rounded border border-[#dee2e6]">
               {fileName}
             </span>
           ))}

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -586,19 +586,19 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const displayName = result.display_name || result.slot_name;
 
   return (
-    <div className="p-[16px] bg-[#f8f9fa] rounded-[12px]">
-      <div className="flex items-center justify-between mb-[8px]">
-        <span className="font-title-small text-[#212529]">{displayName}</span>
-        <span className={`px-[10px] py-[4px] rounded text-sm font-medium border ${VERDICT_STYLES[verdict]}`}>
+    <div className="p-[20px] bg-[#f8f9fa] rounded-[12px]">
+      <div className="flex items-center justify-between mb-[12px]">
+        <span className="font-title-medium text-[#212529]">{displayName}</span>
+        <span className={`px-[12px] py-[6px] rounded-[6px] text-base font-semibold border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>
 
       {result.reasons && result.reasons.length > 0 && (
-        <ul className="space-y-[4px] mt-[8px]">
+        <ul className="space-y-[8px] mt-[12px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[6px] font-body-medium text-[#868e96]">
-              <span className="w-[4px] h-[4px] bg-[#adb5bd] rounded-full mt-[8px] flex-shrink-0" />
+            <li key={index} className="flex items-start gap-[8px] text-[17px] text-[#868e96]">
+              <span className="w-[5px] h-[5px] bg-[#adb5bd] rounded-full mt-[10px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
           ))}
@@ -606,9 +606,9 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       )}
 
       {result.file_names && result.file_names.length > 0 && (
-        <div className="mt-[8px] flex flex-wrap gap-[6px]">
+        <div className="mt-[12px] flex flex-wrap gap-[8px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[10px] py-[4px] bg-white text-sm text-[#495057] rounded border border-[#dee2e6]">
+            <span key={index} className="px-[12px] py-[6px] bg-white text-base text-[#495057] rounded-[6px] border border-[#dee2e6]">
               {fileName}
             </span>
           ))}


### PR DESCRIPTION
## Summary
- 위험도 색상 강화 (LOW: 초록, MEDIUM: 노랑, HIGH: 빨강)
- 위험도/슬롯명/verdict 칩/reasons/파일명 텍스트 크기 전체적으로 증가
- 3개 파일 동일하게 적용 (DiagnosticDetailPage, ApprovalDetailPage, DocumentReviewPage)

## Test plan
- [ ] 기안자 역할로 진단 상세 페이지에서 슬롯별 분석 결과 가독성 확인
- [ ] 위험도별 색상 구분 확인 (낮음/중간/높음)

Closes #266