### PR TITLE
fix: vite-env.d.ts 누락으로 인한 import.meta.env 타입 에러 수정

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## 변경 요약
- `src/vite-env.d.ts` 파일 추가 (`/// <reference types="vite/client" />`)
- Vite 프로젝트 초기 세팅 시 자동 생성되어야 할 타입 선언 파일이 누락되어 있었음
- `import.meta.env` 사용하는 모든 파일(`LoginPage.tsx`, `apiRequest.ts`, `client.ts`)에서 `TS2339: Property 'env' does not exist on type 'ImportMeta'` 에러 해결

## 관련 이슈
- 직접 연결된 이슈 없음 (프로젝트 초기 설정 누락 건)

## 테스트 방법
1. `npx tsc --noEmit` 실행하여 `import.meta.env` 관련 타입 에러가 사라졌는지 확인
2. IDE에서 `LoginPage.tsx:297` 라인의 `import.meta.env.VITE_RECAPTCHA_SITE_KEY`에 빨간 밑줄이 없는지 확인
3. `npm run build` 정상 빌드 확인

## 명세 준수 체크
- [x] Vite 공식 문서 권장 구조 준수 (`src/vite-env.d.ts`)
- [x] `tsconfig.json`의 `include: ["**/*.ts"]` 패턴에 의해 자동 인식됨
- [x] 기존 런타임 동작에 영향 없음 (타입 선언 파일만 추가)

## 리뷰 포인트
- 파일 위치가 `src/vite-env.d.ts`로 적절한지 (Vite 기본 생성 경로와 동일)

## TODO / 질문
- `.env` 파일에 사용 중인 환경변수 키를 `ImportMetaEnv` 인터페이스로 명시적 선언할지 검토 필요 (현재는 `vite/client` 기본 타입만 참조)