### PR TITLE
fix: preview API 누락 에러 코드 핸들러 추가

### DIFF
--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -38,8 +38,15 @@ export const ERROR_HANDLERS: Record<string, ErrorConfig> = {
   // Rate limit
   U010: { action: 'toast' },
 
+  // Validation
+  U001: { action: 'toast' },
+
+  // Resource
+  RES_004: { action: 'toast', customMessage: '요청한 파일을 찾을 수 없습니다.' },
+
   // Server
   S001: { action: 'toast', customMessage: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
+  S003: { action: 'toast', customMessage: '서버 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' },
 
   // Diagnostic
   D001: { action: 'redirect', redirectTo: '/not-found', customMessage: '기안을 찾을 수 없습니다.' },
@@ -54,6 +61,7 @@ export const ERROR_HANDLERS: Record<string, ErrorConfig> = {
   AI004: { action: 'toast', customMessage: '요청 형식 오류가 발생했습니다. 입력 데이터를 확인해주세요.' },
   AI005: { action: 'toast', customMessage: '필수 항목이 누락되었습니다. 모든 필수 항목을 제출해주세요.' },
   AI006: { action: 'toast', customMessage: '분석 시간이 초과되었습니다. 다시 시도해주세요.' },
+  AI007: { action: 'toast', customMessage: 'AI 분석 요청에 실패했습니다. 파일을 확인 후 다시 시도해주세요.' },
 };
 
 /**


### PR DESCRIPTION
## 변경 요약
파일 업로드 후 Add(preview) 버튼 클릭 시 간헐적으로 "알 수 없는 오류입니다"가 표시되는 문제를 수정합니다.

백엔드 확인 결과, preview 엔드포인트(`POST /v1/ai/run/diagnostics/{id}/preview`)에서 반환 가능한 에러 코드 중 프론트에서 매핑되지 않은 코드가 있어 기본 메시지로 처리되고 있었습니다.

**추가된 에러 코드:**
| 코드 | 상황 | 메시지 |
|------|------|--------|
| `U001` | Validation 에러 | 서버 메시지 그대로 표시 |
| `RES_004` | 파일 미존재 | "요청한 파일을 찾을 수 없습니다." |
| `S003` | 서버 디코딩 실패 등 | "서버 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요." |
| `AI007` | AI 서버 4xx 응답 | "AI 분석 요청에 실패했습니다. 파일을 확인 후 다시 시도해주세요." |

## 관련 이슈
- Closes #354

## 테스트 방법
1. 파일 업로드 및 관리 페이지에서 파일 업로드 후 Add 버튼 클릭
2. 서버에서 위 에러 코드 반환 시 "알 수 없는 오류" 대신 매핑된 메시지가 표시되는지 확인
3. 기존 에러 코드(AI001~AI006, S001 등)가 정상 동작하는지 회귀 확인

## 명세 준수 체크
- [x] `ERROR_HANDLERS`의 기존 패턴(`action: 'toast'` + `customMessage`) 준수
- [x] `U001`은 서버 validation 메시지를 그대로 노출하도록 `customMessage` 미지정
- [x] 기존 코드 수정 없음 (추가만)

## 리뷰 포인트
- `U001`의 경우 서버 메시지를 그대로 표시하는 것이 적절한지 (validation 메시지가 사용자 친화적인지 백엔드팀 확인 필요)
- `RES_004`의 메시지 톤이 다른 에러 메시지와 일관성이 있는지

## TODO / 질문
- [ ] 백엔드 병행 수정 사항: NPE 방지(`periodStartDate`/`periodEndDate` null 체크), 파싱 미완료 파일 preview 요청 거부 로직 추가
- [ ] 백엔드에서 새 에러 코드가 추가될 경우 프론트 `ERROR_HANDLERS`에도 반영 필요
- [ ] `U001` validation 에러의 서버 메시지가 사용자에게 노출해도 적절한 형태인지 백엔드팀과 확인 필요