### PR TITLE
feat: 결재 상세/파일 관리 페이지 하단에 목록 복귀 버튼 추가

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -287,22 +287,33 @@ export default function ApprovalDetailPage() {
         )}
 
         {/* 액션 버튼 */}
-        {isWaiting && (
-          <div className="flex gap-[12px] justify-end">
-            <button
-              onClick={() => setShowModal('REJECTED')}
-              className="px-[24px] py-[12px] rounded-[8px] border border-red-300 text-red-600 font-title-small hover:bg-red-50 transition-colors"
-            >
-              반려
-            </button>
-            <button
-              onClick={() => setShowModal('APPROVED')}
-              className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
-            >
-              원청에 제출
-            </button>
-          </div>
-        )}
+        <div className="flex justify-between items-center">
+          <button
+            onClick={() => navigate(approval.domainCode ? DOMAIN_TO_LIST[approval.domainCode] || '/dashboard' : '/dashboard')}
+            className="flex items-center gap-[4px] px-[24px] py-[12px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            목록으로
+          </button>
+          {isWaiting && (
+            <div className="flex gap-[12px]">
+              <button
+                onClick={() => setShowModal('REJECTED')}
+                className="px-[24px] py-[12px] rounded-[8px] border border-red-300 text-red-600 font-title-small hover:bg-red-50 transition-colors"
+              >
+                반려
+              </button>
+              <button
+                onClick={() => setShowModal('APPROVED')}
+                className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
+              >
+                원청에 제출
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* 승인/반려 모달 */}

--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -1007,6 +1007,19 @@ export default function DiagnosticFilesPage() {
             </div>
           </div>
         )}
+
+        {/* 하단 네비게이션 */}
+        <div className="flex justify-start">
+          <button
+            onClick={() => navigate(`/diagnostics/${diagnosticId}`)}
+            className="flex items-center gap-[4px] px-[24px] py-[12px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M12.5 15L7.5 10L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            기안 상세로 돌아가기
+          </button>
+        </div>
       </div>
 
       {/* 분석 실행 확인 모달 */}


### PR DESCRIPTION
## 변경 요약
- **결재 상세 페이지** (`/approvals/:id`): 하단 액션 영역을 `justify-between`으로 변경, 왼쪽에 "← 목록으로" 버튼 추가. 모든 결재 상태(WAITING/APPROVED/REJECTED)에서 표시됨
- **파일 관리 페이지** (`/diagnostics/:id/files`): 페이지 최하단에 "← 기안 상세로 돌아가기" 버튼 추가
- #359 에서 적용한 패턴(상단 텍스트 링크 + 하단 bordered 버튼) 동일 적용

## 관련 이슈
- Closes #364
- Related: #359 (기안 상세 페이지 동일 패턴 적용)

## 테스트 방법
### 결재 상세 (`/approvals/:id`)
1. WAITING 상태: 하단에 [목록으로] + [반려] [원청에 제출] 확인
2. APPROVED/REJECTED 상태: 하단에 [목록으로] 단독 표시 확인
3. "목록으로" 클릭 시 domainCode별 목록으로 이동 확인

### 파일 관리 (`/diagnostics/:id/files`)
1. 파일 업로드 후 페이지 하단까지 스크롤
2. 하단 "기안 상세로 돌아가기" 버튼 표시 확인
3. 클릭 시 `/diagnostics/:id`로 정상 이동 확인

### 공통
- 모바일(375px) ~ 데스크톱(1440px) 반응형 레이아웃 확인

## 명세 준수 체크
- [x] 상단 뒤로가기 버튼 기존 동작 유지
- [x] 하단 버튼 네비게이션 로직 상단과 동일
- [x] 기존 액션 버튼(반려/제출) 동작 변경 없음
- [x] 디자인 토큰(CSS 변수) 사용
- [x] #359 패턴과 일관된 스타일 적용

## 리뷰 포인트
- 결재 상세 페이지: APPROVED/REJECTED 상태에서 하단에 "목록으로" 버튼만 왼쪽에 단독 배치 — 시각적으로 괜찮은지 확인
- 파일 관리 페이지: 우측 사이드바에 "최종 제출" 버튼이 sticky로 있으므로 하단 버튼은 "기안 상세로 돌아가기"만 배치 — 적절한지 확인

## TODO / 질문
- [ ] 디자이너 확인: 3개 페이지(기안 상세/결재 상세/파일 관리) 하단 버튼 스타일 일관성 검토
- [ ] 추후 전체 상세 페이지에 대한 네비게이션 가이드라인 수립 검토