### PR TITLE
fix: 백엔드 preview API 변경사항 에러 코드 동기화

### DIFF
--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -62,6 +62,8 @@ export const ERROR_HANDLERS: Record<string, ErrorConfig> = {
   AI005: { action: 'toast', customMessage: '필수 항목이 누락되었습니다. 모든 필수 항목을 제출해주세요.' },
   AI006: { action: 'toast', customMessage: '분석 시간이 초과되었습니다. 다시 시도해주세요.' },
   AI007: { action: 'toast', customMessage: 'AI 분석 요청에 실패했습니다. 파일을 확인 후 다시 시도해주세요.' },
+  AI009: { action: 'toast', customMessage: '파일 처리 중입니다. 잠시 후 다시 시도해주세요.' },
+  AI010: { action: 'toast', customMessage: '진단 기간을 먼저 설정해주세요.' },
 };
 
 /**


### PR DESCRIPTION
## 변경 요약
백엔드 PR #210(파싱 상태 검증 + nullable 필드 체크), #212(타임아웃 분리)에서 추가된 에러 코드를 프론트 `ERROR_HANDLERS`에 반영합니다.

**추가된 에러 코드:**
| 코드 | HTTP | 상황 | 메시지 |
|------|------|------|--------|
| `AI009` | 409 | 파일 파싱 미완료 (업로드 직후 Add 클릭) | "파일 처리 중입니다. 잠시 후 다시 시도해주세요." |
| `AI010` | 422 | 진단 기간(시작일/종료일) 미설정 | "진단 기간을 먼저 설정해주세요." |

## 관련 이슈
- #354
- 백엔드 PR #210, #212

## 테스트 방법
1. 파일 업로드 직후 파싱 완료 전 Add 버튼 클릭 → "파일 처리 중입니다. 잠시 후 다시 시도해주세요." 토스트 확인
2. 진단 기간이 설정되지 않은 상태에서 Add 버튼 클릭 → "진단 기간을 먼저 설정해주세요." 토스트 확인
3. 기존 에러 코드(AI001~AI007, S001, S003 등) 정상 동작 회귀 확인

## 명세 준수 체크
- [x] 백엔드 권장 안내 문구 그대로 적용
- [x] `ERROR_HANDLERS` 기존 패턴 준수
- [x] 기존 코드 수정 없음 (추가만)

## 리뷰 포인트
- 백엔드 권장 문구를 그대로 사용했습니다. 톤/표현이 기존 메시지들과 일관성 있는지 확인 부탁드립니다.

## TODO / 질문
- [ ] 백엔드 권장 선택사항: axios 자체 timeout 35초 설정 (서버 preview 타임아웃 30초보다 약간 길게) — 별도 PR로 진행 여부 논의 필요
- [ ] Add 버튼 로딩 스피너/비활성화는 이미 구현되어 있음 (`previewMutation.isPending` 체크)
- [ ] AI001 에러 시 "다시 시도" 버튼 제공은 별도 UX 논의 후 진행