### PR TITLE
feat: 슬롯별 분석 결과 카드 디자인 개선 (#375)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -34,11 +34,18 @@ const VERDICT_LABELS: Record<Verdict, string> = {
   NEED_FIX: '수정 필요',
 };
 
-const VERDICT_STYLES: Record<Verdict, string> = {
-  PASS: 'bg-green-100 text-green-700 border-green-200',
-  WARN: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-  NEED_CLARIFY: 'bg-orange-100 text-orange-700 border-orange-200',
-  NEED_FIX: 'bg-red-100 text-red-700 border-red-200',
+const VERDICT_CARD_BG: Record<Verdict, React.CSSProperties> = {
+  PASS: { backgroundColor: '#d1fae5', borderColor: '#6ee7b7' },
+  WARN: { backgroundColor: '#fef9c3', borderColor: '#fde047' },
+  NEED_CLARIFY: { backgroundColor: '#fef9c3', borderColor: '#fde047' },
+  NEED_FIX: { backgroundColor: '#fee2e2', borderColor: '#fca5a5' },
+};
+
+const VERDICT_BADGE: Record<Verdict, React.CSSProperties> = {
+  PASS: { backgroundColor: '#22c55e', color: '#fff' },
+  WARN: { backgroundColor: '#eab308', color: '#fff' },
+  NEED_CLARIFY: { backgroundColor: '#eab308', color: '#fff' },
+  NEED_FIX: { backgroundColor: '#ef4444', color: '#fff' },
 };
 
 const RISK_LABELS: Record<RiskLevel, string> = {
@@ -391,8 +398,8 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
       <div className="p-[24px] space-y-[24px]">
         {/* 판정 결과 */}
         <div className="flex items-center gap-[16px]">
-          <div className={`px-[16px] py-[10px] rounded-[8px] border ${VERDICT_STYLES[verdict]}`}>
-            <span className="font-title-medium">{VERDICT_LABELS[verdict]}</span>
+          <div className="px-[20px] py-[12px] rounded-[8px]" style={VERDICT_BADGE[verdict]}>
+            <span className="font-heading-small">{VERDICT_LABELS[verdict]}</span>
           </div>
           <div className={`px-[14px] py-[8px] rounded-full ${RISK_STYLES[riskLevel]}`}>
             <span className="font-title-small font-semibold">위험도: {RISK_LABELS[riskLevel]}</span>
@@ -444,36 +451,50 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
 function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const verdict = result.verdict as Verdict;
   const displayName = result.display_name || result.slot_name;
+  const hasReasons = result.reasons && result.reasons.length > 0;
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="p-[20px] bg-gray-50 rounded-[12px]">
-      <div className="flex items-center justify-between mb-[12px]">
-        <span className="font-title-medium text-[var(--color-text-primary)]">
-          {displayName}
-        </span>
-        <span className={`px-[12px] py-[6px] rounded-[6px] font-title-small border ${VERDICT_STYLES[verdict]}`}>
+    <div className="rounded-[12px] border overflow-hidden" style={VERDICT_CARD_BG[verdict]}>
+      <div
+        className={`flex items-center px-[20px] py-[16px] ${hasReasons ? 'cursor-pointer' : ''}`}
+        onClick={() => hasReasons && setOpen(prev => !prev)}
+      >
+        <div className="flex-1 min-w-0">
+          <span className="font-title-medium text-[var(--color-text-primary)]">
+            {displayName}
+          </span>
+          {result.file_names && result.file_names.length > 0 && (
+            <p className="font-body-small text-[var(--color-text-tertiary)] mt-[4px] truncate">
+              {result.file_names.join(', ')}
+            </p>
+          )}
+        </div>
+        <span
+          className="px-[20px] py-[8px] rounded-[8px] font-title-medium flex-shrink-0 ml-[16px]"
+          style={VERDICT_BADGE[verdict]}
+        >
           {VERDICT_LABELS[verdict]}
         </span>
+        {hasReasons && (
+          <svg
+            className={`w-[20px] h-[20px] ml-[8px] flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
       </div>
-
-      {result.reasons && result.reasons.length > 0 && (
-        <ul className="space-y-[8px] mt-[12px]">
-          {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[8px] font-body-medium text-[var(--color-text-secondary)]">
-              <span className="w-[5px] h-[5px] bg-gray-400 rounded-full mt-[10px] flex-shrink-0" />
-              {REASON_LABELS[reason] || reason}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {result.file_names && result.file_names.length > 0 && (
-        <div className="mt-[12px] flex flex-wrap gap-[8px]">
-          {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[12px] py-[6px] bg-white font-body-medium text-gray-700 rounded-[6px] border border-gray-200">
-              {fileName}
-            </span>
-          ))}
+      {hasReasons && open && (
+        <div className="px-[20px] pb-[16px]">
+          <ul className="space-y-[6px]">
+            {result.reasons!.map((reason, index) => (
+              <li key={index} className="flex items-start gap-[8px] font-body-small text-[var(--color-text-secondary)]">
+                <span className="w-[4px] h-[4px] bg-gray-500 rounded-full mt-[8px] flex-shrink-0" />
+                {REASON_LABELS[reason] || reason}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -22,11 +22,20 @@ const VERDICT_LABELS: Record<Verdict, string> = {
   NEED_FIX: '수정 필요',
 };
 
-const VERDICT_STYLES: Record<Verdict, string> = {
-  PASS: 'bg-green-100 text-green-700 border-green-200',
-  WARN: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-  NEED_CLARIFY: 'bg-orange-100 text-orange-700 border-orange-200',
-  NEED_FIX: 'bg-red-100 text-red-700 border-red-200',
+// 슬롯 카드 배경 (연한 색)
+const VERDICT_CARD_BG: Record<Verdict, React.CSSProperties> = {
+  PASS: { backgroundColor: '#d1fae5', borderColor: '#6ee7b7' },
+  WARN: { backgroundColor: '#fef9c3', borderColor: '#fde047' },
+  NEED_CLARIFY: { backgroundColor: '#fef9c3', borderColor: '#fde047' },
+  NEED_FIX: { backgroundColor: '#fee2e2', borderColor: '#fca5a5' },
+};
+
+// 슬롯 verdict 뱃지 (솔리드 색)
+const VERDICT_BADGE: Record<Verdict, React.CSSProperties> = {
+  PASS: { backgroundColor: '#22c55e', color: '#fff' },
+  WARN: { backgroundColor: '#eab308', color: '#fff' },
+  NEED_CLARIFY: { backgroundColor: '#eab308', color: '#fff' },
+  NEED_FIX: { backgroundColor: '#ef4444', color: '#fff' },
 };
 
 const RISK_LABELS: Record<RiskLevel, string> = {
@@ -468,16 +477,6 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
       </div>
 
       <div className="p-[24px] space-y-[24px]">
-        {/* 판정 결과 */}
-        <div className="flex items-center gap-[16px]">
-          <div className={`px-[16px] py-[10px] rounded-[8px] border ${VERDICT_STYLES[verdict]}`}>
-            <span className="font-title-medium">{VERDICT_LABELS[verdict]}</span>
-          </div>
-          <div className={`px-[14px] py-[8px] rounded-full ${RISK_STYLES[riskLevel]}`}>
-            <span className="font-title-small font-semibold">위험도: {RISK_LABELS[riskLevel]}</span>
-          </div>
-        </div>
-
         {/* 요약 */}
         <div>
           <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[8px]">분석 요약</p>
@@ -523,36 +522,50 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
 function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const verdict = result.verdict as Verdict;
   const displayName = result.display_name || result.slot_name;
+  const hasReasons = result.reasons && result.reasons.length > 0;
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="p-[20px] bg-gray-50 rounded-[12px]">
-      <div className="flex items-center justify-between mb-[12px]">
-        <span className="font-title-medium text-[var(--color-text-primary)]">
-          {displayName}
-        </span>
-        <span className={`px-[12px] py-[6px] rounded-[6px] font-title-small border ${VERDICT_STYLES[verdict]}`}>
+    <div className="rounded-[12px] border overflow-hidden" style={VERDICT_CARD_BG[verdict]}>
+      <div
+        className={`flex items-center px-[20px] py-[16px] ${hasReasons ? 'cursor-pointer' : ''}`}
+        onClick={() => hasReasons && setOpen(prev => !prev)}
+      >
+        <div className="flex-1 min-w-0">
+          <span className="font-title-medium text-[var(--color-text-primary)]">
+            {displayName}
+          </span>
+          {result.file_names && result.file_names.length > 0 && (
+            <p className="font-body-small text-[var(--color-text-tertiary)] mt-[4px] truncate">
+              {result.file_names.join(', ')}
+            </p>
+          )}
+        </div>
+        <span
+          className="px-[20px] py-[8px] rounded-[8px] font-title-medium flex-shrink-0 ml-[16px]"
+          style={VERDICT_BADGE[verdict]}
+        >
           {VERDICT_LABELS[verdict]}
         </span>
+        {hasReasons && (
+          <svg
+            className={`w-[20px] h-[20px] ml-[8px] flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
       </div>
-
-      {result.reasons && result.reasons.length > 0 && (
-        <ul className="space-y-[8px] mt-[12px]">
-          {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[8px] font-body-medium text-[var(--color-text-secondary)]">
-              <span className="w-[5px] h-[5px] bg-gray-400 rounded-full mt-[10px] flex-shrink-0" />
-              {REASON_LABELS[reason] || reason}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {result.file_names && result.file_names.length > 0 && (
-        <div className="mt-[12px] flex flex-wrap gap-[8px]">
-          {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[12px] py-[6px] bg-white font-body-medium text-gray-700 rounded-[6px] border border-gray-200">
-              {fileName}
-            </span>
-          ))}
+      {hasReasons && open && (
+        <div className="px-[20px] pb-[16px]">
+          <ul className="space-y-[6px]">
+            {result.reasons!.map((reason, index) => (
+              <li key={index} className="flex items-start gap-[8px] font-body-small text-[var(--color-text-secondary)]">
+                <span className="w-[4px] h-[4px] bg-gray-500 rounded-full mt-[8px] flex-shrink-0" />
+                {REASON_LABELS[reason] || reason}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -696,45 +696,66 @@ const VERDICT_LABELS: Record<Verdict, string> = {
   NEED_FIX: '수정 필요',
 };
 
-const VERDICT_STYLES: Record<Verdict, string> = {
-  PASS: 'bg-green-100 text-green-700 border-green-200',
-  WARN: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-  NEED_CLARIFY: 'bg-orange-100 text-orange-700 border-orange-200',
-  NEED_FIX: 'bg-red-100 text-red-700 border-red-200',
+const VERDICT_CARD_BG: Record<Verdict, React.CSSProperties> = {
+  PASS: { backgroundColor: '#d1fae5', borderColor: '#6ee7b7' },
+  WARN: { backgroundColor: '#fef9c3', borderColor: '#fde047' },
+  NEED_CLARIFY: { backgroundColor: '#fef9c3', borderColor: '#fde047' },
+  NEED_FIX: { backgroundColor: '#fee2e2', borderColor: '#fca5a5' },
+};
+
+const VERDICT_BADGE: Record<Verdict, React.CSSProperties> = {
+  PASS: { backgroundColor: '#22c55e', color: '#fff' },
+  WARN: { backgroundColor: '#eab308', color: '#fff' },
+  NEED_CLARIFY: { backgroundColor: '#eab308', color: '#fff' },
+  NEED_FIX: { backgroundColor: '#ef4444', color: '#fff' },
 };
 
 
 function SlotResultCard({ result }: { result: SlotResultDetail }) {
   const verdict = result.verdict as Verdict;
   const displayName = result.display_name || result.slot_name;
+  const hasReasons = result.reasons && result.reasons.length > 0;
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="p-[20px] bg-[#f8f9fa] rounded-[12px]">
-      <div className="flex items-center justify-between mb-[12px]">
-        <span className="font-title-medium text-[#212529]">{displayName}</span>
-        <span className={`px-[12px] py-[6px] rounded-[6px] font-title-small border ${VERDICT_STYLES[verdict]}`}>
+    <div className="rounded-[12px] border overflow-hidden" style={VERDICT_CARD_BG[verdict]}>
+      <div
+        className={`flex items-center px-[20px] py-[16px] ${hasReasons ? 'cursor-pointer' : ''}`}
+        onClick={() => hasReasons && setOpen(prev => !prev)}
+      >
+        <div className="flex-1 min-w-0">
+          <span className="font-title-medium text-[#212529]">{displayName}</span>
+          {result.file_names && result.file_names.length > 0 && (
+            <p className="font-body-small text-[#868e96] mt-[4px] truncate">
+              {result.file_names.join(', ')}
+            </p>
+          )}
+        </div>
+        <span
+          className="px-[20px] py-[8px] rounded-[8px] font-title-medium flex-shrink-0 ml-[16px]"
+          style={VERDICT_BADGE[verdict]}
+        >
           {VERDICT_LABELS[verdict]}
         </span>
+        {hasReasons && (
+          <svg
+            className={`w-[20px] h-[20px] ml-[8px] flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
       </div>
-
-      {result.reasons && result.reasons.length > 0 && (
-        <ul className="space-y-[8px] mt-[12px]">
-          {result.reasons.map((reason, index) => (
-            <li key={index} className="flex items-start gap-[8px] font-body-medium text-[#868e96]">
-              <span className="w-[5px] h-[5px] bg-[#adb5bd] rounded-full mt-[10px] flex-shrink-0" />
-              {REASON_LABELS[reason] || reason}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {result.file_names && result.file_names.length > 0 && (
-        <div className="mt-[12px] flex flex-wrap gap-[8px]">
-          {result.file_names.map((fileName, index) => (
-            <span key={index} className="px-[12px] py-[6px] bg-white font-body-medium text-[#495057] rounded-[6px] border border-[#dee2e6]">
-              {fileName}
-            </span>
-          ))}
+      {hasReasons && open && (
+        <div className="px-[20px] pb-[16px]">
+          <ul className="space-y-[6px]">
+            {result.reasons!.map((reason, index) => (
+              <li key={index} className="flex items-start gap-[8px] font-body-small text-[#868e96]">
+                <span className="w-[4px] h-[4px] bg-[#adb5bd] rounded-full mt-[8px] flex-shrink-0" />
+                {REASON_LABELS[reason] || reason}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- 판정별 카드 배경색 적용 (적합: 초록, 확인필요: 노랑, 수정필요: 빨강)
- Tailwind v4 동적 클래스 미적용 이슈로 inline style 사용
- 판정 뱃지를 단색 버튼 스타일로 변경
- DiagnosticDetailPage 상단 중복 판정/위험도 섹션 제거
- 사유(reasons) 아코디언 토글 방식으로 변경 (클릭 시 펼침)
- 판정 텍스트 크기 증가

Closes #375