### PR TITLE
fix: 보완 요청 comment 2000자 제한 및 글자수 카운터 추가 (#400)

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -153,7 +153,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
       const draft = clarifications
         .map((c) => c.message)
         .join('\n\n---\n\n');
-      setRejectReason(draft);
+      setRejectReason(draft.slice(0, 2000));
     }
     setShowRejectModal(true);
   };
@@ -707,12 +707,18 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                 <X className="w-[24px] h-[24px] text-[#868e96]" />
               </button>
             </div>
-            <textarea
-              value={rejectReason}
-              onChange={(e) => setRejectReason(e.target.value)}
-              placeholder="보완이 필요한 사항을 상세히 입력해주세요..."
-              className="w-full h-[200px] border border-[#dee2e6] rounded-[12px] p-[16px] font-body-medium resize-none focus:outline-none focus:border-[#003087] mb-[24px]"
-            />
+            <div className="mb-[24px]">
+              <textarea
+                value={rejectReason}
+                onChange={(e) => { if (e.target.value.length <= 2000) setRejectReason(e.target.value); }}
+                maxLength={2000}
+                placeholder="보완이 필요한 사항을 상세히 입력해주세요..."
+                className={`w-full h-[200px] border rounded-[12px] p-[16px] font-body-medium resize-none focus:outline-none ${rejectReason.length >= 2000 ? 'border-[#dc2626] focus:border-[#dc2626]' : 'border-[#dee2e6] focus:border-[#003087]'}`}
+              />
+              <div className={`text-right mt-[4px] font-body-small ${rejectReason.length >= 2000 ? 'text-[#dc2626]' : 'text-[#868e96]'}`}>
+                {rejectReason.length.toLocaleString()} / 2,000자
+              </div>
+            </div>
             <div className="flex gap-[12px] justify-end">
               <button
                 type="button"


### PR DESCRIPTION
## 변경 요약
수신자 보완 요청(REVISION_REQUIRED) 시 comment 필드에 2000자 제한을 적용하고, 글자수 카운터 UI를 추가합니다.

- `textarea`에 `maxLength={2000}` + `onChange` 가드로 2000자 초과 입력 차단
- 글자수 카운터 표시 (`n / 2,000자`), 2000자 도달 시 빨간색 경고
- AI clarifications 자동 채움 시 `draft.slice(0, 2000)`으로 초과분 절삭

## 관련 이슈
- Closes #400
- 백엔드: `diagnostic_history.comment` VARCHAR(500) → VARCHAR(2000) 확장, DTO `@Size(max=2000)` 추가 완료

## 테스트 방법
1. 수신자 계정으로 심사 상세 페이지 진입
2. "재제출 요청" 버튼 클릭 → 보완 요청 모달 열기
3. **글자수 카운터 확인**: 입력 시 우하단에 `n / 2,000자` 표시되는지 확인
4. **2000자 제한 확인**: 2000자 이상 입력 시 더 이상 입력되지 않고, 카운터 및 테두리가 빨간색으로 변경되는지 확인
5. **AI 자동 채움 확인**: AI 분석이 있는 문서에서 모달을 열었을 때, 자동 채움 텍스트가 2000자를 넘지 않는지 확인
6. 보완 요청 전송 → 정상 처리 확인

## 명세 준수 체크
- [x] 백엔드 comment 2000자 제한과 FE 제한이 일치
- [x] 2000자 초과 시 백엔드 HTTP 400 반환 → FE에서 사전 차단하므로 도달하지 않음
- [x] 기존 승인/반려 플로우에 영향 없음

## 리뷰 포인트
- `onChange` 가드와 `maxLength` 이중 적용이 적절한지
- 글자수 카운터 스타일이 디자인 시스템과 일관적인지

## TODO / 질문
- [ ] 디자이너 확인: 글자수 카운터 위치(textarea 우하단) 및 경고색(#dc2626) 적절한지
- [ ] 백엔드 운영 DB 마이그레이션(`ALTER TABLE diagnostic_history ALTER COLUMN comment TYPE VARCHAR(2000)`) 완료 여부 확인 필요