### PR TITLE
fix: 결재자 도메인별 역할 인식 및 승인+원청제출 통합

### DIFF
--- a/features/dashboard/CompliancePage.tsx
+++ b/features/dashboard/CompliancePage.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import { useApprovals } from '../../src/hooks/useApprovals';
 import { useReviews } from '../../src/hooks/useReviews';
+import { useAuthStore } from '../../src/store/authStore';
 import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 
 interface CompliancePageProps {
@@ -57,8 +59,20 @@ function formatDate(dateString?: string): string {
   return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
 }
 
-export default function CompliancePage({ userRole }: CompliancePageProps) {
+export default function CompliancePage({ userRole: legacyUserRole }: CompliancePageProps) {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
+
+  // COMPLIANCE 도메인에서의 역할 결정 (domainRoles 우선, 없으면 레거시 역할 사용)
+  const userRole = useMemo(() => {
+    const domainRole = user?.domainRoles?.find((dr) => dr.domainCode === 'COMPLIANCE');
+    if (domainRole) {
+      if (domainRole.roleCode === 'REVIEWER') return 'receiver';
+      if (domainRole.roleCode === 'APPROVER') return 'approver';
+      if (domainRole.roleCode === 'DRAFTER') return 'drafter';
+    }
+    return legacyUserRole;
+  }, [user?.domainRoles, legacyUserRole]);
 
   const diagnosticsQuery = useDiagnosticsList(
     userRole === 'drafter' ? { domainCode: 'COMPLIANCE' } : undefined

--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -272,7 +272,7 @@ export default function HomePage({ userRole }: HomePageProps) {
       return acc;
     }, {} as Record<string, number>);
 
-    const basePath = `/approvals?domainCode=${activeTab}`;
+    const basePath = `/diagnostics?domainCode=${activeTab}`;
     return [
       { label: '대기중', value: String(statusCounts['WAITING'] || 0), color: 'text-[#e65100]', path: basePath },
       { label: '승인', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: basePath },

--- a/features/dashboard/SafetyPage.tsx
+++ b/features/dashboard/SafetyPage.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import { useApprovals } from '../../src/hooks/useApprovals';
 import { useReviews } from '../../src/hooks/useReviews';
+import { useAuthStore } from '../../src/store/authStore';
 import type { DiagnosticStatus, ApprovalStatus, ReviewStatus } from '../../src/types/api.types';
 
 interface SafetyPageProps {
@@ -57,8 +59,20 @@ function formatDate(dateString?: string): string {
   return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
 }
 
-export default function SafetyPage({ userRole }: SafetyPageProps) {
+export default function SafetyPage({ userRole: legacyUserRole }: SafetyPageProps) {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
+
+  // SAFETY 도메인에서의 역할 결정 (domainRoles 우선, 없으면 레거시 역할 사용)
+  const userRole = useMemo(() => {
+    const domainRole = user?.domainRoles?.find((dr) => dr.domainCode === 'SAFETY');
+    if (domainRole) {
+      if (domainRole.roleCode === 'REVIEWER') return 'receiver';
+      if (domainRole.roleCode === 'APPROVER') return 'approver';
+      if (domainRole.roleCode === 'DRAFTER') return 'drafter';
+    }
+    return legacyUserRole;
+  }, [user?.domainRoles, legacyUserRole]);
 
   const diagnosticsQuery = useDiagnosticsList(
     userRole === 'drafter' ? { domainCode: 'SAFETY' } : undefined

--- a/src/hooks/useApprovals.ts
+++ b/src/hooks/useApprovals.ts
@@ -17,6 +17,7 @@ export const useApprovals = (params?: ApprovalListParams) => {
   return useQuery({
     queryKey: QUERY_KEYS.APPROVALS.LIST(params),
     queryFn: () => approvalsApi.getApprovals(params),
+    enabled: !!params,
   });
 };
 

--- a/src/hooks/useDiagnostics.ts
+++ b/src/hooks/useDiagnostics.ts
@@ -18,6 +18,7 @@ export const useDiagnosticsList = (params?: DiagnosticsListParams) => {
   return useQuery({
     queryKey: QUERY_KEYS.DIAGNOSTICS.LIST(params),
     queryFn: () => diagnosticsApi.getDiagnostics(params),
+    enabled: !!params,
   });
 };
 

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -18,6 +18,7 @@ export const useReviews = (params?: ReviewListParams) => {
   return useQuery({
     queryKey: QUERY_KEYS.REVIEWS.LIST(params),
     queryFn: () => reviewsApi.getReviews(params),
+    enabled: !!params,
   });
 };
 


### PR DESCRIPTION
## Summary
- 결재자가 도메인별 역할(domainRoles)을 올바르게 인식하여 `/v1/approvals` API 호출
- 결재 승인과 원청 제출을 하나의 버튼으로 통합

## Changes

### 도메인별 역할 인식 수정
- HomePage, ESGPage, SafetyPage, CompliancePage, DiagnosticsListPage에서 `user.role.code` 대신 `user.domainRoles`를 우선 확인
- 각 도메인(ESG, SAFETY, COMPLIANCE)에서의 역할에 따라 올바른 API 호출

### 훅 최적화
- `useApprovals`, `useDiagnostics`, `useReviews`에 `enabled: !!params` 조건 추가
- params가 없을 때 불필요한 API 호출 방지

### 결재 승인 + 원청 제출 통합
- "승인" 버튼을 "원청에 제출"로 변경
- 버튼 클릭 시 승인 처리 후 자동으로 원청에 제출
- 모달에 "승인 후 자동으로 원청에 제출됩니다" 안내 문구 추가