### PR TITLE
fix: 권한 관리 '보기' 버튼 텍스트 크기 증가

### DIFF
--- a/features/permission/PermissionManagementPage.tsx
+++ b/features/permission/PermissionManagementPage.tsx
@@ -302,13 +302,13 @@ export default function PermissionManagementPage() {
                         <td className="py-[14px] px-[16px] text-center border-b border-[#f1f3f5]">
                           <button
                             onClick={() => handleViewClick(req)}
-                            className={`inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                            className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-lg font-title-small transition-colors ${
                               req.status === 'PENDING'
                                 ? 'bg-[#003087] text-white hover:bg-[#002266]'
                                 : 'bg-[#f1f3f5] text-[#495057] hover:bg-[#e9ecef]'
                             }`}
                           >
-                            <Eye className="w-4 h-4" />
+                            <Eye className="w-5 h-5" />
                             {req.status === 'PENDING' ? '처리' : '보기'}
                           </button>
                         </td>


### PR DESCRIPTION
## Summary
- 권한 관리 페이지의 관리 컬럼 '보기'/'처리' 버튼 텍스트 크기를 증가하여 가독성 향상

## Changes
- `text-sm font-medium` → `font-title-small`로 변경
- 버튼 패딩 `px-3 py-1.5` → `px-4 py-2`로 조정
- Eye 아이콘 크기 `w-4 h-4` → `w-5 h-5`로 조정
- 아이콘-텍스트 간격 `gap-1` → `gap-1.5`로 조정

Closes #272