### PR TITLE
fix: 로그인 실패 시 에러 알럿 미표시 버그 수정

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -84,7 +84,11 @@ apiClient.interceptors.response.use(
       }
     }
 
-    if (error.response?.status === 401) {
+    const loginErrorCodes = ['A003', 'A005', 'A006'];
+    if (
+      error.response?.status === 401 &&
+      !loginErrorCodes.includes(error.response.data?.code ?? '')
+    ) {
       useAuthStore.getState().logout();
       window.location.href = '/login';
     }


### PR DESCRIPTION
## 변경 요약
- Axios response interceptor의 범용 401 핸들러가 **로그인 실패 응답(A003 등)까지 포함하여** `window.location.href = '/login'`으로 페이지를 새로고침하던 버그 수정
- 로그인 관련 에러코드(`A003`, `A005`, `A006`)는 interceptor에서 redirect하지 않고, React 에러 핸들러(`handleApiError`)로 위임하도록 변경
- 기존 토큰 만료/무효(A001 등) 시나리오의 redirect 동작은 그대로 유지

## 관련 이슈
- Closes #341

## 테스트 방법
1. 로그인 페이지에서 **형식은 올바르지만 가입되지 않은 이메일/비밀번호** 입력 후 로그인 시도
   - [x] 페이지가 새로고침되지 않고, 에러 토스트("이메일 또는 비밀번호를 확인해주세요")가 표시되는지 확인
2. 로그인 페이지에서 **가입된 이메일 + 틀린 비밀번호** 입력 후 로그인 시도
   - [x] 동일하게 에러 토스트가 정상 표시되는지 확인
3. 계정 잠금(A005/A006) 시나리오에서도 에러 메시지가 정상 노출되는지 확인
4. 이미 로그인된 상태에서 **토큰 만료(A002) / 토큰 무효(A001)** 시 기존처럼 `/login`으로 redirect 되는지 확인 (기존 동작 유지 검증)

## 명세 준수 체크
- [x] `errorCodes.ts`의 A003 설정(`action: 'toast'`)과 일관된 동작
- [x] `useLogin` hook의 `onError` → `handleApiError()` 플로우가 정상 동작
- [x] A002 토큰 갱신 로직 영향 없음
- [x] 기존 401 redirect(토큰 만료/무효) 동작 유지

## 리뷰 포인트
- `loginErrorCodes` 배열을 interceptor 내부에 인라인으로 선언했습니다. 향후 에러코드가 추가될 경우 `errorCodes.ts`에서 관리하는 방식으로 리팩터링할 수 있습니다.
- `error.response.data?.code ?? ''`로 nullish 처리 — code가 undefined/null인 경우 빈 문자열로 fallback하여 기존 redirect 동작을 유지합니다.

## TODO / 질문
- [ ] A005, A006이 실제로 401로 응답하는지 백엔드와 확인 필요 (403일 경우 이 분기에 도달하지 않으므로 무관하지만, 명시적 확인 권장)
- [ ] `tests/login.spec.ts`의 로그인 실패 테스트에 에러 토스트 표시 여부 assertion 추가 검토