### PR TITLE
feat: 비밀번호 유효기간 및 변경 기능 구현 (#224)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -26,6 +26,7 @@ import AiAnalysisPage from './features/documents/AiAnalysisPage';
 import UserManagementPage from './features/management/UserManagementPage';
 import CompanyManagementPage from './features/management/CompanyManagementPage';
 import ActivityLogPage from './features/management/ActivityLogPage';
+import ChangePasswordPage from './features/auth/ChangePasswordPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -128,6 +129,16 @@ function AppRoutes() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup/step1" element={<SignupStep1Page />} />
       <Route path="/signup/step2" element={<SignupStep2Page />} />
+
+      {/* Change Password */}
+      <Route
+        path="/change-password"
+        element={
+          <ProtectedRoute>
+            <ChangePasswordPage />
+          </ProtectedRoute>
+        }
+      />
 
       {/* Permission Routes */}
       <Route

--- a/features/auth/ChangePasswordPage.tsx
+++ b/features/auth/ChangePasswordPage.tsx
@@ -1,0 +1,155 @@
+import { useLocation } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '../../shared/components/Button';
+import { Input } from '../../shared/components/Input';
+import { LogoWithSubtitle } from '../../shared/components/Logo';
+import Footer from '../../shared/layout/Footer';
+import { useChangePassword } from '../../src/hooks/useAuth';
+import { changePasswordSchema, type ChangePasswordFormData } from '../../src/validation/auth';
+
+function LoginBackground() {
+  return (
+    <div className="absolute inset-0 overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#002554] to-[#0066cc] opacity-90" />
+    </div>
+  );
+}
+
+function LeftPanel() {
+  return (
+    <div className="bg-[var(--color-surface-primary)] flex-1 hidden lg:flex flex-col relative overflow-hidden rounded-l-[20px]">
+      <LoginBackground />
+      <div className="relative z-10 flex-1 flex flex-col justify-center items-center p-6 text-center">
+        <p className="font-body-large leading-[1.6] text-white mb-4">
+          안전한 서비스 이용을 위해
+          <br aria-hidden="true" />
+          비밀번호를 변경해주세요.
+        </p>
+        <div className="flex flex-col items-center justify-center">
+          <p className="font-display-medium text-white/80">SMARTCHAIN</p>
+          <p className="font-display-large text-white">ESG Platform</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ChangePasswordPage() {
+  const location = useLocation();
+  const isExpired = location.state?.expired === true;
+  const changePasswordMutation = useChangePassword();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ChangePasswordFormData>({
+    resolver: zodResolver(changePasswordSchema),
+  });
+
+  const onSubmit = (data: ChangePasswordFormData) => {
+    changePasswordMutation.mutate({
+      currentPassword: data.currentPassword,
+      newPassword: data.newPassword,
+      newPasswordConfirm: data.newPasswordConfirm,
+    });
+  };
+
+  return (
+    <div className="bg-[var(--color-page-bg)] h-screen w-full flex flex-col overflow-hidden md:overflow-hidden overflow-y-auto">
+      <div className="flex-1 flex items-center justify-center p-4 md:p-8 lg:p-12 min-h-0">
+        <div className="bg-white flex flex-col lg:flex-row w-full max-w-[1400px] h-full max-h-[700px] rounded-[20px] shadow-lg overflow-hidden">
+          <LeftPanel />
+
+          <div className="flex-1 w-full p-6 md:p-8 flex flex-col justify-center items-center">
+            <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-[360px] flex flex-col gap-4 items-center">
+              <div className="w-full flex flex-col gap-6 items-start">
+                <div className="w-full flex justify-center lg:justify-start">
+                  <LogoWithSubtitle />
+                </div>
+
+                {isExpired && (
+                  <div className="w-full p-4 rounded-lg bg-amber-50 border border-amber-200">
+                    <p className="font-title-small text-amber-700">비밀번호 변경 필요</p>
+                    <p className="font-body-small text-amber-600 mt-1">
+                      비밀번호 유효기간(90일)이 만료되었습니다. 새 비밀번호로 변경 후 서비스를 이용해주세요.
+                    </p>
+                  </div>
+                )}
+
+                <div className="w-full flex flex-col gap-4">
+                  <div className="w-full">
+                    <Input
+                      label="현재 비밀번호"
+                      type="password"
+                      placeholder="현재 비밀번호를 입력해주세요."
+                      containerClassName="w-full"
+                      {...register('currentPassword')}
+                    />
+                    {errors.currentPassword && (
+                      <p className="text-red-500 font-detail-small mt-1">{errors.currentPassword.message}</p>
+                    )}
+                  </div>
+                  <div className="w-full">
+                    <Input
+                      label="새 비밀번호"
+                      type="password"
+                      placeholder="새 비밀번호를 입력해주세요."
+                      containerClassName="w-full"
+                      {...register('newPassword')}
+                    />
+                    {errors.newPassword && (
+                      <p className="text-red-500 font-detail-small mt-1">{errors.newPassword.message}</p>
+                    )}
+                  </div>
+                  <div className="w-full">
+                    <Input
+                      label="새 비밀번호 확인"
+                      type="password"
+                      placeholder="새 비밀번호를 다시 입력해주세요."
+                      containerClassName="w-full"
+                      {...register('newPasswordConfirm')}
+                    />
+                    {errors.newPasswordConfirm && (
+                      <p className="text-red-500 font-detail-small mt-1">{errors.newPasswordConfirm.message}</p>
+                    )}
+                  </div>
+
+                  <p className="font-detail-small text-[var(--color-text-tertiary)]">
+                    비밀번호는 영문, 숫자, 특수문자를 포함하여 8자 이상이어야 합니다.
+                  </p>
+                </div>
+
+                <div className="w-full flex flex-col gap-3">
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    size="large"
+                    className="w-full font-title-small"
+                    disabled={changePasswordMutation.isPending}
+                  >
+                    {changePasswordMutation.isPending ? '변경 중...' : '비밀번호 변경'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="large"
+                    className="w-full font-title-small"
+                    onClick={() => reset()}
+                    disabled={changePasswordMutation.isPending}
+                  >
+                    초기화
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+  );
+}

--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -240,6 +240,14 @@ export default function Header({ userName, userRole, onToggleSidebar, showMenuBu
         {/* Divider */}
         <div className="h-[24px] w-px bg-white/30" />
 
+        {/* Change Password */}
+        <Link
+          to="/change-password"
+          className="hidden md:block font-title-medium text-white cursor-pointer hover:opacity-80 whitespace-nowrap"
+        >
+          비밀번호 변경
+        </Link>
+
         {/* Logout Button */}
         <button
           onClick={handleLogout}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -13,6 +13,8 @@ import type {
   EmailVerificationRequest,
   EmailVerificationResponse,
   MyInfoResponse,
+  ChangePasswordRequest,
+  ChangePasswordResponse,
 } from '../types/api.types';
 import type { AuthUser } from '../store/authStore';
 
@@ -72,5 +74,10 @@ export const logout = async (): Promise<void> => {
 
 export const getMe = async (): Promise<MyInfoResponse> => {
   const response = await apiClient.get<BaseResponse<MyInfoResponse>>('/v1/auth/me');
+  return response.data.data;
+};
+
+export const changePassword = async (data: ChangePasswordRequest): Promise<ChangePasswordResponse> => {
+  const response = await apiClient.post<BaseResponse<ChangePasswordResponse>>('/v1/auth/change-password', data);
   return response.data.data;
 };

--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -14,6 +14,8 @@ export const ERROR_HANDLERS: Record<string, ErrorConfig> = {
   A004: { action: 'toast' },
   A005: { action: 'toast', customMessage: '계정이 영구 잠금되었습니다. 관리자에게 문의해주세요.' },
   A006: { action: 'silent' }, // LoginPage에서 직접 처리
+  A007: { action: 'silent' }, // 비밀번호 만료 — LoginPage에서 직접 처리
+  A008: { action: 'toast', customMessage: '이전에 사용한 비밀번호는 재사용할 수 없습니다.' },
 
   // Permission
   PERM_001: { action: 'redirect', redirectTo: '/dashboard', customMessage: '해당 리소스에 대한 접근 권한이 없습니다' },
@@ -174,6 +176,10 @@ export const LOGIN_ERROR_MESSAGES: Record<string, string> = {
   A005: '계정이 영구 잠금되었습니다. 관리자에게 문의해주세요.',
   A006: '계정이 일시 잠금되었습니다.',
   ACCOUNT_LOCKED: '계정이 잠금되었습니다.',
+
+  // 비밀번호 만료/재사용
+  A007: '비밀번호가 만료되었습니다. 새 비밀번호로 변경해주세요.',
+  A008: '이전에 사용한 비밀번호는 재사용할 수 없습니다.',
 
   // 서버 오류 (500)
   S001: '서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.',

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -160,6 +160,9 @@ export interface LoginResponse {
   user: UserInfoDto;
   remainingAttempts?: number;
   warningMessage?: string;
+  passwordExpired?: boolean;
+  passwordExpiresAt?: string;
+  passwordExpiresInDays?: number;
 }
 
 export interface UserInfoDto {
@@ -170,6 +173,18 @@ export interface UserInfoDto {
   role?: RoleInfoDto;
   domainRoles?: UserDomainRole[];
   company?: CompanyInfoDto;
+}
+
+// --- 비밀번호 변경 ---
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
+export interface ChangePasswordResponse {
+  success: boolean;
+  message: string;
 }
 
 // --- 토큰 갱신 ---
@@ -387,6 +402,8 @@ export const ERROR_CODES = {
   ACCESS_DENIED: 'A004',
   ACCOUNT_LOCKED_PERMANENT: 'A005',
   ACCOUNT_LOCKED_TEMPORARY: 'A006',
+  PASSWORD_EXPIRED: 'A007',
+  PASSWORD_REUSE_DENIED: 'A008',
   PERMISSION_DENIED_RESOURCE: 'PERM_001',
   PERMISSION_DENIED_ACTION: 'PERM_002',
 

--- a/src/validation/auth.ts
+++ b/src/validation/auth.ts
@@ -33,3 +33,25 @@ export const emailVerificationSchema = z.object({
 });
 
 export type EmailVerificationFormData = z.infer<typeof emailVerificationSchema>;
+
+const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/;
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요'),
+    newPassword: z
+      .string()
+      .min(8, '비밀번호는 8자 이상이어야 합니다')
+      .regex(passwordRegex, '비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다'),
+    newPasswordConfirm: z.string().min(1, '새 비밀번호 확인을 입력해주세요'),
+  })
+  .refine((data) => data.newPassword === data.newPasswordConfirm, {
+    message: '새 비밀번호가 일치하지 않습니다',
+    path: ['newPasswordConfirm'],
+  })
+  .refine((data) => data.currentPassword !== data.newPassword, {
+    message: '현재 비밀번호와 다른 비밀번호를 입력해주세요',
+    path: ['newPassword'],
+  });
+
+export type ChangePasswordFormData = z.infer<typeof changePasswordSchema>;


### PR DESCRIPTION
## 변경 요약
- 비밀번호 90일 유효기간 만료 시 강제 변경 흐름 구현 (개인정보 보호조치 기준 제4조)
- 로그인 시 `passwordExpired === true`이면 `/change-password`로 리다이렉트
- 비밀번호 변경 페이지 신규 생성 (LoginPage 레이아웃 재사용)
- Header에 자발적 비밀번호 변경 링크 추가
- 에러코드 A007(만료), A008(재사용 불가) 처리

### 변경 파일
| 파일 | 변경 내용 |
|---|---|
| `src/types/api.types.ts` | `ChangePasswordRequest/Response`, `LoginResponse` 만료 필드 3개 추가 |
| `src/constants/errorCodes.ts` | A007(silent), A008(toast) 에러 핸들러 및 메시지 추가 |
| `src/validation/auth.ts` | `changePasswordSchema` (확인 일치 + 현재≠새 검증) |
| `src/api/auth.ts` | `changePassword()` — `POST /v1/auth/change-password` |
| `src/hooks/useAuth.ts` | `useChangePassword` 훅 추가, `useLogin` 만료 리다이렉트 로직 |
| `features/auth/ChangePasswordPage.tsx` | 비밀번호 변경 페이지 (만료 안내 배너, 폼 초기화 버튼) |
| `App.tsx` | `/change-password` 라우트 (`ProtectedRoute`) |
| `shared/layout/Header.tsx` | 비밀번호 변경 링크 추가 |

## 관련 이슈
- Closes #224

## 테스트 방법
- [ ] `npm run build` 타입 에러 없이 빌드 확인
- [ ] `/change-password` 라우트 직접 접근 → 페이지 정상 렌더링
- [ ] 폼 validation 동작 확인:
  - 빈 값 제출 시 에러 메시지
  - 새 비밀번호 ≠ 확인 → "새 비밀번호가 일치하지 않습니다"
  - 현재 비밀번호 = 새 비밀번호 → "현재 비밀번호와 다른 비밀번호를 입력해주세요"
  - 비밀번호 형식 미충족 (영문+숫자+특수문자 8자 이상)
- [ ] 초기화 버튼 클릭 시 모든 필드 초기화
- [ ] Header "비밀번호 변경" 링크 → `/change-password` 이동
- [ ] (백엔드 연동 후) 로그인 시 `passwordExpired: true` 응답 → 자동 리다이렉트

## 명세 준수 체크
- [x] `ChangePasswordRequest`: `currentPassword`, `newPassword`, `newPasswordConfirm`
- [x] `ChangePasswordResponse`: `success`, `message`
- [x] `LoginResponse` 만료 필드: `passwordExpired?`, `passwordExpiresAt?`, `passwordExpiresInDays?`
- [x] API 엔드포인트: `POST /v1/auth/change-password`
- [x] 에러코드: A007 (silent), A008 (toast)
- [x] Zod refine: 비밀번호 확인 일치 + 현재≠새 비밀번호
- [x] 만료 시 `location.state.expired` 기반 안내 메시지 표시
- [x] 변경 완료 시 logout 후 `/login` 이동

## 리뷰 포인트
1. `useLogin`에서 `passwordExpired` 체크 위치가 toast 호출보다 앞 — 만료 시 환영 메시지 미노출이 의도된 동작
2. `ChangePasswordPage` 좌측 패널을 LoginPage의 SVG 배경 대신 단순 그라디언트로 처리 — LoginLeftPanel 재사용 vs 별도 디자인 의견 필요
3. Header의 비밀번호 변경 링크는 `hidden md:block`으로 모바일에서 숨김 — 모바일 햄버거 메뉴에도 추가 필요 여부

## TODO / 질문
- [ ] 백엔드 API 완성 후 실 연동 테스트 필요
- [ ] 비밀번호 만료 임박(예: 7일 전) 시 대시보드 알림 배너 추가 여부 → `passwordExpiresInDays` 활용
- [ ] 모바일 Sidebar에도 비밀번호 변경 메뉴 추가할지?
- [ ] 비밀번호 변경 성공 후 모든 세션 로그아웃(서버측) 정책 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)