### PR TITLE
fix: 기안자 상태 라벨 통일 및 테이블 헤더 수정

### DIFF
--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -268,10 +268,12 @@ export default function HomePage({ userRole: legacyUserRole }: HomePageProps) {
 
     const basePath = `/diagnostics?domainCode=${activeTab}`;
     return [
-      { label: '미제출', value: String(statusCounts['WRITING'] || 0), color: 'text-[#b91c1c]', path: basePath },
-      { label: '검토중', value: String((statusCounts['SUBMITTED'] || 0) + (statusCounts['REVIEWING'] || 0)), color: 'text-[#002554]', path: basePath },
-      { label: '보완요청', value: String(statusCounts['RETURNED'] || 0), color: 'text-[#e65100]', path: basePath },
-      { label: '완료', value: String((statusCounts['APPROVED'] || 0) + (statusCounts['COMPLETED'] || 0)), color: 'text-[#008233]', path: basePath },
+      { label: '작성중', value: String(statusCounts['WRITING'] || 0), color: 'text-[#495057]', path: basePath },
+      { label: '제출됨', value: String(statusCounts['SUBMITTED'] || 0), color: 'text-[#002554]', path: basePath },
+      { label: '반려됨', value: String(statusCounts['RETURNED'] || 0), color: 'text-[#b91c1c]', path: basePath },
+      { label: '승인됨', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: basePath },
+      { label: '심사중', value: String(statusCounts['REVIEWING'] || 0), color: 'text-[#e65100]', path: basePath },
+      { label: '완료', value: String(statusCounts['COMPLETED'] || 0), color: 'text-[#008233]', path: basePath },
     ];
   }, [diagnosticsQuery.data, activeTab]);
 
@@ -576,7 +578,7 @@ export default function HomePage({ userRole: legacyUserRole }: HomePageProps) {
                   <tr className="border-b border-[#dee2e6]">
                     {(userRole === 'drafter' || userRole === 'receiver') && (
                       <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">
-                        제목
+                        {userRole === 'drafter' ? '기안명' : '제목'}
                       </th>
                     )}
                     <th className="text-left py-[12px] px-[16px] font-title-xsmall text-[#868e96]">

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -184,7 +184,7 @@ export default function DiagnosticsListPage() {
     // 기안자
     return (
       <tr className="border-b border-[var(--color-border-default)] bg-gray-50">
-        <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">제목</th>
+        <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기안명</th>
         <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">캠페인</th>
         <th className="px-[16px] py-[12px] text-left font-title-xsmall text-[var(--color-text-secondary)]">기간</th>
         <th className="px-[16px] py-[12px] text-center font-title-xsmall text-[var(--color-text-secondary)]">상태</th>


### PR DESCRIPTION
## Summary
- 기안자 대시보드와 기안관리 페이지의 상태 라벨을 백엔드와 일치하도록 통일
- 기안자 테이블 헤더 수정

## Changes
- 대시보드 통계: 미제출/검토중/보완요청/완료 → 작성중/제출됨/반려됨/승인됨/심사중/완료
- HomePage, DiagnosticsListPage 테이블 헤더: "제목" → "기안명"