### PR TITLE
feat: 기안자 목록 상태 탭을 도메인별로 분기 표시

### DIFF
--- a/features/diagnostics/DiagnosticsListPage.tsx
+++ b/features/diagnostics/DiagnosticsListPage.tsx
@@ -74,8 +74,12 @@ export default function DiagnosticsListPage() {
   const urlStatus = searchParams.get('status');
 
   // 기안자용 상태
+  const validDrafterStatuses = domainCode === 'ESG'
+    ? ['WRITING', 'SUBMITTED', 'REVIEWING', 'APPROVED', 'RETURNED']
+    : ['WRITING', 'REVIEWING', 'APPROVED', 'RETURNED'];
+
   const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
-    if (urlStatus && ['WRITING', 'SUBMITTED', 'RETURNED', 'APPROVED', 'REVIEWING', 'COMPLETED'].includes(urlStatus)) {
+    if (urlStatus && validDrafterStatuses.includes(urlStatus)) {
       return urlStatus as DiagnosticStatus;
     }
     return 'ALL';
@@ -152,15 +156,26 @@ export default function DiagnosticsListPage() {
     return '기안 관리';
   };
 
-  const statusTabs: { key: StatusFilter; label: string }[] = [
-    { key: 'ALL', label: '전체' },
-    { key: 'WRITING', label: '작성중' },
-    { key: 'SUBMITTED', label: '제출됨' },
-    { key: 'RETURNED', label: '반려됨' },
-    { key: 'APPROVED', label: '승인됨' },
-    { key: 'REVIEWING', label: '심사중' },
-    { key: 'COMPLETED', label: '완료' },
-  ];
+  const statusTabs: { key: StatusFilter; label: string }[] = useMemo(() => {
+    if (domainCode === 'ESG') {
+      return [
+        { key: 'ALL', label: '전체' },
+        { key: 'WRITING', label: '작성중' },
+        { key: 'SUBMITTED', label: '검토중' },
+        { key: 'REVIEWING', label: '심사중' },
+        { key: 'APPROVED', label: '승인됨' },
+        { key: 'RETURNED', label: '반려됨' },
+      ];
+    }
+    // SAFETY, COMPLIANCE
+    return [
+      { key: 'ALL', label: '전체' },
+      { key: 'WRITING', label: '작성중' },
+      { key: 'REVIEWING', label: '심사중' },
+      { key: 'APPROVED', label: '승인됨' },
+      { key: 'RETURNED', label: '반려됨' },
+    ];
+  }, [domainCode]);
 
   const approvalStatusTabs: { key: ApprovalStatusFilter; label: string }[] = [
     { key: 'ALL', label: '전체' },


### PR DESCRIPTION
## 변경 요약
- 기안자(DRAFTER) 진단 목록의 상태 필터 탭을 도메인별로 분기 렌더링
  - **ESG**: 전체 / 작성중 / 검토중(SUBMITTED) / 심사중 / 승인됨 / 반려됨
  - **SAFETY / COMPLIANCE**: 전체 / 작성중 / 심사중 / 승인됨 / 반려됨
- `statusTabs`를 `useMemo`로 전환하여 `domainCode` 변경 시 자동 갱신
- URL 파라미터(`?status=...`) 유효성 검증 추가 — 도메인에 없는 상태값은 `ALL`로 fallback
- 기존 `제출됨`/`완료` 탭 제거

## 관련 이슈
- closes #372

## 테스트 방법
1. ESG 도메인 기안자로 로그인 → 진단 목록 페이지 진입
   - 탭이 `전체 / 작성중 / 검토중 / 심사중 / 승인됨 / 반려됨` 순서로 표시되는지 확인
   - `검토중` 탭 클릭 시 `status=SUBMITTED`로 API 호출되는지 확인
2. SAFETY 또는 COMPLIANCE 도메인 기안자로 로그인 → 진단 목록 페이지 진입
   - 탭이 `전체 / 작성중 / 심사중 / 승인됨 / 반려됨` 순서로 표시되는지 확인
   - `검토중` 탭이 노출되지 않는지 확인
3. URL에 `?status=COMPLETED` 입력 → `전체` 탭이 선택된 상태로 표시되는지 확인
4. 결재자(APPROVER) / 수신자(REVIEWER) 역할은 기존과 동일하게 동작하는지 확인

## 명세 준수 체크
- [x] ESG: 전체 / 작성중 / 검토중 / 심사중 / 승인됨 / 반려됨
- [x] SAFETY: 전체 / 작성중 / 심사중 / 승인됨 / 반려됨
- [x] COMPLIANCE: 전체 / 작성중 / 심사중 / 승인됨 / 반려됨
- [x] 검토중 → API status `SUBMITTED` (ESG 전용)
- [x] 전체 탭 → statuses 파라미터 생략
- [x] 백엔드 API 변경 없음

## 리뷰 포인트
1. 명세에서 API 파라미터명이 `statuses`(복수)로 표기되어 있으나, 현재 API는 `status`(단수)를 사용 중 → 기존 파라미터명 유지함. 백엔드에서 파라미터명 변경 계획이 있는지 확인 필요
2. `domainCode`가 null인 경우 (도메인 미선택) SAFETY/COMPLIANCE와 동일한 탭을 표시 — 이 동작이 의도에 맞는지 확인 필요

## TODO / 질문
- [ ] 백엔드 `statuses` vs `status` 파라미터명 통일 여부 확인
- [ ] `domainCode` 미선택 시 기본 탭 구성에 대한 기획 확인 필요
- [ ] 각 탭 옆에 건수(count) 표시가 필요한지 기획팀에 확인