### PR TITLE
fix: Nginx 리버스 프록시 및 SPA fallback 설정 추가 (#370)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ WORKDIR /usr/share/nginx/html
 # Vite의 기본 빌드 폴더명은 'dist'입니다.
 COPY --from=build-stage /app/dist .
 
+# Nginx 설정 파일 복사 (API 리버스 프록시 + SPA fallback)
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 # Nginx의 기본 80포트 노출
 EXPOSE 80
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # API reverse proxy
+    location /api/ {
+        proxy_pass https://sc-backend.victoriouscliff-56531283.eastasia.azurecontainerapps.io/api/;
+        proxy_set_header Host sc-backend.victoriouscliff-56531283.eastasia.azurecontainerapps.io;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 310s;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## 변경 요약
- `nginx.conf` 신규 추가: `/api/` 요청을 백엔드(`sc-backend.victoriouscliff-56531283.eastasia.azurecontainerapps.io`)로 reverse proxy
- `Dockerfile` 수정: 빌드 시 `nginx.conf`를 nginx 설정 경로에 복사
- SPA fallback(`try_files`) 설정으로 클라이언트 라우팅 정상 동작 보장

## 관련 이슈
- Closes #370

## 테스트 방법
1. Docker 빌드: `docker build -t smartchain-fe .`
2. 컨테이너 실행: `docker run -p 80:80 smartchain-fe`
3. 브라우저에서 `http://localhost` 접속 → 프론트엔드 정상 렌더링 확인
4. 개발자 도구 Network 탭에서 `/api/v1/...` 요청이 백엔드로 프록시되는지 확인 (200 응답)
5. 새로고침 시 SPA fallback이 동작하는지 확인 (404 없이 정상 렌더링)

## 명세 준수 체크
- [x] `VITE_API_BASE_URL = /api` 기존 설정 변경 없음
- [x] `proxy_read_timeout 310s` — 리스크 분석 API 타임아웃(310초) 대응
- [x] `proxy_set_header Host` — Azure Container Apps 가상 호스트 라우팅 대응
- [x] SPA `try_files $uri $uri/ /index.html` — React Router 클라이언트 라우팅 지원

## 리뷰 포인트
- `nginx.conf`의 백엔드 URL이 현재 Azure 환경 주소로 하드코딩되어 있음 → 환경별 분리 필요 시 추후 환경변수 치환 방식 도입 검토

## TODO / 질문
- [ ] 스테이징/프로덕션 환경별로 백엔드 URL이 다를 경우, `envsubst` 등으로 nginx.conf 템플릿화 필요 여부 확인
- [ ] SSL 종료(TLS termination)가 Azure Container Apps 레벨에서 처리되는지 확인 (nginx에서는 80 포트만 노출)