### PR TITLE
feat: 알림 클릭 시 기안 페이지로 이동 기능 (#270)

### DIFF
--- a/features/notifications/NotificationsPage.tsx
+++ b/features/notifications/NotificationsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useNotifications, useMarkAsRead, useMarkAllAsRead } from '../../src/hooks/useNotifications';
-import type { NotificationItem } from '../../src/api/notifications';
+import { getNotificationLink, type NotificationItem } from '../../src/api/notifications';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 
 function formatRelativeTime(dateStr: string): string {
@@ -43,12 +43,14 @@ function NotificationCard({
   onMarkRead: (id: number) => void;
   onNavigate: (link: string) => void;
 }) {
+  const link = getNotificationLink(notification);
+
   const handleClick = () => {
     if (!notification.read) {
       onMarkRead(notification.notificationId);
     }
-    if (notification.link) {
-      onNavigate(notification.link);
+    if (link) {
+      onNavigate(link);
     }
   };
 
@@ -89,7 +91,7 @@ function NotificationCard({
       </div>
 
       {/* 링크 화살표 */}
-      {notification.link && (
+      {link && (
         <div className="shrink-0 pt-[4px] text-[var(--color-text-tertiary)]">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
             <path d="M7.5 15L12.5 10L7.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />

--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import svgPaths from '../../imports/svg-h10djjhihc';
 import { useLogout } from '../../src/hooks/useAuth';
 import { useNotifications, useUnreadCount, useMarkAsRead } from '../../src/hooks/useNotifications';
+import { getNotificationLink } from '../../src/api/notifications';
 import { useAuthStore } from '../../src/store/authStore';
 import { maskName } from '../../src/utils/mask';
 
@@ -92,7 +93,7 @@ function NotificationDropdown({ onClose }: { onClose: () => void }) {
         {notifications.map((n) => (
           <div
             key={n.notificationId}
-            onClick={() => handleClickItem(n.notificationId, n.read, n.link)}
+            onClick={() => handleClickItem(n.notificationId, n.read, getNotificationLink(n))}
             className={`flex items-start gap-[12px] px-[16px] py-[12px] cursor-pointer transition-colors ${
               n.read ? 'bg-white hover:bg-gray-50' : 'bg-blue-50/50 hover:bg-blue-50'
             }`}

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -9,6 +9,39 @@ export interface NotificationItem {
   read: boolean;
   createdAt: string;
   link?: string;
+  referenceId?: number;
+  referenceType?: string;
+}
+
+// 알림 타입에 따라 이동할 링크 생성
+export function getNotificationLink(notification: NotificationItem): string | undefined {
+  // 백엔드에서 제공하는 link가 있으면 우선 사용
+  if (notification.link) {
+    return notification.link;
+  }
+
+  // referenceId가 없으면 이동 불가
+  if (!notification.referenceId) {
+    return undefined;
+  }
+
+  // 알림 타입에 따른 링크 생성
+  switch (notification.type) {
+    case 'DIAGNOSTIC_SUBMITTED':
+    case 'DIAGNOSTIC_RETURNED':
+    case 'APPROVAL_COMPLETED':
+    case 'REVIEW_COMPLETED':
+      return `/diagnostics/${notification.referenceId}`;
+
+    case 'APPROVAL_REQUESTED':
+      return `/approvals/${notification.referenceId}`;
+
+    case 'REVIEW_REQUESTED':
+      return `/diagnostics/${notification.referenceId}`;
+
+    default:
+      return undefined;
+  }
 }
 
 export interface NotificationListParams {


### PR DESCRIPTION
## Summary
- 알림 클릭 시 해당 기안/결재 상세 페이지로 이동하는 기능 추가
- `getNotificationLink` 함수로 알림 타입별 이동 링크 생성
- 헤더 알림 드롭다운 및 알림 페이지에 적용

## Related Issue
Closes #270

## Test plan
- [ ] 알림 페이지에서 알림 클릭 시 해당 페이지로 이동 확인
- [ ] 헤더 알림 드롭다운에서 알림 클릭 시 해당 페이지로 이동 확인
- [ ] 링크 화살표 아이콘이 이동 가능한 알림에만 표시되는지 확인

## 참고 사항 (백엔드)
이 기능이 동작하려면 백엔드에서 알림 API 응답에 다음 필드를 제공해야 합니다:
- `referenceId`: 관련 기안/결재의 ID
- 또는 `link`: 이동할 전체 경로 (예: `/diagnostics/123`)

현재 알림 타입별 이동 경로:
| 알림 타입 | 이동 경로 |
|---------|---------|
| DIAGNOSTIC_SUBMITTED | /diagnostics/{referenceId} |
| DIAGNOSTIC_RETURNED | /diagnostics/{referenceId} |
| APPROVAL_REQUESTED | /approvals/{referenceId} |
| APPROVAL_COMPLETED | /diagnostics/{referenceId} |
| REVIEW_REQUESTED | /diagnostics/{referenceId} |
| REVIEW_COMPLETED | /diagnostics/{referenceId} |