### PR TITLE
fix: 심사 리스트 위험등급 표시 개선 및 이력 타임라인 역할 라벨 추가 (#398)

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -267,7 +267,12 @@ export default function ApprovalDetailPage() {
                       <span className="font-title-small text-[var(--color-text-primary)]">{DIAGNOSTIC_STATUS_LABELS[item.newStatus]}</span>
                       {isLatest && <span className="px-[6px] py-[1px] font-label-xsmall font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">최신</span>}
                     </h3>
-                    <p className="font-body-small text-[var(--color-text-secondary)]">{item.performedBy.name}</p>
+                    <p className="font-body-small text-[var(--color-text-secondary)]">
+                      {item.performedBy.name}
+                      {item.performedBy.role && (
+                        <span className="ml-[6px] text-[var(--color-text-tertiary)]">({{ DRAFTER: '기안자', APPROVER: '결재자', REVIEWER: '수신자' }[item.performedBy.role] || item.performedBy.role})</span>
+                      )}
+                    </p>
                     {item.comment && (
                       <div className="p-[12px] mt-[8px] rounded-[10px] border border-[#e5e7eb] bg-[#f9fafb]">
                         <p className="font-body-small text-[var(--color-text-primary)] whitespace-pre-wrap">{item.comment}</p>

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -313,6 +313,9 @@ export default function DiagnosticDetailPage() {
                     </h3>
                     <p className="font-body-small text-[var(--color-text-secondary)] mb-[8px]">
                       {item.performedBy.name}
+                      {item.performedBy.role && (
+                        <span className="ml-[6px] text-[var(--color-text-tertiary)]">({{ DRAFTER: '기안자', APPROVER: '결재자', REVIEWER: '수신자' }[item.performedBy.role] || item.performedBy.role})</span>
+                      )}
                     </p>
 
                     {/* 코멘트 */}

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -426,7 +426,12 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                         <span className="font-title-small text-[#212529]">{DIAGNOSTIC_STATUS_LABELS[item.newStatus]}</span>
                         {isLatest && <span className="px-[6px] py-[1px] font-label-xsmall font-semibold rounded-full bg-[#dbeafe] text-[#1d4ed8]">최신</span>}
                       </h3>
-                      <p className="font-body-small text-[#868e96]">{maskName(item.performedBy.name)}</p>
+                      <p className="font-body-small text-[#868e96]">
+                        {maskName(item.performedBy.name)}
+                        {item.performedBy.role && (
+                          <span className="ml-[6px] text-[#adb5bd]">({{ DRAFTER: '기안자', APPROVER: '결재자', REVIEWER: '수신자' }[item.performedBy.role] || item.performedBy.role})</span>
+                        )}
+                      </p>
                       {item.comment && (
                         <div className="p-[12px] mt-[8px] rounded-[10px] border border-[#e5e7eb] bg-[#f9fafb]">
                           <p className="font-body-small text-[#495057] whitespace-pre-wrap">{item.comment}</p>

--- a/features/reviews/ReviewsListPage.tsx
+++ b/features/reviews/ReviewsListPage.tsx
@@ -11,10 +11,10 @@ const STATUS_STYLES: Record<ReviewStatus, string> = {
   REVISION_REQUIRED: 'text-[#e65100] bg-[#fff3e0]',
 };
 
-const RISK_BADGE_STYLES: Record<string, string> = {
-  red: 'text-[#b91c1c] bg-[#fef2f2]',
-  yellow: 'text-[#e65100] bg-[#fff3e0]',
-  green: 'text-[#008233] bg-[#f0fdf4]',
+const RISK_LEVEL_CONFIG: Record<string, { label: string; style: string }> = {
+  HIGH: { label: '고위험', style: 'text-[#b91c1c] bg-[#fef2f2]' },
+  MEDIUM: { label: '중위험', style: 'text-[#e65100] bg-[#fff3e0]' },
+  LOW: { label: '저위험', style: 'text-[#008233] bg-[#f0fdf4]' },
 };
 
 const STATUS_LABELS: Record<ReviewStatus, string> = {
@@ -218,7 +218,9 @@ export default function ReviewsListPage() {
               )}
 
               {reviews.map((item) => {
-                const riskStyle = item.riskColorClass ? RISK_BADGE_STYLES[item.riskColorClass] : 'bg-gray-100 text-gray-600 border-gray-200';
+                const riskConfig = item.riskLevel ? RISK_LEVEL_CONFIG[item.riskLevel] : null;
+                const riskLabel = riskConfig?.label || item.riskLevelLabel;
+                const riskStyle = riskConfig?.style || (item.riskColorClass ? `text-[#6b7280] bg-gray-100` : '');
                 return (
                   <tr
                     key={item.reviewId}
@@ -242,12 +244,12 @@ export default function ReviewsListPage() {
                       {item.company?.companyName || '-'}
                     </td>
                     <td className="px-[16px] py-[14px] text-center" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>
-                      {item.riskLevelLabel ? (
+                      {riskLabel ? (
                         <span className={`inline-block px-[10px] py-[4px] rounded-full font-title-xsmall border ${riskStyle}`}>
-                          {item.riskLevelLabel}
+                          {riskLabel}
                         </span>
                       ) : (
-                        <span className="font-body-medium text-[var(--color-text-tertiary)]">-</span>
+                        <span className="font-body-medium text-[var(--color-text-tertiary)]">미분석</span>
                       )}
                     </td>
                     <td className="px-[16px] py-[14px] font-body-medium text-[var(--color-text-tertiary)]" onClick={() => navigate(`/dashboard/${item.domainCode.toLowerCase()}/review/${item.reviewId}`)}>


### PR DESCRIPTION
## 변경 요약
- **ReviewsListPage**: 위험등급 표시를 `riskLevelLabel`/`riskColorClass` 의존에서 `riskLevel` enum 기반 매핑으로 변경. 기존 필드는 fallback으로 유지.
- **ApprovalDetailPage / DiagnosticDetailPage / DocumentReviewPage**: 기안 이력 타임라인에 수행자 역할(기안자/결재자/수신자) 라벨 추가.

## 관련 이슈
- Closes #398

## 테스트 방법
1. 수신자 계정으로 로그인
2. `/reviews?domainCode=SAFETY` 접속 → 위험등급 컬럼 확인 (riskLevel 값이 있는 경우 고위험/중위험/저위험 표시)
3. `/reviews?domainCode=ESG` 접속 → 동일 확인
4. `/reviews?domainCode=COMPLIANCE` 접속 → 기존 동작 유지 확인
5. 결재 상세(`/approvals/:id`), 기안 상세(`/diagnostics/:id`), 제출결과 조회(`/dashboard/*/review/:id`) 페이지에서 이력 타임라인에 역할 라벨 표시 확인

## 명세 준수 체크
- [x] 위험등급: `riskLevel` enum → 고위험/중위험/저위험 매핑 (다른 페이지와 동일 패턴)
- [x] 이력 타임라인: `performedBy.role` → 기안자/결재자/수신자 한글 라벨
- [x] 기존 API 응답 호환성 유지 (riskLevelLabel fallback)

## 리뷰 포인트
- `RISK_LEVEL_CONFIG` 매핑의 라벨/색상이 `DocumentReviewPage`, `HomePage`의 `riskLevelConfig`와 일관성 있는지 확인
- fallback 로직(`riskConfig?.label || item.riskLevelLabel`)이 모든 케이스를 커버하는지 확인

## TODO / 질문
- ⚠️ **백엔드 이슈**: `GET /v1/reviews` 리스트 API에서 ESG/SAFETY 도메인 review의 `riskLevel` 필드가 null로 내려오는 경우, 프론트에서는 "미분석"으로 표시됨. 백엔드에서 AI 분석 결과 테이블 조인이 필요함.
- 추후 `riskLevelLabel`/`riskColorClass` 필드가 불필요해지면 `ReviewListItem` 인터페이스에서 제거 검토