### PR TITLE
fix: 한국어 텍스트 단어 중간 줄바꿈 방지

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -137,6 +137,7 @@
     color: var(--foreground);
     font-family: var(--font-family-medium);
     font-size: 1.6rem; /* 16px */
+    word-break: keep-all;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }


### PR DESCRIPTION
## 변경 요약
- `styles/globals.css`의 `body`에 `word-break: keep-all` 속성 추가
- 한국어 텍스트가 글자 단위가 아닌 **단어(띄어쓰기) 단위**로만 줄바꿈되도록 전역 적용

## 관련 이슈
- Closes #352

## 테스트 방법
1. 서비스 소개(온보딩) 페이지 접속
2. 브라우저 창 너비를 줄여가며 텍스트 줄바꿈 확인
3. "중대재해처벌법 전면 확대", "EU 공급망 실사 지침" 등 긴 텍스트가 단어 중간에서 끊기지 않는지 확인
4. 다른 페이지(대시보드, 기안 등)에서도 한국어 텍스트 줄바꿈이 정상 동작하는지 확인

## 명세 준수 체크
- [x] 전역 스타일(`globals.css`) 수정 — 앱 전체 일괄 적용
- [x] 기존 레이아웃/디자인에 사이드이펙트 없음 (`keep-all`은 CJK 텍스트에만 영향)
- [x] 영문/숫자 텍스트는 기존과 동일하게 동작

## 리뷰 포인트
- `word-break: keep-all`은 CJK(한중일) 텍스트에서만 줄바꿈 동작이 변경되며, 영문 텍스트에는 영향 없음
- `body` 레벨 전역 적용이 적절한지 확인 부탁드립니다

## TODO / 질문
- 특정 컴포넌트에서 `word-break: break-all`이 명시적으로 필요한 케이스가 있다면 별도 오버라이드 필요
- 테이블 셀 등 좁은 영역에서 긴 단어가 넘치는 경우 `overflow-wrap: break-word` 보조 적용 검토