### PR TITLE
fix: 만료 토큰으로 인한 로그인→대시보드 플래시 현상 수정

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -63,7 +63,9 @@ apiClient.interceptors.response.use(
 
       if (!refreshToken) {
         logout();
-        window.location.href = '/login';
+        if (window.location.pathname !== '/login') {
+          window.location.href = '/login';
+        }
         return Promise.reject(error);
       }
 
@@ -77,7 +79,9 @@ apiClient.interceptors.response.use(
       } catch (refreshError) {
         processQueue(refreshError, null);
         logout();
-        window.location.href = '/login';
+        if (window.location.pathname !== '/login') {
+          window.location.href = '/login';
+        }
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;
@@ -90,7 +94,9 @@ apiClient.interceptors.response.use(
       !loginErrorCodes.includes(error.response.data?.code ?? '')
     ) {
       useAuthStore.getState().logout();
-      window.location.href = '/login';
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
## 변경 요약
- **LoginPage**: `isAuthenticated`만으로 즉시 `/dashboard` 리다이렉트 → `getMe()` API 호출로 토큰 유효성 검증 후 리다이렉트
- **API Client**: 401 interceptor에서 이미 `/login`에 있을 때 `window.location.href = '/login'` 중복 리로드 방지

## 관련 이슈
- Closes #381

## 테스트 방법
1. 로그인 후 정상적으로 대시보드 진입 확인 (기존 동작 유지)
2. 로그인 상태에서 브라우저 DevTools → Application → Local Storage → `auth-storage`의 accessToken을 만료된 값으로 수동 변경
3. 새 탭에서 `/login` 접속 → 대시보드 플래시 없이 로그인 폼이 바로 표시되는지 확인
4. localStorage에 만료 토큰이 있는 상태에서 `/` → '시작하기' 클릭 → 대시보드가 깜빡이지 않는지 확인

## 명세 준수 체크
- [x] 유효한 토큰이 있는 사용자는 기존처럼 자동으로 대시보드 이동
- [x] 만료 토큰 사용자는 대시보드 플래시 없이 로그인 폼 유지
- [x] 401 interceptor의 logout/redirect 로직 정상 동작
- [x] useEffect cleanup으로 unmount 시 stale navigation 방지

## 리뷰 포인트
- `getMe()` 호출 시 네트워크 비용이 추가되지만, 이미 `AppRoutes`에서 `useMe()` 훅이 동일 요청을 하고 있어 React Query 캐시로 중복 요청 방지됨
- `window.location.pathname !== '/login'` 체크가 3곳에 반복되는데, 헬퍼 함수 추출이 필요한 수준은 아니라고 판단

## TODO / 질문
- [ ] refresh token도 만료된 경우 `getMe()` → refresh 시도 → 실패 → logout 순서로 처리되는데, 이 과정에서 로그인 폼 로딩 상태 표시가 필요한지?
- [ ] `OnboardingPage`에서 `isAuthenticated`일 때 바로 대시보드로 보내는 로직 추가 여부 (현재는 온보딩 → 시작하기 → 로그인 → 대시보드 순서)