### PR TITLE
feat: AI 분석 사유 코드 한글 라벨 통합 (#367)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -11,6 +11,7 @@ import type { AxiosError } from 'axios';
 import type { ErrorResponse } from '../../src/types/api.types';
 import type { AiAnalysisResultResponse, SlotResultDetail } from '../../src/api/aiRun';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
+import { REASON_LABELS } from '../../src/constants/reasonLabels';
 
 const STATUS_LABELS: Record<ApprovalStatus, string> = {
   WAITING: '대기',
@@ -50,19 +51,6 @@ const RISK_STYLES: Record<RiskLevel, string> = {
   LOW: 'bg-[#dcfce7] text-[#15803d]',
   MEDIUM: 'bg-[#fef9c3] text-[#a16207]',
   HIGH: 'bg-[#fee2e2] text-[#dc2626]',
-};
-
-const REASON_LABELS: Record<string, string> = {
-  MISSING_SLOT: '필수 슬롯 누락',
-  HEADER_MISMATCH: '필수 헤더(컬럼) 누락',
-  EMPTY_TABLE: '표/데이터 행이 비어있음',
-  OCR_FAILED: 'OCR 판독 불가/텍스트 추출 실패',
-  WRONG_YEAR: '문서 대상 연도 불일치',
-  PARSE_FAILED: '파싱 실패',
-  DATE_MISMATCH: '기간 불일치',
-  UNIT_MISSING: '단위 누락',
-  EVIDENCE_MISSING: '근거문서 누락',
-  SIGNATURE_MISSING: '확인 서명란 미기재',
 };
 
 const DOMAIN_TO_LIST: Record<string, string> = {

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -11,6 +11,7 @@ import type { DiagnosticStatus, DomainCode, RiskLevel } from '../../src/types/ap
 import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.types';
 import type { AiAnalysisResultResponse, SlotResultDetail } from '../../src/api/aiRun';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
+import { REASON_LABELS } from '../../src/constants/reasonLabels';
 
 type Verdict = 'PASS' | 'WARN' | 'NEED_CLARIFY' | 'NEED_FIX';
 
@@ -38,19 +39,6 @@ const RISK_STYLES: Record<RiskLevel, string> = {
   LOW: 'bg-[#dcfce7] text-[#15803d]',
   MEDIUM: 'bg-[#fef9c3] text-[#a16207]',
   HIGH: 'bg-[#fee2e2] text-[#dc2626]',
-};
-
-const REASON_LABELS: Record<string, string> = {
-  MISSING_SLOT: '필수 슬롯 누락',
-  HEADER_MISMATCH: '필수 헤더(컬럼) 누락',
-  EMPTY_TABLE: '표/데이터 행이 비어있음',
-  OCR_FAILED: 'OCR 판독 불가/텍스트 추출 실패',
-  WRONG_YEAR: '문서 대상 연도 불일치',
-  PARSE_FAILED: '파싱 실패',
-  DATE_MISMATCH: '기간 불일치',
-  UNIT_MISSING: '단위 누락',
-  EVIDENCE_MISSING: '근거문서 누락',
-  SIGNATURE_MISSING: '확인 서명란 미기재',
 };
 
 const STATUS_STYLES: Record<DiagnosticStatus, string> = {

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -8,6 +8,7 @@ import { useDiagnosticHistory } from '../../src/hooks/useDiagnostics';
 import type { DomainCode, DiagnosticStatus } from '../../src/types/api.types';
 import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.types';
 import type { SlotResultDetail } from '../../src/api/aiRun';
+import { REASON_LABELS } from '../../src/constants/reasonLabels';
 
 interface DocumentReviewPageProps {
   userRole: 'receiver' | 'drafter' | 'approver';
@@ -702,18 +703,6 @@ const VERDICT_STYLES: Record<Verdict, string> = {
   NEED_FIX: 'bg-red-100 text-red-700 border-red-200',
 };
 
-const REASON_LABELS: Record<string, string> = {
-  MISSING_SLOT: '필수 슬롯 누락',
-  HEADER_MISMATCH: '필수 헤더(컬럼) 누락',
-  EMPTY_TABLE: '표/데이터 행이 비어있음',
-  OCR_FAILED: 'OCR 판독 불가/텍스트 추출 실패',
-  WRONG_YEAR: '문서 대상 연도 불일치',
-  PARSE_FAILED: '파싱 실패',
-  DATE_MISMATCH: '기간 불일치',
-  UNIT_MISSING: '단위 누락',
-  EVIDENCE_MISSING: '근거문서 누락',
-  SIGNATURE_MISSING: '확인 서명란 미기재',
-};
 
 function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const verdict = result.verdict as Verdict;

--- a/src/constants/reasonLabels.ts
+++ b/src/constants/reasonLabels.ts
@@ -1,0 +1,26 @@
+/**
+ * AI 분석 결과 사유(reason) 코드 → 한글 라벨 매핑
+ * 서버에서 내려오는 reason 코드를 사용자에게 표시할 때 사용
+ */
+export const REASON_LABELS: Record<string, string> = {
+  // 공통 사유 (Common)
+  MISSING_SLOT: '필수 슬롯 누락',
+  HEADER_MISMATCH: '필수 헤더 누락',
+  EMPTY_TABLE: '표/데이터 행이 비어있음',
+  DATE_MISMATCH: '제출 기간 범위 밖 데이터',
+  SIGNATURE_MISSING: '확인 서명란 미기재',
+  OCR_FAILED: '문서 판독 불가',
+  LLM_ANOMALY_DETECTED: 'AI 문서 이상 징후 감지',
+  LLM_MISSING_FIELDS: 'AI 누락 항목 감지',
+  VIOLATION_DETECTED: 'AI 안전 위반 사항 감지',
+
+  // 교차 검증 (Cross Validation)
+  CROSS_HEADCOUNT_MISMATCH: '출석부와 사진 인원수 불일치',
+  CROSS_ATTENDANCE_PARSE_FAILED: '출석부 인원 추출 실패',
+  CROSS_PHOTO_COUNT_FAILED: '사진 인원 감지 실패',
+
+  // 안전(Safety) 특정 사유
+  LOW_EDUCATION_RATE: '교육 이수율 기준 미달',
+  EDU_DEPT_ZERO: '특정 부서 이수율 0%',
+  RISK_ACTION_MISSING: '위험성평가 조치 내용 누락',
+};


### PR DESCRIPTION
## 변경요약
- `src/constants/reasonLabels.ts` 신규 생성: 서버 매핑 기준 전체 사유 코드 한글 라벨 정의
- 3개 파일에서 중복 `REASON_LABELS` 로컬 정의 삭제 → import로 교체
- 기존에 누락되어 원문(영문) 그대로 노출되던 사유 코드 추가:
  - `VIOLATION_DETECTED` → AI 안전 위반 사항 감지
  - `LLM_ANOMALY_DETECTED` → AI 문서 이상 징후 감지
  - `LLM_MISSING_FIELDS` → AI 누락 항목 감지
  - `CROSS_HEADCOUNT_MISMATCH` → 출석부와 사진 인원수 불일치
  - 외 5건

## 관련이슈
- Closes #367

## 테스트방법
1. AI 분석 결과가 있는 기안 상세 페이지에서 사유 목록이 한글로 표시되는지 확인
2. `VIOLATION_DETECTED`, `LLM_ANOMALY_DETECTED` 등 신규 코드가 포함된 분석 결과에서 한글 라벨 확인
3. 매핑에 없는 미지 코드는 기존처럼 원문 그대로 fallback 표시되는지 확인

## 명세준수 체크
- [x] 서버 REASON_MAP 기준 전체 사유 코드 반영
- [x] 3개 파일 중복 제거 → 단일 소스 관리
- [x] fallback 동작 유지 (`REASON_LABELS[reason] || reason`)

## 리뷰포인트
- 기존 라벨과 일부 워딩 변경 (서버 매핑 기준으로 통일):
  - `필수 헤더(컬럼) 누락` → `필수 헤더 누락`
  - `OCR 판독 불가/텍스트 추출 실패` → `문서 판독 불가`
  - `기간 불일치` → `제출 기간 범위 밖 데이터`
- 기존에 있던 `WRONG_YEAR`, `PARSE_FAILED`, `UNIT_MISSING`, `EVIDENCE_MISSING`은 서버 매핑에 없어 제거됨 (서버에서 해당 코드를 보내는 경우 원문으로 fallback)

## TODO / 질문
- 없음