### PR TITLE
fix: 파일 관리 페이지 진입 시 필수 첨부 자료 리스트 즉시 표시

### DIFF
--- a/features/diagnostics/DiagnosticFilesPage.tsx
+++ b/features/diagnostics/DiagnosticFilesPage.tsx
@@ -484,10 +484,19 @@ export default function DiagnosticFilesPage() {
     );
   }, [requiredSlotStatus]);
 
-  // 초기 로드 플래그 (preview와 add는 사용자가 직접 수행)
+  // 초기 로드 시 preview 자동 호출 (슬롯 목록을 즉시 표시)
   useEffect(() => {
     if (diagnosticId > 0 && existingFiles && !initialLoadDoneRef.current) {
       initialLoadDoneRef.current = true;
+      // 기존 완료 파일을 addedFileIds에 자동 추가
+      const existingCompleteIds = existingFiles
+        .filter(f => f.parsingStatus === 'SUCCESS')
+        .map(f => f.fileId);
+      if (existingCompleteIds.length > 0) {
+        setAddedFileIds(new Set(existingCompleteIds));
+      }
+      // preview 호출하여 슬롯 목록 로드
+      previewMutation.mutate({ diagnosticId, fileIds: existingCompleteIds });
     }
   }, [diagnosticId, existingFiles]);
 


### PR DESCRIPTION
## 변경 요약
- 파일 업로드 및 관리 페이지(`DiagnosticFilesPage`) 진입 시 우측 **필수 첨부 자료 리스트**(슬롯 목록)가 즉시 표시되도록 수정
- 기존: 파일 업로드 → Add 버튼 클릭 후에야 슬롯 목록이 나타남
- 변경: 페이지 초기 로드 시 `preview API`를 자동 호출하여 슬롯 목록을 즉시 렌더링
- 기존에 업로드 완료된 파일이 있으면 `addedFileIds`에 자동 추가하여 슬롯 매칭도 반영

## 관련 이슈
- Closes #393

## 테스트 방법
1. 기안(diagnostic)을 하나 생성하고 파일 관리 페이지(`/diagnostics/:id/files`)로 이동
2. **파일 업로드 전**: 우측 필수 첨부 자료 리스트에 슬롯 목록이 즉시 표시되는지 확인 (모두 미제출 상태)
3. **기존 파일이 있는 기안**: 페이지 재진입 시 기존 파일의 슬롯 매칭이 자동 반영되는지 확인
4. 파일 업로드 → Add → 슬롯 매칭 업데이트가 기존처럼 정상 작동하는지 확인

## 명세 준수 체크
- [x] preview API 호출로 슬롯 목록 로드
- [x] 기존 완료 파일 자동 addedFileIds 추가
- [x] initialLoadDoneRef로 중복 호출 방지

## 리뷰 포인트
- `previewMutation.mutate`를 useEffect 안에서 호출하므로, 의존성 배열에 `previewMutation`을 포함하지 않아 eslint exhaustive-deps 경고가 발생할 수 있음 → `initialLoadDoneRef`로 1회만 실행되므로 실질적 문제 없음
- 기존 파일이 없는 경우(빈 fileIds 배열) preview API가 슬롯 목록만 반환하는지 백엔드 확인 필요

## TODO / 질문
- [ ] 빈 fileIds로 preview 호출 시 백엔드가 슬롯 목록을 정상 반환하는지 확인 필요
- [ ] 기존 파일이 많은 경우(10개+) 초기 preview 호출 성능 이슈 없는지 확인