### PR TITLE
fix: 회원가입 1단계 페이지 용어 순화

### DIFF
--- a/features/auth/SignupStep1Page.tsx
+++ b/features/auth/SignupStep1Page.tsx
@@ -51,7 +51,7 @@ export default function SignupStep1Page() {
                         <span className="leading-[1.4] text-[var(--color-primary-main)]">1단계</span>
                         <span className="leading-[1.4]">/2단계</span>
                       </p>
-                      <p className="font-title-medium leading-[1.35]">개인정보 활용동의</p>
+                      <p className="font-title-medium leading-[1.35]">개인정보 수집 동의</p>
                     </div>
 
                     {/* Agreement Section */}
@@ -83,17 +83,17 @@ export default function SignupStep1Page() {
                     {/* Terms Detail */}
                     <div className="flex flex-col gap-[12px] items-start shrink-0 w-full">
                       <p className="font-title-small leading-[1.4] text-[var(--color-text-primary)] w-full">
-                        [필수] 개인정보수집 및 이용
+                        [필수] 개인정보 수집 및 이용
                       </p>
                       <div className="bg-white relative rounded-[24px] shrink-0 w-full max-h-[120px] lg:max-h-[200px] overflow-y-auto">
                         <div className="overflow-clip rounded-[inherit] size-full">
                           <div className="flex flex-col gap-[12px] items-start p-[24px] text-[var(--color-text-primary)] w-full">
-                            <p className="font-title-small leading-[1.4]">약관동의 및 개인정보수집이용동의</p>
+                            <p className="font-title-small leading-[1.4]">개인정보 수집 및 이용 안내</p>
                             <div className="font-body-small leading-[1.5]">
                               <ol className="list-decimal pl-[24px]">
-                                <li>수집하는 개인정보 항목: 이름, 이메일, 비밀번호</li>
-                                <li>수집 목적: 서비스 제공 및 회원 관리</li>
-                                <li>보유 기간: 회원 탈퇴 시까지</li>
+                                <li>수집 항목: 이름, 이메일, 비밀번호</li>
+                                <li>이용 목적: 서비스 제공 및 회원 관리</li>
+                                <li>보관 기간: 회원 탈퇴 시까지</li>
                               </ol>
                             </div>
                           </div>
@@ -107,7 +107,7 @@ export default function SignupStep1Page() {
                       <div className="overflow-clip rounded-[inherit] size-full">
                         <div className="flex flex-wrap gap-[10px] items-center p-[24px] relative w-full">
                           <p className="flex-1 font-body-small leading-[1.5] min-w-[200px] text-[var(--color-state-info-text)]">
-                            개인정보수집 및 이용에 대한 안내 사항을 읽고 동의합니다.
+                            위 개인정보 수집 및 이용 안내를 읽었으며 이에 동의합니다.
                           </p>
                           <div className="flex gap-[10px] items-center shrink-0">
                             <RadioButton


### PR DESCRIPTION
## 변경 요약
- 회원가입 1단계(약관 동의) 페이지의 문구를 사용자 친화적으로 순화
  - '개인정보 활용동의' → '개인정보 수집 동의'
  - '약관동의 및 개인정보수집이용동의' → '개인정보 수집 및 이용 안내'
  - 항목 레이블 간결화 (수집하는 개인정보 항목 → 수집 항목 등)
  - 동의 안내 문구 자연스럽게 수정

## 관련 이슈
- Closes #383
- 온보딩 페이지 용어 순화(a9224be)의 후속 작업

## 테스트 방법
1. `/signup/step1` 페이지 접속
2. 페이지 제목, 약관 섹션 제목, 동의 안내 문구가 자연스러운지 확인
3. 약관 동의 → 다음 버튼 클릭 → step2로 정상 이동 확인
4. 동의 없이 다음 클릭 → 에러 토스트 정상 표시 확인

## 명세 준수 체크
- [x] 기능 변경 없이 텍스트만 수정
- [x] 기존 동의 로직(전체 동의, 개별 동의, 동의안함) 동작 유지
- [x] 띄어쓰기 및 표현 통일

## 리뷰 포인트
- 법률 용어 수준의 문구("개인정보 활용동의")를 일반 사용자 대상 표현("개인정보 수집 동의")으로 바꿨으나, 법적 효력에 영향이 없는지 법무 확인 필요 여부

## TODO / 질문
- [ ] 실제 서비스 배포 전 법무팀 검토 필요 여부 확인