### PR TITLE
feat: AI 문서 분석 페이지 라우팅·API·레이아웃 인프라 구성 (#326)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,7 @@ import DiagnosticDetailPage from './features/diagnostics/DiagnosticDetailPage';
 import DiagnosticCreatePage from './features/diagnostics/DiagnosticCreatePage';
 import DiagnosticFilesPage from './features/diagnostics/DiagnosticFilesPage';
 import ReviewsListPage from './features/reviews/ReviewsListPage';
+import AiAnalysisPage from './features/documents/AiAnalysisPage';
 import UserManagementPage from './features/management/UserManagementPage';
 import CompanyManagementPage from './features/management/CompanyManagementPage';
 import ActivityLogPage from './features/management/ActivityLogPage';
@@ -313,6 +314,14 @@ function AppRoutes() {
         element={
           <DomainProtectedRoute domainCode="COMPLIANCE">
             <DocumentReviewPage userRole={legacyRole} />
+          </DomainProtectedRoute>
+        }
+      />
+      <Route
+        path="/dashboard/compliance/review/:id/ai-analysis"
+        element={
+          <DomainProtectedRoute domainCode="COMPLIANCE">
+            <AiAnalysisPage />
           </DomainProtectedRoute>
         }
       />

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
-import { AlertCircle, ArrowLeft, X, FileText, Download } from 'lucide-react';
+import { AlertCircle, ArrowLeft, X, FileText, Download, Bot } from 'lucide-react';
 import { useReviewDetail, useSubmitReview } from '../../src/hooks/useReviews';
 import { useAiResult } from '../../src/hooks/useAiRun';
 import type { DomainCode } from '../../src/types/api.types';
@@ -424,6 +424,19 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                   <ArrowLeft className="w-[20px] h-[20px]" />
                   목록으로 (Back to List)
                 </button>
+                {review.domainCode === 'COMPLIANCE' && (
+                  <button
+                    onClick={() =>
+                      navigate(
+                        `/dashboard/compliance/review/${reviewId}/ai-analysis?diagnosticId=${diagnosticId}&domain=compliance`
+                      )
+                    }
+                    className="px-[32px] py-[14px] bg-[#003087] text-white rounded-[8px] font-title-small hover:bg-[#002554] transition-colors flex items-center gap-[8px]"
+                  >
+                    <Bot className="w-[20px] h-[20px]" />
+                    AI 문서 분석
+                  </button>
+                )}
                 <button
                   onClick={handleReject}
                   className="px-[32px] py-[14px] bg-[#e65100] text-white rounded-[8px] font-title-small hover:bg-[#d84a00] transition-colors"

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.0",
+        "xlsx": "^0.18.5",
         "zod": "^3.22.4",
         "zustand": "^5.0.10"
       },
@@ -3556,6 +3557,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3778,6 +3788,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3814,6 +3837,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -3861,6 +3893,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4541,6 +4585,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -6091,6 +6144,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -6439,6 +6504,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6455,6 +6538,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tailwindcss": "^4.0.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.0",
+    "xlsx": "^0.18.5",
     "zod": "^3.22.4",
     "zustand": "^5.0.10"
   },

--- a/shared/layout/DashboardLayout.tsx
+++ b/shared/layout/DashboardLayout.tsx
@@ -6,9 +6,10 @@ import { useAuthStore } from '../../src/store/authStore';
 
 interface DashboardLayoutProps {
   children: ReactNode;
+  hideSidebar?: boolean;
 }
 
-export default function DashboardLayout({ children }: DashboardLayoutProps) {
+export default function DashboardLayout({ children, hideSidebar }: DashboardLayoutProps) {
   const { user, isGuest } = useAuthStore();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -32,7 +33,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         onToggleSidebar={() => setSidebarOpen((prev) => !prev)}
       />
       <div className="flex flex-1 relative">
-        {!isUserGuest && (
+        {!isUserGuest && !hideSidebar && (
           <Sidebar
             isOpen={sidebarOpen}
             onClose={() => setSidebarOpen(false)}

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,0 +1,53 @@
+import { apiClient } from './client';
+import type { BaseResponse } from '../types/api.types';
+
+// ============================================
+// Request / Response Types
+// ============================================
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatRequest {
+  message: string;
+  file_id?: number;
+  history?: ChatMessage[];
+  domain?: 'safety' | 'compliance' | 'esg' | 'all';
+  doc_name?: string;
+  top_k?: number;
+  session_id?: string;
+}
+
+export interface SourceItem {
+  title: string;
+  type: 'manual' | 'code' | 'law';
+  snippet: string;
+  score: number;
+  loc: {
+    page: number | null;
+    lineStart: number | null;
+  };
+}
+
+export interface ChatResponseData {
+  answer: string;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string | null;
+  sources: SourceItem[];
+  session_id?: string;
+}
+
+// ============================================
+// API Functions
+// ============================================
+
+export const sendChat = async (request: ChatRequest): Promise<ChatResponseData> => {
+  const response = await apiClient.post<BaseResponse<ChatResponseData>>(
+    '/v1/chat',
+    request,
+    { timeout: 60000 },
+  );
+  return response.data.data;
+};

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -83,9 +83,30 @@ export const getParsingResult = async (
   return response.data.data;
 };
 
-export const getDownloadUrl = async (fileId: number): Promise<string> => {
-  const response = await apiClient.get<BaseResponse<{ url: string }>>(`/v1/files/${fileId}/download-url`);
-  return response.data.data.url;
+export interface DownloadUrlResponse {
+  downloadUrl: string;
+  fileName: string;
+  fileSize: number;
+  expiresAt: string;
+}
+
+export const getDownloadUrl = async (fileId: number): Promise<DownloadUrlResponse> => {
+  const response = await apiClient.get<BaseResponse<DownloadUrlResponse>>(
+    `/v1/files/${fileId}/download-url`,
+  );
+  const data = response.data.data;
+
+  // downloadUrl이 상대경로이면 origin을 붙여 절대 URL로 변환
+  if (data.downloadUrl && !data.downloadUrl.startsWith('http')) {
+    data.downloadUrl = `${window.location.origin}${data.downloadUrl}`;
+  }
+
+  return data;
+};
+
+export const fetchFileBlob = async (url: string): Promise<string> => {
+  const response = await apiClient.get(url, { responseType: 'blob' });
+  return URL.createObjectURL(response.data);
 };
 
 export const deleteFile = async (fileId: number): Promise<void> => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { handleApiError } from '../utils/errorHandler';
+import * as chatApi from '../api/chat';
+import type { ErrorResponse } from '../types/api.types';
+
+export const useChatSend = () => {
+  return useMutation({
+    mutationFn: (request: chatApi.ChatRequest) => chatApi.sendChat(request),
+    onError: (error: AxiosError<ErrorResponse>) => {
+      handleApiError(error);
+    },
+  });
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -190,3 +190,24 @@
     }
   }
 }
+
+/* SheetJS table viewer */
+.sheet-viewer table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 1.3rem;
+}
+.sheet-viewer th,
+.sheet-viewer td {
+  border: 1px solid #dee2e6;
+  padding: 6px 10px;
+  text-align: left;
+  white-space: nowrap;
+}
+.sheet-viewer th {
+  background-color: #f1f3f5;
+  font-weight: 600;
+}
+.sheet-viewer tr:hover td {
+  background-color: #f8f9fa;
+}


### PR DESCRIPTION
## 변경 요약
- AI 문서 분석 페이지가 동작하기 위한 라우팅, API, 레이아웃, 스타일 인프라 일괄 구성
- 문서 검토 페이지에서 COMPLIANCE 도메인일 때 "AI 문서 분석" 진입 버튼 추가
- 챗봇 API 클라이언트(`chat.ts`) 및 React Query 훅(`useChat.ts`) 신규 생성
- 파일 다운로드 API 반환 타입 확장 및 blob fetch 유틸 추가

## 관련 이슈
- Closes #326
- Related #314, #324

## 테스트 방법
1. COMPLIANCE 도메인 문서 검토 페이지 진입 → "AI 문서 분석" 버튼 노출 확인
2. 버튼 클릭 → `/dashboard/compliance/review/:id/ai-analysis` 라우트 정상 이동 확인
3. AI 분석 페이지에서 사이드바가 숨겨지는지 확인
4. 파일 목록 로드 → PDF/이미지/엑셀 뷰어 각각 정상 렌더링 확인
5. 엑셀 파일 선택 시 SheetJS 테이블 스타일 적용 확인
6. 챗봇 메시지 전송 → API 호출 및 응답 렌더링 확인

## 명세 준수 체크
- [x] 라우트를 `DomainProtectedRoute`로 감싸 COMPLIANCE 도메인 보호
- [x] `getDownloadUrl` 상대경로 → 절대 URL 변환 처리
- [x] `fetchFileBlob`에서 apiClient 사용 (인증 헤더 자동 포함)
- [x] `sendChat` 타임아웃 60초 설정
- [x] `hideSidebar` prop 기본값 false (기존 레이아웃 영향 없음)

## 리뷰 포인트
- `files.ts`의 `getDownloadUrl` 반환 타입이 `string` → `DownloadUrlResponse`로 변경됨. 기존 호출부가 있다면 마이그레이션 필요
- `dangerouslySetInnerHTML`로 SheetJS HTML을 렌더링하고 있음 — 서버 데이터가 아닌 로컬 파싱 결과이므로 XSS 위험 낮음
- `chat.ts`의 `ChatRequest`에 `history` 필드가 있어 클라이언트에서 대화 히스토리를 직접 전송하는 구조

## TODO / 질문
- [ ] SAFETY / ESG 도메인에서도 AI 문서 분석 버튼을 노출할지 (현재 COMPLIANCE만)
- [ ] `getDownloadUrl` 반환 타입 변경에 따른 기존 호출부 영향 확인 필요
- [ ] 챗봇 API 에러 시 재시도(retry) 정책 추가 여부