### PR TITLE
fix: 폰트 사이즈 디자인 토큰 통일 (#346)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -264,13 +264,13 @@ export default function ApprovalDetailPage() {
                     >
                       <TimelineIcon status={item.newStatus} />
                     </span>
-                    <time className="inline-flex items-center px-[8px] py-[3px] mb-[6px] text-[11px] font-medium rounded-full"
+                    <time className="inline-flex items-center px-[8px] py-[3px] mb-[6px] font-label-xsmall rounded-full"
                       style={{ backgroundColor: statusConfig.bgColor, color: statusConfig.textColor }}>
                       {new Date(item.timestamp).toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                     </time>
                     <h3 className="flex items-center gap-[6px] mt-[6px] mb-[2px]">
                       <span className="font-title-small text-[var(--color-text-primary)]">{DIAGNOSTIC_STATUS_LABELS[item.newStatus]}</span>
-                      {isLatest && <span className="px-[6px] py-[1px] text-[10px] font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">최신</span>}
+                      {isLatest && <span className="px-[6px] py-[1px] font-label-xsmall font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">최신</span>}
                     </h3>
                     <p className="font-body-small text-[var(--color-text-secondary)]">{item.performedBy.name}</p>
                     {item.comment && (
@@ -452,7 +452,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
         <span className="font-title-medium text-[var(--color-text-primary)]">
           {displayName}
         </span>
-        <span className={`px-[12px] py-[6px] rounded-[6px] text-base font-semibold border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[12px] py-[6px] rounded-[6px] font-title-small border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>
@@ -460,7 +460,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.reasons && result.reasons.length > 0 && (
         <ul className="space-y-[8px] mt-[12px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[8px] text-[17px] text-[var(--color-text-secondary)]">
+            <li key={index} className="flex items-start gap-[8px] font-body-medium text-[var(--color-text-secondary)]">
               <span className="w-[5px] h-[5px] bg-gray-400 rounded-full mt-[10px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
@@ -471,7 +471,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.file_names && result.file_names.length > 0 && (
         <div className="mt-[12px] flex flex-wrap gap-[8px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[12px] py-[6px] bg-white text-base text-gray-700 rounded-[6px] border border-gray-200">
+            <span key={index} className="px-[12px] py-[6px] bg-white font-body-medium text-gray-700 rounded-[6px] border border-gray-200">
               {fileName}
             </span>
           ))}

--- a/features/auth/SignupStep2Page.tsx
+++ b/features/auth/SignupStep2Page.tsx
@@ -200,7 +200,7 @@ export default function SignupStep2Page() {
                     {...register('name')}
                   />
                   {errors.name && (
-                    <p className="text-red-500 text-sm mt-1">{errors.name.message}</p>
+                    <p className="text-red-500 font-body-small mt-1">{errors.name.message}</p>
                   )}
                 </div>
 
@@ -225,16 +225,16 @@ export default function SignupStep2Page() {
                     </Button>
                   </div>
                   {errors.email && (
-                    <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>
+                    <p className="text-red-500 font-body-small mt-1">{errors.email.message}</p>
                   )}
                   {emailAvailable === false && (
-                    <p className="text-red-500 text-sm mt-1">이미 사용 중인 이메일입니다.</p>
+                    <p className="text-red-500 font-body-small mt-1">이미 사용 중인 이메일입니다.</p>
                   )}
                   {emailAvailable === true && !emailVerified && (
-                    <p className="text-blue-600 text-sm mt-1">사용 가능한 이메일입니다. 인증코드를 확인해주세요.</p>
+                    <p className="text-blue-600 font-body-small mt-1">사용 가능한 이메일입니다. 인증코드를 확인해주세요.</p>
                   )}
                   {emailVerified && (
-                    <p className="text-green-600 text-sm mt-1">이메일 인증이 완료되었습니다.</p>
+                    <p className="text-green-600 font-body-small mt-1">이메일 인증이 완료되었습니다.</p>
                   )}
                 </div>
 
@@ -253,7 +253,7 @@ export default function SignupStep2Page() {
                           maxLength={6}
                         />
                         {remainingSeconds > 0 && (
-                          <span className="absolute right-4 top-[42px] text-sm text-red-500 font-medium">
+                          <span className="absolute right-4 top-[42px] font-body-small text-red-500">
                             {formatTime(remainingSeconds)}
                           </span>
                         )}
@@ -269,7 +269,7 @@ export default function SignupStep2Page() {
                       </Button>
                     </div>
                     {remainingSeconds <= 0 && (
-                      <p className="text-red-500 text-sm mt-1">
+                      <p className="text-red-500 font-body-small mt-1">
                         인증코드가 만료되었습니다.
                         <button
                           type="button"
@@ -293,7 +293,7 @@ export default function SignupStep2Page() {
                     {...register('password')}
                   />
                   {errors.password && (
-                    <p className="text-red-500 text-sm mt-1">{errors.password.message}</p>
+                    <p className="text-red-500 font-body-small mt-1">{errors.password.message}</p>
                   )}
                 </div>
 
@@ -307,7 +307,7 @@ export default function SignupStep2Page() {
                     {...register('passwordConfirm')}
                   />
                   {errors.passwordConfirm && (
-                    <p className="text-red-500 text-sm mt-1">{errors.passwordConfirm.message}</p>
+                    <p className="text-red-500 font-body-small mt-1">{errors.passwordConfirm.message}</p>
                   )}
                 </div>
 

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -291,7 +291,7 @@ export default function DiagnosticDetailPage() {
                     </span>
 
                     {/* 날짜 뱃지 */}
-                    <time className="inline-flex items-center px-[10px] py-[4px] mb-[8px] text-[12px] font-medium rounded-full"
+                    <time className="inline-flex items-center px-[10px] py-[4px] mb-[8px] font-detail-small rounded-full"
                       style={{ backgroundColor: statusConfig.bgColor, color: statusConfig.textColor }}>
                       {new Date(item.timestamp).toLocaleString('ko-KR', {
                         year: 'numeric',
@@ -308,7 +308,7 @@ export default function DiagnosticDetailPage() {
                         {DIAGNOSTIC_STATUS_LABELS[item.newStatus]}
                       </span>
                       {isLatest && (
-                        <span className="px-[8px] py-[2px] text-[11px] font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">
+                        <span className="px-[8px] py-[2px] font-label-xsmall font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">
                           최신
                         </span>
                       )}
@@ -542,7 +542,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
         <span className="font-title-medium text-[var(--color-text-primary)]">
           {displayName}
         </span>
-        <span className={`px-[12px] py-[6px] rounded-[6px] text-base font-semibold border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[12px] py-[6px] rounded-[6px] font-title-small border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>
@@ -550,7 +550,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.reasons && result.reasons.length > 0 && (
         <ul className="space-y-[8px] mt-[12px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[8px] text-[17px] text-[var(--color-text-secondary)]">
+            <li key={index} className="flex items-start gap-[8px] font-body-medium text-[var(--color-text-secondary)]">
               <span className="w-[5px] h-[5px] bg-gray-400 rounded-full mt-[10px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
@@ -561,7 +561,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.file_names && result.file_names.length > 0 && (
         <div className="mt-[12px] flex flex-wrap gap-[8px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[12px] py-[6px] bg-white text-base text-gray-700 rounded-[6px] border border-gray-200">
+            <span key={index} className="px-[12px] py-[6px] bg-white font-body-medium text-gray-700 rounded-[6px] border border-gray-200">
               {fileName}
             </span>
           ))}

--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -139,7 +139,7 @@ function FileUploadItem({
               {statusLabel}
             </p>
             {autoTag && file.uploadStatus === 'complete' && (
-              <span className="px-[6px] py-[1px] bg-blue-100 text-blue-700 text-xs font-medium rounded">
+              <span className="px-[6px] py-[1px] bg-blue-100 text-blue-700 font-detail-small rounded">
                 Auto-tag: {autoTag}
               </span>
             )}
@@ -205,7 +205,7 @@ function FileUploadItem({
 
                 return (
                   <div key={step} className="flex items-center gap-[6px]">
-                    <div className={`w-[16px] h-[16px] rounded-full flex items-center justify-center text-[10px] font-bold ${
+                    <div className={`w-[16px] h-[16px] rounded-full flex items-center justify-center font-label-xsmall font-bold ${
                       isComplete ? 'bg-green-500 text-white' :
                       isActive ? 'bg-amber-500 text-white' :
                       'bg-gray-200 text-gray-500'
@@ -362,7 +362,7 @@ function ParsingResultView({ diagnosticId, fileId }: { diagnosticId: number; fil
       <div className="flex items-center gap-[12px]">
         <div>
           <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[4px]">상태</p>
-          <span className={`px-[8px] py-[2px] rounded text-xs font-medium ${
+          <span className={`px-[8px] py-[2px] rounded font-detail-small ${
             parsingResult.parsingStatus === 'SUCCESS'
               ? 'bg-green-100 text-green-700'
               : 'bg-red-100 text-red-700'
@@ -827,7 +827,7 @@ export default function DiagnosticFilesPage() {
             {/* 가이드 */}
             <div className="bg-blue-50 rounded-[12px] p-[16px] flex gap-[12px]">
               <div className="w-[20px] h-[20px] rounded-full bg-[var(--color-primary-main)] flex items-center justify-center flex-shrink-0 mt-[2px]">
-                <span className="text-white text-xs font-bold">!</span>
+                <span className="text-white font-detail-small font-bold">!</span>
               </div>
               <div>
                 <p className="font-title-xsmall text-[var(--color-primary-main)] mb-[4px]">

--- a/features/documents/AiAnalysisPage.tsx
+++ b/features/documents/AiAnalysisPage.tsx
@@ -352,7 +352,7 @@ export default function AiAnalysisPage() {
               {chatSend.isPending && (
                 <div className="flex items-start gap-[8px]">
                   <div className="w-[28px] h-[28px] rounded-full bg-[#003087] flex items-center justify-center flex-shrink-0">
-                    <span className="text-white text-xs font-bold">AI</span>
+                    <span className="text-white font-detail-small font-bold">AI</span>
                   </div>
                   <div className="bg-[#f1f3f5] rounded-[12px] px-[14px] py-[10px]">
                     <div className="flex gap-[4px]">
@@ -480,11 +480,11 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
       {/* Avatar */}
       {isUser ? (
         <div className="w-[28px] h-[28px] rounded-full bg-[#495057] flex items-center justify-center flex-shrink-0">
-          <span className="text-white text-xs font-bold">U</span>
+          <span className="text-white font-detail-small font-bold">U</span>
         </div>
       ) : (
         <div className="w-[28px] h-[28px] rounded-full bg-[#003087] flex items-center justify-center flex-shrink-0">
-          <span className="text-white text-xs font-bold">AI</span>
+          <span className="text-white font-detail-small font-bold">AI</span>
         </div>
       )}
 
@@ -493,7 +493,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
         {/* Attached file indicator */}
         {message.attachedFileName && (
           <div className="flex items-center gap-[4px] mb-[4px]">
-            <span className="inline-flex items-center gap-[4px] px-[8px] py-[2px] bg-[#e7f5ff] text-[#1971c2] rounded font-body-small text-xs">
+            <span className="inline-flex items-center gap-[4px] px-[8px] py-[2px] bg-[#e7f5ff] text-[#1971c2] rounded font-detail-small">
               <FileText className="w-[10px] h-[10px]" />
               {message.attachedFileName}
             </span>
@@ -514,7 +514,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
         {message.confidence && (
           <div className="mt-[4px]">
             <span
-              className={`inline-block px-[8px] py-[2px] rounded border text-xs font-medium ${
+              className={`inline-block px-[8px] py-[2px] rounded border font-detail-small ${
                 confidenceColors[message.confidence]
               }`}
             >
@@ -553,13 +553,13 @@ function SourceCard({ source }: { source: SourceItem }) {
   return (
     <div className="bg-white border border-[#dee2e6] rounded-[8px] p-[10px]">
       <div className="flex items-center justify-between mb-[4px]">
-        <span className="font-title-small text-[#212529] text-xs">{source.title}</span>
-        <span className="text-xs text-[#868e96]">{scorePercent}%</span>
+        <span className="font-title-xsmall text-[#212529]">{source.title}</span>
+        <span className="font-detail-small text-[#868e96]">{scorePercent}%</span>
       </div>
       {source.snippet && (
-        <p className="font-body-small text-[#495057] text-xs line-clamp-2">{source.snippet}</p>
+        <p className="font-body-small text-[#495057] line-clamp-2">{source.snippet}</p>
       )}
-      <div className="flex items-center gap-[8px] mt-[4px] text-xs text-[#868e96]">
+      <div className="flex items-center gap-[8px] mt-[4px] font-detail-small text-[#868e96]">
         <span>{source.type}</span>
         {source.loc.page && <span>p.{source.loc.page}</span>}
       </div>

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -285,8 +285,8 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                 >
                   <AlertCircle className="w-[24px] h-[24px] text-white" />
                 </div>
-                <p className="text-[13px] font-medium text-[#6b7280] mb-[4px]">위험등급</p>
-                <p className="text-[28px] font-bold" style={{ color: riskConfig.textColor }}>{riskConfig.label}</p>
+                <p className="font-body-small text-[#6b7280] mb-[4px]">위험등급</p>
+                <p className="font-heading-medium" style={{ color: riskConfig.textColor }}>{riskConfig.label}</p>
               </div>
             </div>
 
@@ -301,10 +301,10 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                   className="w-[48px] h-[48px] rounded-[14px] flex items-center justify-center mb-[16px]"
                   style={{ backgroundColor: verdictConfig.iconBg, boxShadow: `0 8px 16px ${verdictConfig.iconBg}40` }}
                 >
-                  <span className="text-[20px] font-bold text-white">{verdictConfig.icon}</span>
+                  <span className="font-title-large text-white">{verdictConfig.icon}</span>
                 </div>
-                <p className="text-[13px] font-medium text-[#6b7280] mb-[4px]">AI 판정</p>
-                <p className="text-[28px] font-bold" style={{ color: verdictConfig.textColor }}>{verdictConfig.label}</p>
+                <p className="font-body-small text-[#6b7280] mb-[4px]">AI 판정</p>
+                <p className="font-heading-medium" style={{ color: verdictConfig.textColor }}>{verdictConfig.label}</p>
               </div>
             </div>
           </div>
@@ -382,13 +382,13 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                       >
                         <TimelineIcon status={item.newStatus} />
                       </span>
-                      <time className="inline-flex items-center px-[8px] py-[3px] mb-[6px] text-[11px] font-medium rounded-full"
+                      <time className="inline-flex items-center px-[8px] py-[3px] mb-[6px] font-label-xsmall rounded-full"
                         style={{ backgroundColor: statusConfig.bgColor, color: statusConfig.textColor }}>
                         {new Date(item.timestamp).toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                       </time>
                       <h3 className="flex items-center gap-[6px] mt-[6px] mb-[2px]">
                         <span className="font-title-small text-[#212529]">{DIAGNOSTIC_STATUS_LABELS[item.newStatus]}</span>
-                        {isLatest && <span className="px-[6px] py-[1px] text-[10px] font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">최신</span>}
+                        {isLatest && <span className="px-[6px] py-[1px] font-label-xsmall font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">최신</span>}
                       </h3>
                       <p className="font-body-small text-[#868e96]">{item.performedBy.name}</p>
                       {item.comment && (
@@ -723,7 +723,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
     <div className="p-[20px] bg-[#f8f9fa] rounded-[12px]">
       <div className="flex items-center justify-between mb-[12px]">
         <span className="font-title-medium text-[#212529]">{displayName}</span>
-        <span className={`px-[12px] py-[6px] rounded-[6px] text-base font-semibold border ${VERDICT_STYLES[verdict]}`}>
+        <span className={`px-[12px] py-[6px] rounded-[6px] font-title-small border ${VERDICT_STYLES[verdict]}`}>
           {VERDICT_LABELS[verdict]}
         </span>
       </div>
@@ -731,7 +731,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.reasons && result.reasons.length > 0 && (
         <ul className="space-y-[8px] mt-[12px]">
           {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[8px] text-[17px] text-[#868e96]">
+            <li key={index} className="flex items-start gap-[8px] font-body-medium text-[#868e96]">
               <span className="w-[5px] h-[5px] bg-[#adb5bd] rounded-full mt-[10px] flex-shrink-0" />
               {REASON_LABELS[reason] || reason}
             </li>
@@ -742,7 +742,7 @@ function SlotResultCard({ result }: { result: SlotResultDetail }) {
       {result.file_names && result.file_names.length > 0 && (
         <div className="mt-[12px] flex flex-wrap gap-[8px]">
           {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[12px] py-[6px] bg-white text-base text-[#495057] rounded-[6px] border border-[#dee2e6]">
+            <span key={index} className="px-[12px] py-[6px] bg-white font-body-medium text-[#495057] rounded-[6px] border border-[#dee2e6]">
               {fileName}
             </span>
           ))}

--- a/features/documents/FileUploadPage.tsx
+++ b/features/documents/FileUploadPage.tsx
@@ -278,7 +278,7 @@ export default function FileUploadPage() {
                             {file.name}
                           </p>
                           <div className="flex items-center gap-[8px]">
-                            <span className={`inline-block px-[8px] py-[2px] rounded-full text-xs font-medium ${JOB_STATUS_STYLES[file.status]}`}>
+                            <span className={`inline-block px-[8px] py-[2px] rounded-full font-detail-small ${JOB_STATUS_STYLES[file.status]}`}>
                               {JOB_STATUS_LABELS[file.status]}
                             </span>
                             {file.status === 'RUNNING' && file.progress !== undefined && (

--- a/features/management/ActivityLogPage.tsx
+++ b/features/management/ActivityLogPage.tsx
@@ -250,7 +250,7 @@ export default function ActivityLogPage() {
                     {log.userName}
                   </td>
                   <td className="px-[16px] py-[14px]">
-                    <span className={`inline-block px-[8px] py-[4px] rounded text-xs font-medium ${
+                    <span className={`inline-block px-[8px] py-[4px] rounded font-detail-small ${
                       ACTION_TYPE_STYLES[log.actionType] || 'bg-gray-100 text-gray-700'
                     }`}>
                       {log.action}

--- a/features/management/CompanyManagementPage.tsx
+++ b/features/management/CompanyManagementPage.tsx
@@ -44,13 +44,13 @@ const getCompanyTypeLabel = (type: string) => {
 const getCompanyTypeBadge = (type: string) => {
   if (type === 'SUPPLIER') {
     return (
-      <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-[#e3f2fd] text-[#1565c0]">
+      <span className="inline-flex items-center px-2 py-1 rounded-full font-detail-small bg-[#e3f2fd] text-[#1565c0]">
         공급업체
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-[#f3e5f5] text-[#7b1fa2]">
+    <span className="inline-flex items-center px-2 py-1 rounded-full font-detail-small bg-[#f3e5f5] text-[#7b1fa2]">
       협력업체
     </span>
   );

--- a/features/management/UserManagementPage.tsx
+++ b/features/management/UserManagementPage.tsx
@@ -90,14 +90,14 @@ export default function UserManagementPage() {
   const getStatusBadge = (status: string) => {
     if (status === 'ACTIVE') {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-[#e8f5e9] text-[#2e7d32]">
+        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full font-detail-small bg-[#e8f5e9] text-[#2e7d32]">
           <span className="w-1.5 h-1.5 rounded-full bg-[#2e7d32]" />
           활성
         </span>
       );
     }
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-[#f5f5f5] text-[#757575]">
+      <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full font-detail-small bg-[#f5f5f5] text-[#757575]">
         <span className="w-1.5 h-1.5 rounded-full bg-[#757575]" />
         비활성
       </span>

--- a/features/permission/PermissionManagementPage.tsx
+++ b/features/permission/PermissionManagementPage.tsx
@@ -154,7 +154,7 @@ export default function PermissionManagementPage() {
                   value={searchKeyword}
                   onChange={(e) => setSearchKeyword(e.target.value)}
                   placeholder="이름 또는 회사명으로 검색"
-                  className="w-full h-[48px] pl-[16px] pr-[48px] rounded-[12px] border border-[#dee2e6] text-[14px] focus:outline-none focus:border-[#003087]"
+                  className="w-full h-[48px] pl-[16px] pr-[48px] rounded-[12px] border border-[#dee2e6] font-body-small focus:outline-none focus:border-[#003087]"
                 />
                 <Search className="absolute right-[16px] top-[12px] w-[24px] h-[24px] text-[#adb5bd]" />
               </div>
@@ -168,7 +168,7 @@ export default function PermissionManagementPage() {
                   onClick={() => setIsStatusDropdownOpen(!isStatusDropdownOpen)}
                   className="w-full h-[48px] px-[16px] rounded-[12px] border border-[#dee2e6] flex items-center justify-between bg-white"
                 >
-                  <span className={`text-[14px] ${filterStatus ? 'text-[#212529]' : 'text-[#adb5bd]'}`}>
+                  <span className={`font-body-small ${filterStatus ? 'text-[#212529]' : 'text-[#adb5bd]'}`}>
                     {filterStatus ? STATUS_LABELS[filterStatus] : '전체'}
                   </span>
                   <ChevronDown className="w-5 h-5 text-[#868e96]" />
@@ -183,7 +183,7 @@ export default function PermissionManagementPage() {
                           setIsStatusDropdownOpen(false);
                           setPage(0);
                         }}
-                        className={`w-full px-[16px] py-[12px] text-left text-[14px] hover:bg-[#f8f9fa] ${
+                        className={`w-full px-[16px] py-[12px] text-left font-body-small hover:bg-[#f8f9fa] ${
                           (option.value === 'ALL' && !filterStatus) || option.value === filterStatus
                             ? 'bg-[#eff4fc] text-[#003087]'
                             : 'text-[#212529]'

--- a/features/permission/PermissionRequestPage.tsx
+++ b/features/permission/PermissionRequestPage.tsx
@@ -259,7 +259,7 @@ export default function PermissionRequestPage() {
                     <Button
                         variant="primary"
                         size="large"
-                        className="w-full h-[64px] rounded-[20px] text-[18px] bg-[#003087]"
+                        className="w-full h-[64px] rounded-[20px] font-title-medium bg-[#003087]"
                         onClick={handleSubmit}
                         disabled={createRequest.isPending || !!pageData?.pendingRequest || !selectedRole || !selectedDomain || !selectedCompanyId}
                     >

--- a/features/permission/PermissionStatusPage.tsx
+++ b/features/permission/PermissionStatusPage.tsx
@@ -58,7 +58,7 @@ function formatDate(dateString: string): string {
 function StatusBadge({ status }: { status: RequestStatus }) {
   const config = STATUS_CONFIG[status];
   return (
-    <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium ${config.bgColor} ${config.textColor}`}>
+    <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full font-body-small ${config.bgColor} ${config.textColor}`}>
       {config.icon}
       {config.label}
     </span>


### PR DESCRIPTION
## 변경요약
- features 전체에서 인라인 `text-[Npx]` 및 Tailwind 기본 텍스트 클래스(`text-base`, `text-xs`, `text-sm`)를 디자인 토큰 클래스로 통일
- Root font-size 62.5% 환경에서 Tailwind 기본 클래스가 의도와 다른 크기로 렌더링되는 문제 해결
  - `text-base`(1rem) = 10px (의도: 16px) → `font-body-medium`/`font-title-small`
  - `text-xs`(0.75rem) = 7.5px (의도: 12px) → `font-detail-small`
  - `text-sm`(0.875rem) = 8.75px (의도: 14px) → `font-body-small`
- 13개 파일, 53건 변환

## 관련이슈
- Closes #346

## 테스트방법
1. 각 페이지에서 텍스트 크기가 디자인 시스템과 일치하는지 확인
2. 특히 아래 영역의 폰트 크기 변화 확인:
   - DocumentReviewPage: 위험등급/AI판정 카드, 타임라인, 사유 목록
   - ApprovalDetailPage: 타임라인, verdict 뱃지
   - DiagnosticDetailPage: 타임라인, verdict 뱃지
   - AiAnalysisPage: 채팅 아바타, 신뢰도 뱃지, 소스 카드
   - SignupStep2Page: 유효성 검사 메시지
   - PermissionManagementPage: 검색/필터 텍스트
3. 뱃지/칩 요소의 크기가 자연스러운지 확인

## 명세준수 체크
- [x] `styles/token/typography.css` 디자인 토큰 기준 변환
- [x] features 디렉토리 내 `text-[Npx]`, `text-base`, `text-xs`, `text-sm` 완전 제거
- [x] 기존 기능 동작 변경 없음 (순수 스타일 변경)

## 리뷰포인트
- `text-[13px]` → `font-body-small`(14px): 1px 증가, 가장 가까운 토큰 적용
- `text-[17px]` → `font-body-medium`(16px): 1px 감소, 가장 가까운 토큰 적용
- `text-[10px]` → `font-label-xsmall`(11px): 1px 증가, 토큰 최소값

## TODO / 질문
- 없음