### PR TITLE
fix: 파일 업로드 진행상황 글자 크기 증가 (#268)

### DIFF
--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -133,7 +133,7 @@ function FileUploadItem({
             {file.name}
           </p>
           <div className="flex items-center gap-[8px] mt-[2px]">
-            <p className={`font-title-xsmall ${style.text}`}>
+            <p className={`font-title-small ${style.text}`}>
               {statusLabel}
             </p>
             {autoTag && file.uploadStatus === 'complete' && (
@@ -794,7 +794,7 @@ export default function DiagnosticFilesPage() {
             </p>
           </div>
           {uploadedFiles.length > 0 && (
-            <div className="flex items-center gap-[16px] text-sm">
+            <div className="flex items-center gap-[16px] font-title-small">
               {processingCount > 0 && (
                 <span className="flex items-center gap-[6px] text-amber-600">
                   <span className="w-[8px] h-[8px] rounded-full bg-amber-500 animate-pulse" />


### PR DESCRIPTION
## Summary
- 파일 업로드 탭의 '처리중', '실패' 등 진행상황 글자 크기를 증가시켜 가독성 개선
- 상단 요약 영역: `text-sm` → `font-title-small` (1.6rem)
- 파일별 상태 라벨: `font-title-xsmall` → `font-title-small` (1.6rem)

## Related Issue
Closes #268

## Test plan
- [ ] 파일 업로드 페이지에서 파일 업로드 후 '처리중', '대기중', '완료', '실패' 상태 텍스트 크기 확인
- [ ] 상단 요약 영역의 '처리중 N', '실패 N' 텍스트 크기 확인