### PR TITLE
feat: 파일 전환 시 기존 채팅 세션 유지 (#324)

### DIFF
--- a/docs/FE_AI_CHATBOT_INTEGRATION.md
+++ b/docs/FE_AI_CHATBOT_INTEGRATION.md
@@ -1,0 +1,343 @@
+# AI Chatbot 프론트엔드 통합 가이드
+
+> 작성일: 2026-02-04 | 수정일: 2026-02-05
+> 관련 이슈: #140, #141, #186, #187, #188
+
+## 개요
+
+AI 기반 RAG 챗봇 API가 백엔드에 통합되었습니다. 이 문서는 프론트엔드에서 API를 연동하기 위한 가이드입니다.
+
+---
+
+## v1.1 변경사항 (2026-02-05)
+
+| 항목 | 변경 내용 |
+|------|----------|
+| `file_id` 필드 추가 | 증빙파일 ID를 보내면 AI가 해당 문서를 분석하여 답변 생성 |
+| `file_url` 필드 | **FE는 사용하지 않음** (BE가 내부적으로 Python에 전달하는 용도) |
+| 권한 검증 강화 | 다른 회사의 파일 접근 시 403 에러 |
+
+---
+
+## API 엔드포인트
+
+| Method | Path | 설명 | 권한 |
+|--------|------|------|------|
+| POST | `/api/v1/chat` | AI 채팅 | DRAFTER, APPROVER, REVIEWER |
+| POST | `/api/v1/admin/chat/sync` | Vector DB 동기화 | REVIEWER |
+| GET | `/api/v1/admin/chat/inspect` | DB 현황 조회 | REVIEWER |
+
+---
+
+## 1. 채팅 API
+
+사용자의 질문에 대해 RAG 기반으로 답변을 생성합니다.
+
+### Request
+
+```http
+POST /api/v1/chat
+Authorization: Bearer {token}
+Content-Type: application/json
+```
+
+#### 기본 채팅 (텍스트만)
+
+```json
+{
+  "message": "하도급법 위반 시 벌점은?",
+  "domain": "compliance"
+}
+```
+
+#### 파일 분석 채팅 (v1.1 신규)
+
+```json
+{
+  "message": "이 문서의 핵심 내용을 요약해줘",
+  "file_id": 42,
+  "domain": "esg"
+}
+```
+
+#### 멀티턴 대화
+
+```json
+{
+  "message": "좀 더 자세히 설명해줘",
+  "history": [
+    {"role": "user", "content": "하도급법이 뭐야?"},
+    {"role": "assistant", "content": "하도급 거래 공정화에 관한 법률입니다..."}
+  ],
+  "domain": "compliance",
+  "session_id": "이전-응답에서-받은-세션ID"
+}
+```
+
+### Request 필드
+
+| 필드 | JSON key | 타입 | 필수 | 기본값 | 설명 |
+|------|----------|------|------|--------|------|
+| message | `message` | string | **Yes** | - | 사용자의 질문 내용 |
+| fileId | `file_id` | number | No | `null` | **[v1.1]** 분석할 증빙파일 ID (`EvidenceFile.resultFileId`) |
+| history | `history` | array | No | `[]` | 이전 대화 기록 (멀티턴 문맥 파악용) |
+| domain | `domain` | string | No | `"all"` | 검색 영역 필터: `safety`, `compliance`, `esg`, `all` |
+| docName | `doc_name` | string | No | `null` | 특정 문서 내 검색 시 파일명 |
+| topK | `top_k` | integer | No | `8` | 검색할 문서 개수 (1~30) |
+| sessionId | `session_id` | string | No | `null` | 세션 식별자 (null이면 서버에서 자동 생성) |
+
+> **참고**: `file_url` 필드는 BE 내부 전용입니다. FE에서 보내지 마세요. `file_id`만 보내면 BE가 presigned URL을 생성하여 AI 서비스에 전달합니다.
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "채팅 완료",
+  "data": {
+    "answer": "하도급법 위반 시 벌점은 위반 사유에 따라 다르며, 최대 5점까지 부과될 수 있습니다.",
+    "confidence": "high",
+    "notes": null,
+    "sources": [
+      {
+        "title": "하도급가이드.pdf",
+        "type": "manual",
+        "snippet": "벌점 부과 기준은 다음과 같다...",
+        "score": 0.89,
+        "loc": {
+          "page": 15,
+          "lineStart": null
+        }
+      }
+    ]
+  },
+  "timestamp": "2026-02-05T13:40:00"
+}
+```
+
+### Response 필드
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `answer` | string | AI가 생성한 최종 답변 |
+| `confidence` | string | 답변 신뢰도: `high`, `medium`, `low` |
+| `notes` | string | 비고 (예: "근거 자료 없음") |
+| `sources` | array | 답변에 사용된 근거 자료 목록 |
+
+### Source 객체
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `title` | string | 문서 제목 또는 파일명 |
+| `type` | string | 자료 유형: `manual`, `code`, `law` |
+| `snippet` | string | 실제 참고한 본문 내용 (일부) |
+| `score` | number | 검색 유사도 점수 (0.0 ~ 1.0) |
+| `loc.page` | integer | 페이지 번호 |
+| `loc.lineStart` | integer | 시작 줄 번호 |
+
+---
+
+## 2. Admin 동기화 API (REVIEWER 전용)
+
+PDF 파일과 소스 코드를 파싱하여 Vector DB에 적재합니다. 비동기로 실행됩니다.
+
+### Request
+
+```http
+POST /api/v1/admin/chat/sync
+Authorization: Bearer {token}
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "동기화 요청이 접수되었습니다",
+  "data": {
+    "status": "accepted",
+    "message": "동기화 작업이 백그라운드에서 시작되었습니다."
+  },
+  "timestamp": "2026-02-05T13:40:00"
+}
+```
+
+---
+
+## 3. Admin DB 현황 조회 API (REVIEWER 전용)
+
+현재 Vector DB에 저장된 문서 개수와 샘플 데이터를 확인합니다.
+
+### Request
+
+```http
+GET /api/v1/admin/chat/inspect
+Authorization: Bearer {token}
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "DB 현황 조회 완료",
+  "data": {
+    "totalDocuments": 1542,
+    "samples": [
+      "[manual] 안전작업표준.pdf (ID: manual:안전작업표준.pdf:p1:c0...)",
+      "[code] validators.py (ID: code:validators.py:L10-L50...)"
+    ]
+  },
+  "timestamp": "2026-02-05T13:40:00"
+}
+```
+
+---
+
+## 에러 코드
+
+| 코드 | HTTP Status | 설명 |
+|------|-------------|------|
+| `CHAT001` | 500 | AI 채팅 서비스 오류가 발생했습니다 |
+| `CHAT002` | 504 | AI 채팅 서비스 응답 시간이 초과되었습니다 |
+| `CHAT003` | 400 | 유효하지 않은 도메인입니다 |
+| `FILE_001` | 404 | **[v1.1]** 파일을 찾을 수 없습니다 (`file_id`가 잘못된 경우) |
+| `PERM_002` | 403 | 해당 작업을 수행할 권한이 없습니다 (다른 회사 파일 접근 포함) |
+| `A001` | 401 | 유효하지 않은 토큰입니다 |
+
+### 에러 응답 예시
+
+```json
+{
+  "success": false,
+  "code": "FILE_001",
+  "message": "파일을 찾을 수 없습니다",
+  "timestamp": "2026-02-05T13:40:00"
+}
+```
+
+---
+
+## 파일 분석 연동 가이드 (v1.1)
+
+### 사용 시나리오
+
+1. 사용자가 진단 상세 화면에서 증빙파일을 보고 있음
+2. 챗봇을 열고 "이 문서 요약해줘" + 파일 선택
+3. FE는 해당 파일의 `resultFileId`를 `file_id`로 전달
+4. AI가 문서를 분석하여 답변 생성
+
+### file_id 얻는 방법
+
+증빙파일 목록 API 응답에서 `resultFileId` 사용:
+
+```
+GET /api/v1/diagnostics/{id}/files
+→ response.data[].resultFileId  ← 이 값을 file_id로 사용
+```
+
+### 권한 규칙
+
+- 자기 회사의 파일만 분석 가능
+- 다른 회사 파일 → `403 PERM_002`
+- 존재하지 않는 file_id → `404 FILE_001`
+
+### UI 구현 포인트
+
+- 챗봇 입력창 옆에 **파일 첨부 버튼** (클립 아이콘 등)
+- 클릭 시 현재 진단의 증빙파일 목록에서 선택
+- 선택된 파일명을 입력창 위에 칩/태그로 표시
+- 파일 없이도 일반 채팅은 정상 동작
+
+---
+
+## UI 구현 가이드
+
+### 1. 채팅 UI
+
+- **메시지 입력**: 텍스트 입력 필드 + 전송 버튼
+- **파일 첨부**: 파일 선택 버튼 (optional)
+- **도메인 선택**: 드롭다운 (safety, compliance, esg, all)
+- **히스토리 관리**: 클라이언트에서 대화 기록 유지 후 `history` 파라미터로 전달
+- **세션 관리**: 첫 응답에서 받은 sessionId를 이후 요청에 재사용 (또는 서버 자동 생성)
+
+### 2. 답변 표시
+
+- **답변 텍스트**: `data.answer` 표시
+- **신뢰도 뱃지**: `data.confidence`에 따라 색상 구분
+  - `high`: 녹색
+  - `medium`: 노란색
+  - `low`: 빨간색
+- **출처 표시**: `data.sources` 배열을 접이식 패널로 표시
+  - 문서명, 유형, 페이지 번호, 유사도 점수
+
+### 3. 로딩 상태
+
+- AI 응답은 최대 30초까지 소요될 수 있음
+- 파일 분석 시 더 오래 걸릴 수 있음
+- 로딩 인디케이터 또는 타이핑 애니메이션 권장
+
+### 4. Admin 페이지 (REVIEWER 전용)
+
+- **동기화 버튼**: "Vector DB 동기화" 버튼 클릭 시 `/admin/chat/sync` 호출
+- **현황 조회**: 총 문서 수, 샘플 목록 표시
+
+---
+
+## TypeScript 타입 정의
+
+```typescript
+// Request
+interface ChatRequest {
+  message: string;
+  file_id?: number;         // [v1.1] 분석할 증빙파일 ID
+  history?: ChatMessage[];
+  domain?: 'safety' | 'compliance' | 'esg' | 'all';
+  doc_name?: string;
+  top_k?: number;
+  session_id?: string;
+}
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+// Response
+interface ChatResponse {
+  answer: string;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string | null;
+  sources: SourceItem[];
+}
+
+interface SourceItem {
+  title: string;
+  type: 'manual' | 'code' | 'law';
+  snippet: string;
+  score: number;
+  loc: {
+    page: number | null;
+    lineStart: number | null;
+  };
+}
+
+interface AdminSyncResponse {
+  status: string;
+  message: string;
+}
+
+interface AdminInspectResponse {
+  totalDocuments: number;
+  samples: string[];
+}
+```
+
+---
+
+## 변경 이력
+
+| 날짜 | 버전 | 변경 내용 |
+|------|------|----------|
+| 2026-02-04 | 1.0 | 최초 작성 |
+| 2026-02-05 | 1.1 | `file_id` 파일 분석 기능 추가, 에러코드 추가, TS 타입 업데이트 |

--- a/features/documents/AiAnalysisPage.tsx
+++ b/features/documents/AiAnalysisPage.tsx
@@ -1,0 +1,568 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import * as XLSX from 'xlsx';
+import DashboardLayout from '../../shared/layout/DashboardLayout';
+import {
+  ArrowLeft,
+  FileText,
+  Send,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  Download,
+} from 'lucide-react';
+import { useDiagnosticFiles } from '../../src/hooks/useFiles';
+import { useChatSend } from '../../src/hooks/useChat';
+import { getDownloadUrl, fetchFileBlob } from '../../src/api/files';
+import type { EvidenceFile, DownloadUrlResponse } from '../../src/api/files';
+import type { ChatMessage, SourceItem } from '../../src/api/chat';
+
+// ============================================
+// Types
+// ============================================
+
+interface DisplayMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  confidence?: 'high' | 'medium' | 'low';
+  sources?: SourceItem[];
+  attachedFileName?: string;
+}
+
+interface FileSession {
+  messages: DisplayMessage[];
+  sessionId?: string;
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+function getFileExt(fileName: string): string {
+  return fileName.split('.').pop()?.toLowerCase() || '';
+}
+
+function isImage(fileName: string): boolean {
+  return ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'].includes(getFileExt(fileName));
+}
+
+function isPdf(fileName: string): boolean {
+  return getFileExt(fileName) === 'pdf';
+}
+
+function isSpreadsheet(fileName: string): boolean {
+  return ['xlsx', 'xls', 'csv'].includes(getFileExt(fileName));
+}
+
+// ============================================
+// Constants
+// ============================================
+
+const confidenceColors: Record<string, string> = {
+  high: 'bg-[#f0fdf4] text-[#008233] border-[#bbf7d0]',
+  medium: 'bg-[#fffbeb] text-[#b45309] border-[#fde68a]',
+  low: 'bg-[#fef2f2] text-[#b91c1c] border-[#fecaca]',
+};
+
+const confidenceLabels: Record<string, string> = {
+  high: '높음',
+  medium: '보통',
+  low: '낮음',
+};
+
+// ============================================
+// Main Component
+// ============================================
+
+export default function AiAnalysisPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const diagnosticId = Number(searchParams.get('diagnosticId')) || 0;
+  const domain = (searchParams.get('domain') || 'compliance') as 'safety' | 'compliance' | 'esg' | 'all';
+
+  // Hide reCAPTCHA badge on this page
+  useEffect(() => {
+    const badge = document.querySelector('.grecaptcha-badge') as HTMLElement | null;
+    if (badge) badge.style.visibility = 'hidden';
+    return () => { if (badge) badge.style.visibility = 'visible'; };
+  }, []);
+
+  // File state
+  const { data: files = [] } = useDiagnosticFiles(diagnosticId);
+  const [selectedFile, setSelectedFile] = useState<EvidenceFile | null>(null);
+  const [fileDownload, setFileDownload] = useState<DownloadUrlResponse | null>(null);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [loadingFileUrl, setLoadingFileUrl] = useState(false);
+  const [sheetHtml, setSheetHtml] = useState<string | null>(null);
+
+  // Chat state (per-file sessions)
+  const fileSessionsRef = useRef<Map<number, FileSession>>(new Map());
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [sessionId, setSessionId] = useState<string | undefined>();
+  const chatSend = useChatSend();
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-select first file
+  useEffect(() => {
+    if (files.length > 0 && !selectedFile) {
+      setSelectedFile(files[0]);
+    }
+  }, [files, selectedFile]);
+
+  // Load file download info when selected file changes
+  useEffect(() => {
+    if (!selectedFile) {
+      setFileDownload(null);
+      setBlobUrl(null);
+      setSheetHtml(null);
+      return;
+    }
+    let cancelled = false;
+    setLoadingFileUrl(true);
+    setSheetHtml(null);
+
+    getDownloadUrl(selectedFile.fileId)
+      .then(async (data) => {
+        if (cancelled) return;
+        setFileDownload(data);
+
+        // xlsx/xls/csv → fetch via apiClient & parse with sheetjs
+        if (isSpreadsheet(data.fileName)) {
+          const url = await fetchFileBlob(data.downloadUrl);
+          if (cancelled) { URL.revokeObjectURL(url); return; }
+          setBlobUrl(url);
+          const resp = await fetch(url);
+          const buf = await resp.arrayBuffer();
+          const wb = XLSX.read(buf, { type: 'array' });
+          const ws = wb.Sheets[wb.SheetNames[0]];
+          const html = XLSX.utils.sheet_to_html(ws, { editable: false });
+          if (!cancelled) setSheetHtml(html);
+        } else {
+          // PDF, image, etc. → fetch via apiClient as blob
+          const url = await fetchFileBlob(data.downloadUrl);
+          if (cancelled) { URL.revokeObjectURL(url); return; }
+          setBlobUrl(url);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) { setFileDownload(null); setBlobUrl(null); }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingFileUrl(false);
+      });
+    return () => {
+      cancelled = true;
+      setBlobUrl((prev) => { if (prev) URL.revokeObjectURL(prev); return null; });
+    };
+  }, [selectedFile]);
+
+  // Keep fileSessionsRef in sync with current chat state
+  useEffect(() => {
+    if (selectedFile) {
+      fileSessionsRef.current.set(selectedFile.fileId, { messages, sessionId });
+    }
+  }, [messages, sessionId, selectedFile]);
+
+  // Auto-scroll chat
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSelectFile = (file: EvidenceFile) => {
+    if (file.fileId === selectedFile?.fileId) return;
+
+    // Save current file's session
+    if (selectedFile) {
+      fileSessionsRef.current.set(selectedFile.fileId, { messages, sessionId });
+    }
+
+    // Restore or start fresh for the new file
+    const saved = fileSessionsRef.current.get(file.fileId);
+    setMessages(saved?.messages ?? []);
+    setSessionId(saved?.sessionId);
+    setSelectedFile(file);
+  };
+
+  const buildHistory = useCallback((): ChatMessage[] => {
+    return messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+    }));
+  }, [messages]);
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed || chatSend.isPending) return;
+
+    const userMsg: DisplayMessage = {
+      role: 'user',
+      content: trimmed,
+      attachedFileName: selectedFile?.fileName,
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+
+    const request = {
+      message: trimmed,
+      domain,
+      history: buildHistory(),
+      session_id: sessionId,
+      ...(selectedFile ? { file_id: selectedFile.fileId } : {}),
+    };
+
+    chatSend.mutate(request, {
+      onSuccess: (data) => {
+        if (data.session_id) setSessionId(data.session_id);
+        const assistantMsg: DisplayMessage = {
+          role: 'assistant',
+          content: data.answer,
+          confidence: data.confidence,
+          sources: data.sources,
+        };
+        setMessages((prev) => [...prev, assistantMsg]);
+      },
+      onError: () => {
+        const errorMsg: DisplayMessage = {
+          role: 'assistant',
+          content: 'AI 응답을 가져오지 못했습니다. 다시 시도해주세요.',
+        };
+        setMessages((prev) => [...prev, errorMsg]);
+      },
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <DashboardLayout hideSidebar>
+      <div className="h-[calc(100vh-64px)] flex flex-col">
+        {/* Top Bar */}
+        <div className="flex items-center gap-[12px] px-[24px] py-[12px] border-b border-[#dee2e6] bg-white">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-[6px] text-[#495057] hover:text-[#212529] transition-colors font-body-medium"
+          >
+            <ArrowLeft className="w-[18px] h-[18px]" />
+            결과 조회로 돌아가기
+          </button>
+          <div className="w-[1px] h-[20px] bg-[#dee2e6]" />
+          <span className="font-title-small text-[#212529]">AI 문서 분석</span>
+        </div>
+
+        {/* Main Content: [File Tabs | Viewer | Chatbot] */}
+        <div className="flex flex-1 min-h-0">
+          {/* ===== LEFT: Vertical File Tabs ===== */}
+          <div className="w-[220px] flex-shrink-0 border-r border-[#dee2e6] bg-[#f8f9fa] flex flex-col">
+            <div className="px-[14px] py-[12px] border-b border-[#dee2e6]">
+              <span className="font-title-small text-[#495057]">
+                증빙파일 ({files.length})
+              </span>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {files.map((file) => (
+                <button
+                  key={file.fileId}
+                  onClick={() => handleSelectFile(file)}
+                  className={`w-full flex items-center gap-[8px] px-[14px] py-[10px] text-left transition-colors border-l-[3px] ${
+                    selectedFile?.fileId === file.fileId
+                      ? 'bg-white border-l-[#003087] text-[#003087]'
+                      : 'border-l-transparent text-[#495057] hover:bg-[#e9ecef]'
+                  }`}
+                >
+                  <FileText className="w-[16px] h-[16px] flex-shrink-0" />
+                  <span className="font-body-small truncate">{file.fileName}</span>
+                </button>
+              ))}
+              {files.length === 0 && (
+                <div className="px-[14px] py-[20px] font-body-small text-[#868e96] text-center">
+                  파일이 없습니다.
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* ===== CENTER: File Viewer ===== */}
+          <div className="flex-1 bg-[#e9ecef] flex items-center justify-center min-h-0 min-w-0 overflow-auto">
+            {loadingFileUrl ? (
+              <div className="flex flex-col items-center gap-[12px] text-[#868e96]">
+                <Loader2 className="w-[32px] h-[32px] animate-spin" />
+                <span className="font-body-medium">파일 로딩 중...</span>
+              </div>
+            ) : fileDownload ? (
+              <FileViewer
+                fileDownload={fileDownload}
+                blobUrl={blobUrl}
+                sheetHtml={sheetHtml}
+                fileName={selectedFile?.fileName || ''}
+              />
+            ) : (
+              <div className="flex flex-col items-center gap-[12px] text-[#868e96]">
+                <FileText className="w-[48px] h-[48px]" />
+                <span className="font-body-medium">
+                  {files.length > 0 ? '파일을 선택해주세요' : '등록된 파일이 없습니다'}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* ===== RIGHT: Chatbot ===== */}
+          <div className="w-[380px] flex-shrink-0 flex flex-col bg-white border-l border-[#dee2e6]">
+            {/* Chat Header */}
+            <div className="px-[20px] py-[14px] border-b border-[#dee2e6]">
+              <h3 className="font-title-medium text-[#212529]">AI 어시스턴트</h3>
+              <p className="font-body-small text-[#868e96] mt-[2px]">
+                선택한 파일 기반으로 질문하세요
+              </p>
+            </div>
+
+            {/* Selected file indicator */}
+            {selectedFile && (
+              <div className="px-[16px] py-[8px] bg-[#e7f5ff] border-b border-[#dee2e6]">
+                <span className="inline-flex items-center gap-[4px] font-body-small text-[#1971c2]">
+                  <FileText className="w-[12px] h-[12px]" />
+                  {selectedFile.fileName}
+                </span>
+              </div>
+            )}
+
+            {/* Messages */}
+            <div className="flex-1 overflow-y-auto px-[16px] py-[16px] space-y-[16px] min-h-0">
+              {messages.length === 0 && (
+                <div className="flex flex-col items-center justify-center h-full text-[#868e96] gap-[12px]">
+                  <div className="w-[56px] h-[56px] rounded-full bg-[#f1f3f5] flex items-center justify-center">
+                    <Send className="w-[24px] h-[24px]" />
+                  </div>
+                  <p className="font-body-medium text-center">
+                    AI에게 문서 분석을<br />요청해보세요.
+                  </p>
+                </div>
+              )}
+
+              {messages.map((msg, idx) => (
+                <MessageBubble key={idx} message={msg} />
+              ))}
+
+              {chatSend.isPending && (
+                <div className="flex items-start gap-[8px]">
+                  <div className="w-[28px] h-[28px] rounded-full bg-[#003087] flex items-center justify-center flex-shrink-0">
+                    <span className="text-white text-xs font-bold">AI</span>
+                  </div>
+                  <div className="bg-[#f1f3f5] rounded-[12px] px-[14px] py-[10px]">
+                    <div className="flex gap-[4px]">
+                      <span className="w-[6px] h-[6px] bg-[#868e96] rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                      <span className="w-[6px] h-[6px] bg-[#868e96] rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                      <span className="w-[6px] h-[6px] bg-[#868e96] rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Input Area */}
+            <div className="border-t border-[#dee2e6] px-[12px] py-[10px]">
+              <div className="flex items-end gap-[8px]">
+                <textarea
+                  ref={inputRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="질문을 입력하세요..."
+                  rows={1}
+                  className="flex-1 resize-none border border-[#dee2e6] rounded-[10px] px-[12px] py-[10px] font-body-medium focus:outline-none focus:border-[#003087] max-h-[120px]"
+                  style={{ minHeight: '40px' }}
+                />
+                <button
+                  onClick={handleSend}
+                  disabled={!input.trim() || chatSend.isPending}
+                  className="p-[10px] bg-[#003087] text-white rounded-[10px] hover:bg-[#002554] transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0"
+                >
+                  <Send className="w-[18px] h-[18px]" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}
+
+// ============================================
+// Sub-components
+// ============================================
+
+function FileViewer({
+  fileDownload,
+  blobUrl,
+  sheetHtml,
+  fileName,
+}: {
+  fileDownload: DownloadUrlResponse;
+  blobUrl: string | null;
+  sheetHtml: string | null;
+  fileName: string;
+}) {
+  const name = fileDownload.fileName || fileName;
+  const viewUrl = blobUrl || fileDownload.downloadUrl;
+
+  // PDF
+  if (isPdf(name)) {
+    return (
+      <iframe
+        src={viewUrl}
+        className="w-full h-full border-none"
+        title={name}
+      />
+    );
+  }
+
+  // Image
+  if (isImage(name)) {
+    return (
+      <div className="p-[24px] flex items-center justify-center w-full h-full">
+        <img
+          src={viewUrl}
+          alt={name}
+          className="max-w-full max-h-full object-contain rounded-[8px]"
+        />
+      </div>
+    );
+  }
+
+  // Spreadsheet (xlsx/xls/csv)
+  if (isSpreadsheet(name) && sheetHtml) {
+    return (
+      <div
+        className="w-full h-full overflow-auto bg-white p-[16px] sheet-viewer"
+        dangerouslySetInnerHTML={{ __html: sheetHtml }}
+        style={{
+          // sheetjs 테이블 기본 스타일링
+          // @ts-expect-error CSS custom property
+          '--sheet-border': '#dee2e6',
+        }}
+      />
+    );
+  }
+
+  // Fallback: download
+  return (
+    <div className="flex flex-col items-center gap-[16px] text-[#868e96]">
+      <FileText className="w-[48px] h-[48px]" />
+      <span className="font-body-medium">{name}</span>
+      <span className="font-body-small">이 파일 형식은 미리보기를 지원하지 않습니다.</span>
+      <a
+        href={viewUrl}
+        download={name}
+        className="flex items-center gap-[6px] px-[20px] py-[10px] bg-[#003087] text-white rounded-[8px] font-title-small hover:bg-[#002554] transition-colors"
+      >
+        <Download className="w-[16px] h-[16px]" />
+        파일 다운로드
+      </a>
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: DisplayMessage }) {
+  const [showSources, setShowSources] = useState(false);
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex items-start gap-[8px] ${isUser ? 'flex-row-reverse' : ''}`}>
+      {/* Avatar */}
+      {isUser ? (
+        <div className="w-[28px] h-[28px] rounded-full bg-[#495057] flex items-center justify-center flex-shrink-0">
+          <span className="text-white text-xs font-bold">U</span>
+        </div>
+      ) : (
+        <div className="w-[28px] h-[28px] rounded-full bg-[#003087] flex items-center justify-center flex-shrink-0">
+          <span className="text-white text-xs font-bold">AI</span>
+        </div>
+      )}
+
+      {/* Bubble */}
+      <div className={`max-w-[80%] ${isUser ? 'items-end' : 'items-start'}`}>
+        {/* Attached file indicator */}
+        {message.attachedFileName && (
+          <div className="flex items-center gap-[4px] mb-[4px]">
+            <span className="inline-flex items-center gap-[4px] px-[8px] py-[2px] bg-[#e7f5ff] text-[#1971c2] rounded font-body-small text-xs">
+              <FileText className="w-[10px] h-[10px]" />
+              {message.attachedFileName}
+            </span>
+          </div>
+        )}
+
+        <div
+          className={`rounded-[12px] px-[14px] py-[10px] ${
+            isUser
+              ? 'bg-[#003087] text-white'
+              : 'bg-[#f1f3f5] text-[#212529]'
+          }`}
+        >
+          <p className="font-body-medium whitespace-pre-wrap">{message.content}</p>
+        </div>
+
+        {/* Confidence badge */}
+        {message.confidence && (
+          <div className="mt-[4px]">
+            <span
+              className={`inline-block px-[8px] py-[2px] rounded border text-xs font-medium ${
+                confidenceColors[message.confidence]
+              }`}
+            >
+              신뢰도: {confidenceLabels[message.confidence]}
+            </span>
+          </div>
+        )}
+
+        {/* Sources */}
+        {message.sources && message.sources.length > 0 && (
+          <div className="mt-[6px]">
+            <button
+              onClick={() => setShowSources(!showSources)}
+              className="flex items-center gap-[4px] text-[#868e96] hover:text-[#495057] font-body-small transition-colors"
+            >
+              {showSources ? <ChevronUp className="w-[14px] h-[14px]" /> : <ChevronDown className="w-[14px] h-[14px]" />}
+              출처 ({message.sources.length})
+            </button>
+            {showSources && (
+              <div className="mt-[6px] space-y-[6px]">
+                {message.sources.map((source, i) => (
+                  <SourceCard key={i} source={source} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SourceCard({ source }: { source: SourceItem }) {
+  const scorePercent = Math.round(source.score * 100);
+
+  return (
+    <div className="bg-white border border-[#dee2e6] rounded-[8px] p-[10px]">
+      <div className="flex items-center justify-between mb-[4px]">
+        <span className="font-title-small text-[#212529] text-xs">{source.title}</span>
+        <span className="text-xs text-[#868e96]">{scorePercent}%</span>
+      </div>
+      {source.snippet && (
+        <p className="font-body-small text-[#495057] text-xs line-clamp-2">{source.snippet}</p>
+      )}
+      <div className="flex items-center gap-[8px] mt-[4px] text-xs text-[#868e96]">
+        <span>{source.type}</span>
+        {source.loc.page && <span>p.{source.loc.page}</span>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 요약
- AI 문서 분석 페이지에서 파일 전환 시 채팅 세션이 초기화되던 문제 해결
- `fileSessionsRef`(Map)를 활용하여 파일별 `messages` + `sessionId`를 보존
- 파일을 다시 선택하면 이전 대화가 그대로 복원됨

## 관련 이슈
- Closes #324
- Related #314

## 테스트 방법
1. AI 문서 분석 페이지 진입 (증빙파일 2개 이상 필요)
2. 파일 A 선택 → 챗봇에 질문 → 응답 확인
3. 파일 B로 전환 → 채팅이 빈 상태로 초기화되는지 확인
4. 다시 파일 A로 전환 → 이전 대화 내용이 복원되는지 확인
5. 같은 파일 재클릭 시 아무 변화 없는지 확인

## 명세 준수 체크
- [x] `FileSession` 인터페이스 추가 (`messages`, `sessionId`)
- [x] `useRef<Map<number, FileSession>>`로 세션 저장 (불필요한 리렌더 방지)
- [x] `handleSelectFile`에서 현재 세션 저장 → 대상 세션 복원
- [x] `messages`/`sessionId` 변경 시 자동 동기화 effect
- [x] 동일 파일 재클릭 시 early return

## 리뷰 포인트
- `fileSessionsRef`를 `useRef`로 관리하여 Map 업데이트가 리렌더를 유발하지 않도록 했습니다. 동기화는 별도 `useEffect`에서 처리합니다.
- 페이지 이탈 시 세션은 메모리에서 해제됩니다 (영속 저장 불필요 판단)

## TODO / 질문
- [ ] 세션 수가 많아질 경우 메모리 제한 정책이 필요한지? (현재는 파일 수만큼만 저장)
- [ ] 서버 측 `session_id`가 만료될 경우 에러 핸들링 추가 필요 여부
- [ ] 페이지 새로고침 시 세션 복원이 필요하면 sessionStorage 연동 검토