### PR TITLE
fix: 대시보드 통계 클릭 시 상태별 필터 적용 (#347)

### DIFF
--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -508,12 +508,12 @@ export default function HomePage({ userRole: legacyUserRole }: HomePageProps) {
 
     const basePath = `/diagnostics?domainCode=${activeTab}`;
     return [
-      { label: '작성중', value: String(statusCounts['WRITING'] || 0), color: 'text-[#495057]', path: basePath },
-      { label: '제출됨', value: String(statusCounts['SUBMITTED'] || 0), color: 'text-[#002554]', path: basePath },
-      { label: '반려됨', value: String(statusCounts['RETURNED'] || 0), color: 'text-[#b91c1c]', path: basePath },
-      { label: '승인됨', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: basePath },
-      { label: '심사중', value: String(statusCounts['REVIEWING'] || 0), color: 'text-[#e65100]', path: basePath },
-      { label: '완료', value: String(statusCounts['COMPLETED'] || 0), color: 'text-[#008233]', path: basePath },
+      { label: '작성중', value: String(statusCounts['WRITING'] || 0), color: 'text-[#495057]', path: `${basePath}&status=WRITING` },
+      { label: '제출됨', value: String(statusCounts['SUBMITTED'] || 0), color: 'text-[#002554]', path: `${basePath}&status=SUBMITTED` },
+      { label: '반려됨', value: String(statusCounts['RETURNED'] || 0), color: 'text-[#b91c1c]', path: `${basePath}&status=RETURNED` },
+      { label: '승인됨', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: `${basePath}&status=APPROVED` },
+      { label: '심사중', value: String(statusCounts['REVIEWING'] || 0), color: 'text-[#e65100]', path: `${basePath}&status=REVIEWING` },
+      { label: '완료', value: String(statusCounts['COMPLETED'] || 0), color: 'text-[#008233]', path: `${basePath}&status=COMPLETED` },
     ];
   }, [diagnosticsQuery.data, activeTab]);
 
@@ -527,9 +527,9 @@ export default function HomePage({ userRole: legacyUserRole }: HomePageProps) {
 
     const basePath = `/diagnostics?domainCode=${activeTab}`;
     return [
-      { label: '대기중', value: String(statusCounts['WAITING'] || 0), color: 'text-[#e65100]', path: basePath },
-      { label: '승인', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: basePath },
-      { label: '반려', value: String(statusCounts['REJECTED'] || 0), color: 'text-[#b91c1c]', path: basePath },
+      { label: '대기중', value: String(statusCounts['WAITING'] || 0), color: 'text-[#e65100]', path: `${basePath}&status=WAITING` },
+      { label: '승인', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: `${basePath}&status=APPROVED` },
+      { label: '반려', value: String(statusCounts['REJECTED'] || 0), color: 'text-[#b91c1c]', path: `${basePath}&status=REJECTED` },
     ];
   }, [approvalsQuery.data, activeTab]);
 
@@ -541,12 +541,12 @@ export default function HomePage({ userRole: legacyUserRole }: HomePageProps) {
     const basePath = `/reviews?domainCode=${activeTab}`;
     return [
       { label: '전체 협력사', value: String(summary.totalCompanies || 0), color: 'text-[#212529]' },
-      { label: '완료', value: String(summary.completedCount || 0), color: 'text-[#008233]', path: basePath },
-      { label: '진행중', value: String(summary.inProgressCount || 0), color: 'text-[#002554]', path: basePath },
+      { label: '완료', value: String(summary.completedCount || 0), color: 'text-[#008233]', path: `${basePath}&status=APPROVED` },
+      { label: '진행중', value: String(summary.inProgressCount || 0), color: 'text-[#002554]', path: `${basePath}&status=REVIEWING` },
       { label: '대기', value: String(summary.pendingCount || 0), color: 'text-[#495057]', path: basePath },
-      { label: '고위험', value: String(summary.highRiskCount || 0), color: 'text-[#b91c1c]' },
-      { label: '중위험', value: String(summary.mediumRiskCount || 0), color: 'text-[#e65100]' },
-      { label: '저위험', value: String(summary.lowRiskCount || 0), color: 'text-[#008233]' },
+      { label: '고위험', value: String(summary.highRiskCount || 0), color: 'text-[#b91c1c]', path: `${basePath}&riskLevel=HIGH` },
+      { label: '중위험', value: String(summary.mediumRiskCount || 0), color: 'text-[#e65100]', path: `${basePath}&riskLevel=MEDIUM` },
+      { label: '저위험', value: String(summary.lowRiskCount || 0), color: 'text-[#008233]', path: `${basePath}&riskLevel=LOW` },
     ];
   }, [reviewsListQuery.data?.summary, activeTab]);
 

--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useDiagnosticsList } from '../../src/hooks/useDiagnostics';
 import { useApprovals } from '../../src/hooks/useApprovals';
 import { useReviews } from '../../src/hooks/useReviews';
@@ -69,17 +69,36 @@ export default function DiagnosticsListPage() {
     return 'drafter';
   }, [domainCode, user?.domainRoles, user?.role?.code]);
 
+  // URL 파라미터에서 초기 필터 값 읽기
+  const [searchParams] = useSearchParams();
+  const urlStatus = searchParams.get('status');
+
   // 기안자용 상태
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
+    if (urlStatus && ['WRITING', 'SUBMITTED', 'RETURNED', 'APPROVED', 'REVIEWING', 'COMPLETED'].includes(urlStatus)) {
+      return urlStatus as DiagnosticStatus;
+    }
+    return 'ALL';
+  });
   const [keyword, setKeyword] = useState('');
   const [searchInput, setSearchInput] = useState('');
   const [page, setPage] = useState(0);
 
   // 결재자용 상태
-  const [approvalStatusFilter, setApprovalStatusFilter] = useState<ApprovalStatusFilter>('ALL');
+  const [approvalStatusFilter, setApprovalStatusFilter] = useState<ApprovalStatusFilter>(() => {
+    if (urlStatus && ['WAITING', 'APPROVED', 'REJECTED'].includes(urlStatus)) {
+      return urlStatus as ApprovalStatus;
+    }
+    return 'ALL';
+  });
 
   // 수신자용 상태
-  const [reviewStatusFilter, setReviewStatusFilter] = useState<ReviewStatusFilter>('ALL');
+  const [reviewStatusFilter, setReviewStatusFilter] = useState<ReviewStatusFilter>(() => {
+    if (urlStatus && ['REVIEWING', 'APPROVED', 'REVISION_REQUIRED'].includes(urlStatus)) {
+      return urlStatus as ReviewStatus;
+    }
+    return 'ALL';
+  });
 
   // 데이터 조회
   const diagnosticsQuery = useDiagnosticsList(


### PR DESCRIPTION
## 변경요약
- 대시보드 통계 숫자 클릭 시 해당 상태로 필터링된 목록 페이지로 이동하도록 개선
- 기안자(6개 상태), 결재자(3개 상태), 수신자(상태 3개 + 위험등급 3개) 모두 적용
- 목록 페이지에서 URL 쿼리 파라미터(`status`, `riskLevel`)를 읽어 초기 필터 적용
- 수신자 위험등급 필터 활성 시 해제 가능한 뱃지 UI 추가

## 관련이슈
- closes #347

## 테스트방법
1. 기안자 대시보드에서 "제출됨" 숫자 클릭 → 목록 페이지에서 "제출됨" 필터 활성 확인
2. 결재자 대시보드에서 "대기중" 숫자 클릭 → 목록 페이지에서 "대기" 필터 활성 확인
3. 수신자 대시보드에서 "고위험" 숫자 클릭 → 심사 목록에서 riskLevel=HIGH 필터 적용 및 뱃지 표시 확인
4. 위험등급 뱃지의 X 버튼 클릭 시 필터 해제 확인

## 명세준수 체크
- [x] 대시보드 통계 클릭 → 상태별 필터링된 목록 이동
- [x] 수신자 위험도 통계 클릭 가능
- [x] 전체 도메인(ESG, SAFETY, COMPLIANCE) 동작

## 리뷰포인트
- 수신자 "대기" 통계는 ReviewStatus에 직접 매핑되는 값이 없어 필터 없이 전체 목록으로 이동

## TODO/질문
- 없음