### PR TITLE
fix: 모달 및 폼에서 Enter 키 제출이 동작하도록 form 패턴 통일 (#348)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -314,7 +314,7 @@ export default function ApprovalDetailPage() {
       {/* 승인/반려 모달 */}
       {showModal && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40">
-          <div className="bg-white rounded-[16px] w-full max-w-[480px] mx-[16px] shadow-xl">
+          <form onSubmit={(e) => { e.preventDefault(); handleProcess(); }} className="bg-white rounded-[16px] w-full max-w-[480px] mx-[16px] shadow-xl">
             <div className="px-[24px] py-[20px] border-b border-[var(--color-border-default)]">
               <h2 className="font-title-medium text-[var(--color-text-primary)]">
                 {showModal === 'APPROVED' ? '원청에 제출' : '결재 반려'}
@@ -347,13 +347,14 @@ export default function ApprovalDetailPage() {
 
             <div className="px-[24px] py-[16px] border-t border-[var(--color-border-default)] flex justify-end gap-[12px]">
               <button
+                type="button"
                 onClick={() => { setShowModal(null); setComment(''); }}
                 className="px-[20px] py-[10px] rounded-[8px] border border-[var(--color-border-default)] font-title-small text-[var(--color-text-secondary)] hover:bg-gray-50 transition-colors"
               >
                 취소
               </button>
               <button
-                onClick={handleProcess}
+                type="submit"
                 disabled={processApprovalMutation.isPending || submitToReviewerMutation.isPending || (showModal === 'REJECTED' && !comment.trim())}
                 className={`px-[20px] py-[10px] rounded-[8px] font-title-small text-white transition-colors disabled:opacity-50 ${
                   showModal === 'APPROVED'
@@ -366,7 +367,7 @@ export default function ApprovalDetailPage() {
                   : showModal === 'APPROVED' ? '원청에 제출' : '반려'}
               </button>
             </div>
-          </div>
+          </form>
         </div>
       )}
     </DashboardLayout>

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -589,12 +589,13 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
       {/* ESG Approve Modal */}
       {showApproveModal && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-[20px] p-[32px] w-[700px] max-w-[90%]">
+          <form onSubmit={(e) => { e.preventDefault(); handleApproveWithComments(); }} className="bg-white rounded-[20px] p-[32px] w-[700px] max-w-[90%]">
             <div className="flex items-center justify-between mb-[24px]">
               <h3 className="font-heading-small text-[#212529]">
                 ESG 심사 승인
               </h3>
               <button
+                type="button"
                 onClick={() => setShowApproveModal(false)}
                 className="p-[8px] hover:bg-[#f1f3f5] rounded-[8px] transition-colors"
               >
@@ -642,27 +643,28 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
 
             <div className="flex gap-[12px] justify-end">
               <button
+                type="button"
                 onClick={() => setShowApproveModal(false)}
                 className="px-[24px] py-[12px] bg-[#e9ecef] text-[#495057] rounded-[8px] font-title-small hover:bg-[#dee2e6] transition-colors"
               >
                 취소
               </button>
               <button
-                onClick={handleApproveWithComments}
+                type="submit"
                 disabled={isMutating}
                 className="px-[24px] py-[12px] bg-[#00ad1d] text-white rounded-[8px] font-title-small hover:bg-[#008a18] transition-colors disabled:opacity-50"
               >
                 승인
               </button>
             </div>
-          </div>
+          </form>
         </div>
       )}
 
       {/* Confirm Approve Modal (SAFETY/COMPLIANCE) */}
       {showConfirmApproveModal && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-[20px] p-[32px] w-[480px] max-w-[90%]">
+          <form onSubmit={(e) => { e.preventDefault(); handleConfirmApprove(); }} className="bg-white rounded-[20px] p-[32px] w-[480px] max-w-[90%]">
             <h3 className="font-heading-small text-[#212529] mb-[16px]">
               승인 확인
             </h3>
@@ -671,32 +673,34 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
             </p>
             <div className="flex gap-[12px] justify-end">
               <button
+                type="button"
                 onClick={() => setShowConfirmApproveModal(false)}
                 className="px-[24px] py-[12px] bg-[#e9ecef] text-[#495057] rounded-[8px] font-title-small hover:bg-[#dee2e6] transition-colors"
               >
                 취소
               </button>
               <button
-                onClick={handleConfirmApprove}
+                type="submit"
                 disabled={isMutating}
                 className="px-[24px] py-[12px] bg-[#00ad1d] text-white rounded-[8px] font-title-small hover:bg-[#008a18] transition-colors disabled:opacity-50"
               >
                 승인
               </button>
             </div>
-          </div>
+          </form>
         </div>
       )}
 
       {/* Reject Modal */}
       {showRejectModal && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-[20px] p-[32px] w-[600px] max-w-[90%]">
+          <form onSubmit={(e) => { e.preventDefault(); handleRequestFix(); }} className="bg-white rounded-[20px] p-[32px] w-[600px] max-w-[90%]">
             <div className="flex items-center justify-between mb-[24px]">
               <h3 className="font-heading-small text-[#212529]">
                 보완 요청 사유 입력
               </h3>
               <button
+                type="button"
                 onClick={() => setShowRejectModal(false)}
                 className="p-[8px] hover:bg-[#f1f3f5] rounded-[8px] transition-colors"
               >
@@ -711,20 +715,21 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
             />
             <div className="flex gap-[12px] justify-end">
               <button
+                type="button"
                 onClick={() => setShowRejectModal(false)}
                 className="px-[24px] py-[12px] bg-[#e9ecef] text-[#495057] rounded-[8px] font-title-small hover:bg-[#dee2e6] transition-colors"
               >
                 취소
               </button>
               <button
-                onClick={handleRequestFix}
+                type="submit"
                 disabled={isMutating || !rejectReason.trim()}
                 className="px-[24px] py-[12px] bg-[#dc2626] text-white rounded-[8px] font-title-small hover:bg-[#b91c1c] transition-colors disabled:opacity-50"
               >
                 보완 요청 전송
               </button>
             </div>
-          </div>
+          </form>
         </div>
       )}
     </DashboardLayout>

--- a/features/permission/PermissionModal.tsx
+++ b/features/permission/PermissionModal.tsx
@@ -55,7 +55,7 @@ export default function PermissionModal({ isOpen, request, onClose, onConfirm, i
   if (showConfirm) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-        <div className="bg-white rounded-[20px] p-[32px] w-[400px] flex flex-col gap-[24px] shadow-xl">
+        <form onSubmit={(e) => { e.preventDefault(); handleConfirm(); }} className="bg-white rounded-[20px] p-[32px] w-[400px] flex flex-col gap-[24px] shadow-xl">
           <div className="flex flex-col items-center gap-4">
             {action === 'approve' ? (
               <div className="w-16 h-16 bg-[#e8f5e9] rounded-full flex items-center justify-center">
@@ -82,6 +82,7 @@ export default function PermissionModal({ isOpen, request, onClose, onConfirm, i
               className="flex-1"
               onClick={() => setShowConfirm(false)}
               disabled={isProcessing}
+              type="button"
             >
               취소
             </Button>
@@ -89,24 +90,24 @@ export default function PermissionModal({ isOpen, request, onClose, onConfirm, i
               variant="primary"
               size="large"
               className={`flex-1 ${action === 'reject' ? 'bg-[#c62828] hover:bg-[#b71c1c]' : ''}`}
-              onClick={handleConfirm}
+              type="submit"
               disabled={isProcessing}
             >
               {isProcessing ? '처리 중...' : '확인'}
             </Button>
           </div>
-        </div>
+        </form>
       </div>
     );
   }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-[24px] p-[32px] w-[560px] flex flex-col gap-[24px] shadow-xl max-h-[90vh] overflow-y-auto">
+      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="bg-white rounded-[24px] p-[32px] w-[560px] flex flex-col gap-[24px] shadow-xl max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex justify-between items-center">
           <h2 className="font-heading-small text-[#212529]">권한 요청 상세</h2>
-          <button onClick={handleClose} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+          <button type="button" onClick={handleClose} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
             <X className="w-5 h-5 text-[#868e96]" />
           </button>
         </div>
@@ -243,11 +244,11 @@ export default function PermissionModal({ isOpen, request, onClose, onConfirm, i
           className={`w-full h-[56px] rounded-[16px] ${
             action === 'reject' ? 'bg-[#c62828] hover:bg-[#b71c1c]' : 'bg-[#003087]'
           }`}
-          onClick={handleSubmit}
+          type="submit"
         >
           {action === 'approve' ? '승인하기' : '반려하기'}
         </Button>
-      </div>
+      </form>
     </div>
   );
 }

--- a/features/permission/PermissionRequestPage.tsx
+++ b/features/permission/PermissionRequestPage.tsx
@@ -77,7 +77,7 @@ export default function PermissionRequestPage() {
   return (
     <GuestLayout>
       <div className="flex justify-center w-full py-[48px] px-4">
-        <div className="bg-white rounded-[32px] p-[48px] w-full max-w-[1392px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)] border border-[#b0cbef]">
+        <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="bg-white rounded-[32px] p-[48px] w-full max-w-[1392px] shadow-[4px_4px_20px_0px_rgba(0,0,0,0.1)] border border-[#b0cbef]">
             <div className="flex flex-col gap-[24px]">
                 <h1 className="font-heading-medium text-[#212529]">시스템 권한요청</h1>
 
@@ -260,7 +260,7 @@ export default function PermissionRequestPage() {
                         variant="primary"
                         size="large"
                         className="w-full h-[64px] rounded-[20px] font-title-medium bg-[#003087]"
-                        onClick={handleSubmit}
+                        type="submit"
                         disabled={createRequest.isPending || !!pageData?.pendingRequest || !selectedRole || !selectedDomain || !selectedCompanyId}
                     >
                         {createRequest.isPending ? '요청 중...' : '권한요청'}
@@ -268,7 +268,7 @@ export default function PermissionRequestPage() {
                 </div>
 
             </div>
-        </div>
+        </form>
       </div>
     </GuestLayout>
   );


### PR DESCRIPTION
## 변경 요약
- 모달 및 폼 컴포넌트에서 `<div>` + `onClick` 패턴을 `<form onSubmit>` + `type="submit"` 패턴으로 통일
- 취소/닫기 버튼에 `type="button"` 명시하여 의도치 않은 제출 방지
- 4개 파일, 7개 폼/모달 수정

### 수정 대상
| 파일 | 수정 내용 |
|------|-----------|
| `PermissionModal.tsx` | 메인 모달 + 확인 다이얼로그 `<form>` 래핑 |
| `ApprovalDetailPage.tsx` | 승인/반려 모달 `<form>` 래핑 |
| `DocumentReviewPage.tsx` | ESG 승인, 승인 확인, 반려 모달 3개 `<form>` 래핑 |
| `PermissionRequestPage.tsx` | 권한요청 전체 폼 `<form>` 래핑 |

## 관련 이슈
- Closes #348

## 테스트 방법
1. **PermissionModal**: 권한 요청 상세 모달에서 승인/반려 선택 후 Enter 키로 제출 확인
2. **ApprovalDetailPage**: 결재 상세 → 반려 모달에서 사유 입력 후 Enter 키 제출 확인
3. **DocumentReviewPage**: 제출결과 조회 → ESG 승인 모달, 보완 요청 모달에서 Enter 키 제출 확인
4. **PermissionRequestPage**: 권한요청 페이지에서 모든 항목 선택 후 Enter 키 제출 확인
5. 각 모달에서 취소/닫기 버튼이 Enter 키에 반응하지 않는지 확인
6. textarea에서 Enter 키가 줄바꿈으로 정상 동작하는지 확인

## 명세 준수 체크
- [x] `<form onSubmit>` 패턴으로 통일
- [x] 제출 버튼에 `type="submit"` 명시
- [x] 취소/닫기 버튼에 `type="button"` 명시
- [x] `e.preventDefault()` 호출로 페이지 리로드 방지
- [x] 기존 동작(onClick 핸들러 로직) 변경 없음

## 리뷰 포인트
- textarea 내에서 Enter 키는 줄바꿈으로 동작하므로, 이 PR은 주로 **확인 모달(input 없는 모달)** 및 **시맨틱 HTML 통일**에 초점
- `PermissionRequestPage`는 textarea만 있어 Enter 키 제출 효과가 크지 않지만, 패턴 일관성을 위해 포함

## TODO / 질문
- [ ] 검색 필터 컴포넌트들(`UserManagementPage`, `CompanyManagementPage`, `DiagnosticsListPage`)은 현재 `onKeyDown` 커스텀 핸들러로 동작 중 — 이들도 `<form>` 패턴으로 통일할지 추후 논의 필요
- [ ] `AiAnalysisPage` 채팅 입력은 Shift+Enter 지원이 필요하므로 현행 `onKeyDown` 유지가 적절