### PR TITLE
fix: preview API timeout 35초 설정 및 AI001 다시 시도 버튼 추가

### DIFF
--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -12,8 +12,10 @@ import {
   useAiResult,
 } from '../../src/hooks/useAiRun';
 import * as filesApi from '../../src/api/files';
+import type { AxiosError } from 'axios';
 import type { JobStatus } from '../../src/api/jobs';
 import type { SlotStatus, SlotHint } from '../../src/api/aiRun';
+import type { ErrorResponse } from '../../src/types/api.types';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 
 // 파일 업로드 상태 타입
@@ -921,6 +923,28 @@ export default function DiagnosticFilesPage() {
                     </>
                   )}
                 </button>
+
+                {/* AI001 에러 시 다시 시도 UI */}
+                {previewMutation.isError &&
+                  (previewMutation.error as AxiosError<ErrorResponse>)?.response?.data?.code === 'AI001' && (
+                  <div className="flex items-center gap-[12px] px-[16px] py-[12px] bg-red-50 rounded-[10px] border border-red-200">
+                    <svg className="w-[18px] h-[18px] text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                    <p className="flex-1 font-body-small text-red-700">
+                      AI 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.
+                    </p>
+                    <button
+                      onClick={() => callPreview(allCompletedFileIds)}
+                      className="px-[12px] py-[6px] rounded-[8px] bg-white border border-red-200 font-title-xsmall text-red-600 hover:bg-red-100 transition-colors flex items-center gap-[6px] flex-shrink-0"
+                    >
+                      <svg className="w-[14px] h-[14px]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                      </svg>
+                      다시 시도
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/api/aiRun.ts
+++ b/src/api/aiRun.ts
@@ -75,7 +75,8 @@ export const previewAiRun = async (
 ): Promise<RunPreviewResponse> => {
   const response = await apiClient.post<BaseResponse<RunPreviewResponse>>(
     `/v1/ai/run/diagnostics/${diagnosticId}/preview`,
-    { fileIds }
+    { fileIds },
+    { timeout: 35000 }
   );
   return response.data.data;
 };


### PR DESCRIPTION
## Summary
- `previewAiRun` API에 `timeout: 35000` (35초) 설정 — 백엔드 30초 타임아웃보다 약간 길게
- AI001(AI 서비스 연결 불가) 에러 시 Add 버튼 아래에 에러 메시지 + "다시 시도" 버튼 표시
- AI009/AI010 등 사용자 액션이 필요한 에러는 기존 토스트만 유지 (재시도 의미 없음)

## Test plan
- [ ] preview API 호출 시 네트워크 탭에서 timeout이 35초로 설정되는지 확인
- [ ] AI001 에러 응답 시 Add 버튼 아래 에러 메시지 + "다시 시도" 버튼 표시 확인
- [ ] "다시 시도" 클릭 시 preview 재호출 확인
- [ ] AI009 등 다른 에러 발생 시 "다시 시도" 버튼 미표시 확인

Closes #356