### PR TITLE
feat: 기안 상세 페이지 하단에 목록으로 버튼 추가

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -334,29 +334,40 @@ export default function DiagnosticDetailPage() {
         )}
 
         {/* 액션 버튼 */}
-        <div className="flex justify-end gap-[12px]">
-          {canDelete && (
-            <button
-              onClick={() => setShowDeleteModal(true)}
-              className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-state-error-icon)] font-title-small text-[var(--color-state-error-icon)] hover:bg-[var(--color-state-error-bg)] transition-colors"
-            >
-              삭제
-            </button>
-          )}
+        <div className="flex justify-between items-center">
           <button
-            onClick={() => navigate(`/diagnostics/${diagnosticId}/files`)}
-            className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-primary-main)] font-title-small text-[var(--color-primary-main)] hover:bg-blue-50 transition-colors"
+            onClick={() => navigate(diagnostic.domain?.code ? `/diagnostics?domainCode=${diagnostic.domain.code}` : '/diagnostics')}
+            className="flex items-center gap-[4px] px-[24px] py-[12px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
           >
-            파일 관리 및 AI 분석
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            목록으로
           </button>
-          {canSubmit && (
+          <div className="flex gap-[12px]">
+            {canDelete && (
+              <button
+                onClick={() => setShowDeleteModal(true)}
+                className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-state-error-icon)] font-title-small text-[var(--color-state-error-icon)] hover:bg-[var(--color-state-error-bg)] transition-colors"
+              >
+                삭제
+              </button>
+            )}
             <button
-              onClick={() => setShowSubmitModal(true)}
-              className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+              onClick={() => navigate(`/diagnostics/${diagnosticId}/files`)}
+              className="px-[24px] py-[12px] rounded-[8px] border border-[var(--color-primary-main)] font-title-small text-[var(--color-primary-main)] hover:bg-blue-50 transition-colors"
             >
-              {hasApprovalWorkflow ? '결재자에게 제출' : '수신자에게 제출'}
+              파일 관리 및 AI 분석
             </button>
-          )}
+            {canSubmit && (
+              <button
+                onClick={() => setShowSubmitModal(true)}
+                className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+              >
+                {hasApprovalWorkflow ? '결재자에게 제출' : '수신자에게 제출'}
+              </button>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## 변경 요약
- 기안 상세 페이지(`/diagnostics/:id`) 하단 액션 영역에 **"← 목록으로"** 버튼 추가
- 하단 레이아웃을 `justify-between`으로 변경하여 좌측(목록 복귀) / 우측(액션 버튼) 분리
- 모든 기안 상태(WRITING~COMPLETED)에서 하단 목록 복귀 가능

## 관련 이슈
- Closes #359

## 테스트 방법
1. `/diagnostics/:id` 페이지 진입
2. **WRITING 상태**: 하단에 [목록으로] [삭제] [파일 관리 및 AI 분석] [제출] 4개 버튼 확인
3. **SUBMITTED/REVIEWING/APPROVED/COMPLETED 상태**: 하단에 [목록으로] [파일 관리 및 AI 분석] 2개 버튼 확인
4. "목록으로" 클릭 시 domainCode 필터가 유지된 채 목록 페이지로 이동하는지 확인
5. 모바일(375px) ~ 데스크톱(1440px) 반응형 레이아웃 깨짐 없는지 확인

## 명세 준수 체크
- [x] 기존 상단 "목록으로" 버튼 동작 유지
- [x] 하단 버튼 네비게이션 로직 상단과 동일 (domainCode 파라미터 전달)
- [x] 기존 액션 버튼(삭제/파일관리/제출) 동작 변경 없음
- [x] 디자인 토큰(CSS 변수) 사용

## 리뷰 포인트
- 하단 "목록으로" 버튼 스타일: 회색 테두리 버튼(`border-default` + `text-secondary`)으로 액션 버튼과 시각적 구분. 디자인팀 확인 필요 여부?
- 상단 "목록으로"는 텍스트 링크 스타일, 하단은 bordered 버튼 스타일로 차이가 있음 — 의도적 구분 vs 통일 필요 의견 요청

## TODO / 질문
- [ ] 디자이너 확인: 하단 버튼 스타일 가이드 반영 여부
- [ ] 추후 상단 "목록으로" 버튼을 sticky header에 포함시키는 방안도 검토 가능