### PR TITLE
fix: 대시보드 기안자 상태 필터를 도메인 탭 필터와 일치시키기

### DIFF
--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -507,14 +507,20 @@ export default function HomePage({ userRole: legacyUserRole }: HomePageProps) {
     }, {} as Record<string, number>);
 
     const basePath = `/diagnostics?domainCode=${activeTab}`;
-    return [
+    const totalCount = content.length;
+    const stats = [
+      { label: '전체', value: String(totalCount), color: 'text-[#212529]', path: basePath },
       { label: '작성중', value: String(statusCounts['WRITING'] || 0), color: 'text-[#495057]', path: `${basePath}&status=WRITING` },
-      { label: '제출됨', value: String(statusCounts['SUBMITTED'] || 0), color: 'text-[#002554]', path: `${basePath}&status=SUBMITTED` },
-      { label: '반려됨', value: String(statusCounts['RETURNED'] || 0), color: 'text-[#b91c1c]', path: `${basePath}&status=RETURNED` },
-      { label: '승인됨', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: `${basePath}&status=APPROVED` },
-      { label: '심사중', value: String(statusCounts['REVIEWING'] || 0), color: 'text-[#e65100]', path: `${basePath}&status=REVIEWING` },
-      { label: '완료', value: String(statusCounts['COMPLETED'] || 0), color: 'text-[#008233]', path: `${basePath}&status=COMPLETED` },
     ];
+    if (activeTab === 'ESG') {
+      stats.push({ label: '검토중', value: String(statusCounts['SUBMITTED'] || 0), color: 'text-[#002554]', path: `${basePath}&status=SUBMITTED` });
+    }
+    stats.push(
+      { label: '심사중', value: String(statusCounts['REVIEWING'] || 0), color: 'text-[#e65100]', path: `${basePath}&status=REVIEWING` },
+      { label: '승인됨', value: String(statusCounts['APPROVED'] || 0), color: 'text-[#008233]', path: `${basePath}&status=APPROVED` },
+      { label: '반려됨', value: String(statusCounts['RETURNED'] || 0), color: 'text-[#b91c1c]', path: `${basePath}&status=RETURNED` },
+    );
+    return stats;
   }, [diagnosticsQuery.data, activeTab]);
 
   // Calculate stats for APPROVER from approvals data


### PR DESCRIPTION
## 변경 요약
- 대시보드 메인 화면의 기안자(DRAFTER) 상태 통계 카드를 각 도메인 탭(DiagnosticsListPage)의 필터 순서/항목과 일치시킴
- **제거:** 제출됨(SUBMITTED), 완료(COMPLETED) — 도메인 탭에 없는 상태
- **추가:** 전체 카운트 (전체 건수 표시)
- **순서 변경:** 전체 → 작성중 → 심사중 → 승인됨 → 반려됨
- **ESG 도메인:** 작성중 다음에 검토중(SUBMITTED) 항목 조건부 표시

## 관련 이슈
- Closes #387

## 테스트 방법
1. 기안자(DRAFTER) 계정으로 로그인
2. 대시보드 메인 화면에서 상태 통계 카드 순서 확인
   - SAFETY/COMPLIANCE 탭: 전체 → 작성중 → 심사중 → 승인됨 → 반려됨
   - ESG 탭: 전체 → 작성중 → 검토중 → 심사중 → 승인됨 → 반려됨
3. 각 도메인 탭 페이지 진입 후 필터 순서와 일치하는지 비교
4. 각 통계 카드 클릭 시 올바른 필터가 적용된 목록 페이지로 이동하는지 확인

## 명세 준수 체크
- [x] 도메인 탭 필터 순서(전체/작성중/심사중/승인됨/반려됨)와 일치
- [x] ESG 도메인의 검토중(SUBMITTED) 상태 조건부 표시
- [x] 기존 라우팅 path 파라미터 유지

## 리뷰 포인트
- `전체` 카운트를 `content.length`로 계산 — 페이지네이션 적용 시 전체 건수와 다를 수 있음 (현재 대시보드는 전체 목록 조회)

## TODO / 질문
- [ ] 승인자(APPROVER)/수신자(REVIEWER) 통계 카드도 동일하게 정렬 필요한지 확인 필요