### PR TITLE
feat: 심사자 사이드 메뉴 라우팅 및 심사 관리 UI 개선 (#317)

### DIFF
--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import { useApprovals } from '../../src/hooks/useApprovals';
-import { useReviewsDashboard, useReviews } from '../../src/hooks/useReviews';
+import { useReviews } from '../../src/hooks/useReviews';
 import { useNotifications, useMarkAsRead } from '../../src/hooks/useNotifications';
 import { useAuthStore } from '../../src/store/authStore';
 import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
@@ -243,7 +243,6 @@ export default function HomePage({ userRole }: HomePageProps) {
     userRole === 'approver' ? { domainCode: activeTab, size: 10 } : undefined
   );
 
-  const reviewsDashboardQuery = useReviewsDashboard();
   const reviewsListQuery = useReviews(
     userRole === 'receiver' ? { domainCode: activeTab, size: 10 } : undefined
   );
@@ -279,19 +278,21 @@ export default function HomePage({ userRole }: HomePageProps) {
     ];
   }, [approvalsQuery.data]);
 
-  // Stats for REVIEWER from dashboard API
+  // Stats for REVIEWER from reviews API summary
   const reviewerStats = useMemo(() => {
-    const dashboard = reviewsDashboardQuery.data;
-    if (!dashboard) return [];
+    const summary = reviewsListQuery.data?.summary;
+    if (!summary) return [];
 
     return [
-      { label: '전체 협력사', value: String(dashboard.totalCompanies || 0), color: 'text-[#212529]' },
-      { label: '미제출', value: String(dashboard.notSubmitted || 0), color: 'text-[#b91c1c]' },
-      { label: '검토중', value: String(dashboard.reviewing || 0), color: 'text-[#002554]' },
-      { label: '보완요청', value: String(dashboard.revisionRequired || 0), color: 'text-[#e65100]' },
-      { label: '완료', value: String(dashboard.completed || 0), color: 'text-[#008233]' },
+      { label: '전체 협력사', value: String(summary.totalCompanies || 0), color: 'text-[#212529]' },
+      { label: '완료', value: String(summary.completedCount || 0), color: 'text-[#008233]' },
+      { label: '진행중', value: String(summary.inProgressCount || 0), color: 'text-[#002554]' },
+      { label: '대기', value: String(summary.pendingCount || 0), color: 'text-[#495057]' },
+      { label: '고위험', value: String(summary.highRiskCount || 0), color: 'text-[#b91c1c]' },
+      { label: '중위험', value: String(summary.mediumRiskCount || 0), color: 'text-[#e65100]' },
+      { label: '저위험', value: String(summary.lowRiskCount || 0), color: 'text-[#008233]' },
     ];
-  }, [reviewsDashboardQuery.data]);
+  }, [reviewsListQuery.data?.summary]);
 
   // Get current stats based on role
   const currentStats = useMemo(() => {
@@ -501,7 +502,7 @@ export default function HomePage({ userRole }: HomePageProps) {
 
         {/* Stats Cards */}
         <div className="bg-white rounded-[20px] p-6 md:p-11 flex flex-wrap gap-8 md:gap-[100px] justify-between md:justify-start">
-          {(userRole === 'receiver' && reviewsDashboardQuery.isLoading) ||
+          {(userRole === 'receiver' && reviewsListQuery.isLoading) ||
           (userRole === 'drafter' && diagnosticsQuery.isLoading) ||
           (userRole === 'approver' && approvalsQuery.isLoading) ? (
             <div className="w-full">

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useReviews, useBulkReport, useExportReviews } from '../../src/hooks/useReviews';
 import { useAccessibleDomainOptions } from '../../src/hooks/useDomainGuard';
 import type { ReviewStatus, DomainCode } from '../../src/types/api.types';
@@ -16,11 +16,21 @@ type StatusFilter = ReviewStatus | 'ALL';
 
 export default function ReviewsListPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { domainOptions: accessibleDomainOptions } = useAccessibleDomainOptions();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
-  const [domainFilter, setDomainFilter] = useState('');
+  const domainFilter = searchParams.get('domainCode') || '';
   const [page, setPage] = useState(0);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
+
+  const handleDomainFilterChange = (value: string) => {
+    if (value) {
+      setSearchParams({ domainCode: value });
+    } else {
+      setSearchParams({});
+    }
+    setPage(0);
+  };
 
   const { data, isLoading, isError } = useReviews({
     status: statusFilter === 'ALL' ? undefined : statusFilter,
@@ -91,7 +101,7 @@ export default function ReviewsListPage() {
 
           <select
             value={domainFilter}
-            onChange={(e) => { setDomainFilter(e.target.value); setPage(0); }}
+            onChange={(e) => handleDomainFilterChange(e.target.value)}
             className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
           >
             <option value="">전체 도메인</option>

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -1,36 +1,31 @@
 import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useReviews, useBulkReport, useExportReviews } from '../../src/hooks/useReviews';
-import { useAccessibleDomainOptions } from '../../src/hooks/useDomainGuard';
 import type { ReviewStatus, DomainCode } from '../../src/types/api.types';
 import { DOMAIN_LABELS, REVIEW_STATUS_LABELS } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 
 const STATUS_STYLES: Record<ReviewStatus, string> = {
-  REVIEWING: 'bg-blue-50 text-blue-700 border-blue-200',
-  APPROVED: 'bg-green-50 text-green-700 border-green-200',
-  REVISION_REQUIRED: 'bg-orange-50 text-orange-700 border-orange-200',
+  REVIEWING: 'text-[#002554] bg-[#e3f2fd]',
+  APPROVED: 'text-[#008233] bg-[#f0fdf4]',
+  REVISION_REQUIRED: 'text-[#e65100] bg-[#fff3e0]',
+};
+
+const RISK_BADGE_STYLES: Record<string, string> = {
+  red: 'text-[#b91c1c] bg-[#fef2f2]',
+  yellow: 'text-[#e65100] bg-[#fff3e0]',
+  green: 'text-[#008233] bg-[#f0fdf4]',
 };
 
 type StatusFilter = ReviewStatus | 'ALL';
 
 export default function ReviewsListPage() {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { domainOptions: accessibleDomainOptions } = useAccessibleDomainOptions();
+  const [searchParams] = useSearchParams();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const domainFilter = searchParams.get('domainCode') || '';
   const [page, setPage] = useState(0);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
-
-  const handleDomainFilterChange = (value: string) => {
-    if (value) {
-      setSearchParams({ domainCode: value });
-    } else {
-      setSearchParams({});
-    }
-    setPage(0);
-  };
 
   const { data, isLoading, isError } = useReviews({
     status: statusFilter === 'ALL' ? undefined : statusFilter,
@@ -44,6 +39,7 @@ export default function ReviewsListPage() {
 
   const reviews = data?.content || [];
   const totalPages = data?.page?.totalPages || 0;
+  const dashboardData = data?.summary;
 
   const toggleSelect = (id: number) => {
     setSelectedIds((prev) =>
@@ -76,10 +72,96 @@ export default function ReviewsListPage() {
     { key: 'REVISION_REQUIRED', label: '보완요청' },
   ];
 
+  const domainLabel = domainFilter ? (DOMAIN_LABELS[domainFilter as DomainCode] || domainFilter) : '';
+
   return (
     <DashboardLayout>
       <div className="flex flex-col gap-[24px] p-[24px] lg:p-[40px] max-w-[1200px] mx-auto w-full">
-        <h1 className="font-heading-small text-[var(--color-text-primary)]">심사 관리</h1>
+        <h1 className="font-heading-small text-[var(--color-text-primary)]">
+          {domainLabel ? `${domainLabel} 심사 관리` : '심사 관리'}
+        </h1>
+
+        {/* 대시보드 통계 */}
+        {dashboardData && (
+          <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-[16px]">
+            {/* 총 협력사 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#dbeafe] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#2563eb]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">총 협력사</p>
+              <p className="font-title-large text-[#111827]">{dashboardData.totalCompanies}</p>
+            </div>
+
+            {/* 완료 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#dcfce7] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#16a34a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">완료</p>
+              <p className="font-title-large text-[#16a34a]">{dashboardData.completedCount}</p>
+            </div>
+
+            {/* 진행중 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#dbeafe] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#2563eb]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">진행중</p>
+              <p className="font-title-large text-[#2563eb]">{dashboardData.inProgressCount}</p>
+            </div>
+
+            {/* 대기 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#f3f4f6] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#6b7280]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">대기</p>
+              <p className="font-title-large text-[#6b7280]">{dashboardData.pendingCount}</p>
+            </div>
+
+            {/* 고위험 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#fee2e2] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#dc2626]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">고위험</p>
+              <p className="font-title-large text-[#dc2626]">{dashboardData.highRiskCount}</p>
+            </div>
+
+            {/* 중위험 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#fef3c7] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#d97706]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">중위험</p>
+              <p className="font-title-large text-[#d97706]">{dashboardData.mediumRiskCount}</p>
+            </div>
+
+            {/* 저위험 */}
+            <div className="bg-white rounded-[16px] p-[20px] shadow-sm">
+              <div className="w-[40px] h-[40px] rounded-full bg-[#dcfce7] flex items-center justify-center mb-[12px]">
+                <svg className="w-[20px] h-[20px] text-[#16a34a]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                </svg>
+              </div>
+              <p className="font-body-small text-[#6b7280] mb-[4px]">저위험</p>
+              <p className="font-title-large text-[#16a34a]">{dashboardData.lowRiskCount}</p>
+            </div>
+          </div>
+        )}
 
         {/* 필터 */}
         <div className="flex flex-wrap items-center gap-[12px]">
@@ -98,17 +180,6 @@ export default function ReviewsListPage() {
               </button>
             ))}
           </div>
-
-          <select
-            value={domainFilter}
-            onChange={(e) => handleDomainFilterChange(e.target.value)}
-            className="px-[12px] py-[8px] rounded-[8px] border border-[var(--color-border-default)] font-body-medium text-[var(--color-text-primary)] bg-white"
-          >
-            <option value="">전체 도메인</option>
-            {accessibleDomainOptions.map((opt: { value: string; label: string }) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
-          </select>
         </div>
 
         {/* 액션 바 */}
@@ -155,8 +226,8 @@ export default function ReviewsListPage() {
                   />
                 </th>
                 <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기안명</th>
-                <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">도메인</th>
                 <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">회사명</th>
+                <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">위험등급</th>
                 <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제출일</th>
                 <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>
               </tr>
@@ -186,41 +257,50 @@ export default function ReviewsListPage() {
                 </tr>
               )}
 
-              {reviews.map((item) => (
-                <tr
-                  key={item.reviewId}
-                  className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
-                >
-                  <td className="px-[16px] py-[14px]" onClick={(e) => e.stopPropagation()}>
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.includes(item.reviewId)}
-                      onChange={() => toggleSelect(item.reviewId)}
-                      className="w-[16px] h-[16px] cursor-pointer"
-                    />
-                  </td>
-                  <td
-                    className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]"
-                    onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}
+              {reviews.map((item) => {
+                const riskStyle = item.riskColorClass ? RISK_BADGE_STYLES[item.riskColorClass] : 'bg-gray-100 text-gray-600 border-gray-200';
+                return (
+                  <tr
+                    key={item.reviewId}
+                    className="border-b border-[var(--color-border-default)] hover:bg-gray-50 cursor-pointer transition-colors"
                   >
-                    {item.diagnostic?.title || item.reviewIdLabel || `R-${item.reviewId}`}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
-                    {item.domainName || DOMAIN_LABELS[item.domainCode as DomainCode] || item.domainCode}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
-                    {item.company?.companyName || '-'}
-                  </td>
-                  <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
-                    {new Date(item.submittedAt).toLocaleDateString('ko-KR')}
-                  </td>
-                  <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
-                    <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
-                      {REVIEW_STATUS_LABELS[item.status]}
-                    </span>
-                  </td>
-                </tr>
-              ))}
+                    <td className="px-[16px] py-[14px]" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.includes(item.reviewId)}
+                        onChange={() => toggleSelect(item.reviewId)}
+                        className="w-[16px] h-[16px] cursor-pointer"
+                      />
+                    </td>
+                    <td
+                      className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-primary)]"
+                      onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}
+                    >
+                      {item.diagnostic?.title || item.reviewIdLabel || `R-${item.reviewId}`}
+                    </td>
+                    <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-secondary)]" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
+                      {item.company?.companyName || '-'}
+                    </td>
+                    <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
+                      {item.riskLevelLabel ? (
+                        <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${riskStyle}`}>
+                          {item.riskLevelLabel}
+                        </span>
+                      ) : (
+                        <span className="font-body-medium text-[var(--color-text-tertiary)]">-</span>
+                      )}
+                    </td>
+                    <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
+                      {new Date(item.submittedAt).toLocaleDateString('ko-KR')}
+                    </td>
+                    <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
+                      <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${STATUS_STYLES[item.status]}`}>
+                        {REVIEW_STATUS_LABELS[item.status]}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/shared/layout/Sidebar.tsx
+++ b/shared/layout/Sidebar.tsx
@@ -13,10 +13,15 @@ interface MenuItem {
   domainCode?: DomainCode;
 }
 
-const DOMAIN_MENU_ITEMS: MenuItem[] = [
-  { label: '안전보건', path: '/diagnostics?domainCode=SAFETY', domainCode: 'SAFETY' },
-  { label: '컴플라이언스', path: '/diagnostics?domainCode=COMPLIANCE', domainCode: 'COMPLIANCE' },
-  { label: 'ESG', path: '/diagnostics?domainCode=ESG', domainCode: 'ESG' },
+interface DomainMenuItem {
+  label: string;
+  domainCode: DomainCode;
+}
+
+const DOMAIN_ITEMS: DomainMenuItem[] = [
+  { label: '안전보건', domainCode: 'SAFETY' },
+  { label: '컴플라이언스', domainCode: 'COMPLIANCE' },
+  { label: 'ESG', domainCode: 'ESG' },
 ];
 
 export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
@@ -31,15 +36,21 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
     return null;
   }
 
+  const isReviewer = user?.role?.code === 'REVIEWER';
   const menuItems: MenuItem[] = [{ label: '홈', path: '/dashboard' }];
 
-  DOMAIN_MENU_ITEMS.forEach((item) => {
-    if (item.domainCode && accessibleDomains.includes(item.domainCode)) {
-      menuItems.push(item);
+  DOMAIN_ITEMS.forEach((item) => {
+    if (accessibleDomains.includes(item.domainCode)) {
+      const basePath = isReviewer ? '/reviews' : '/diagnostics';
+      menuItems.push({
+        label: item.label,
+        path: `${basePath}?domainCode=${item.domainCode}`,
+        domainCode: item.domainCode,
+      });
     }
   });
 
-  if (user?.role?.code === 'REVIEWER') {
+  if (isReviewer) {
     menuItems.push({ label: '권한 관리', path: '/dashboard/permission' });
   }
 

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -7,10 +7,10 @@ import { QUERY_KEYS } from '../constants/queryKeys';
 import { handleApiError } from '../utils/errorHandler';
 import type { ErrorResponse } from '../types/api.types';
 
-export const useReviewsDashboard = () => {
+export const useReviewsDashboard = (domainCode?: string) => {
   return useQuery({
-    queryKey: QUERY_KEYS.REVIEWS.DASHBOARD,
-    queryFn: reviewsApi.getReviewsDashboard,
+    queryKey: [...QUERY_KEYS.REVIEWS.DASHBOARD, domainCode],
+    queryFn: () => reviewsApi.getReviewsDashboard(domainCode),
   });
 };
 


### PR DESCRIPTION
## Summary
- 심사자(REVIEWER)일 때 사이드 메뉴 도메인 클릭 시 `/reviews?domainCode=` 로 이동
- 심사 관리 페이지 대시보드 통계 카드 UI 구현
  - 총 협력사, 완료, 진행중, 대기, 고위험, 중위험, 저위험
- `/v1/reviews` API 응답의 `summary` 데이터 활용 (별도 dashboard API 호출 제거)
- 테이블에 위험등급 컬럼 추가, 도메인 드롭다운 제거
- 상태/위험등급 칩 색상 적용
- HomePage 심사자 대시보드도 동일하게 summary 데이터 연결

## Related Issue
Closes #317

## Test plan
- [ ] 심사자 계정으로 사이드 메뉴에서 도메인 클릭 시 `/reviews?domainCode=` 이동 확인
- [ ] 심사 관리 페이지에서 통계 카드(총 협력사, 완료, 진행중 등) 표시 확인
- [ ] 테이블에 위험등급 컬럼 및 색상 칩 표시 확인
- [ ] 심사자 홈 대시보드에서 통계 데이터 표시 확인
- [ ] Network 탭에서 `/v1/reviews/dashboard` API 호출이 없는지 확인