### PR TITLE
feat: 제출결과 조회 기안자 정보 추가 및 수신자 완료 처리 개선

### DIFF
--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -5,7 +5,7 @@ import DashboardLayout from '../../shared/layout/DashboardLayout';
 import { AlertCircle, ArrowLeft, X, FileText, Download, Bot } from 'lucide-react';
 import { useReviewDetail, useSubmitReview } from '../../src/hooks/useReviews';
 import { useAiResult } from '../../src/hooks/useAiRun';
-import { useDiagnosticHistory, useSubmitDiagnostic } from '../../src/hooks/useDiagnostics';
+import { useDiagnosticDetail, useDiagnosticHistory, useSubmitDiagnostic } from '../../src/hooks/useDiagnostics';
 import type { DomainCode, DiagnosticStatus } from '../../src/types/api.types';
 import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.types';
 import type { SlotResultDetail } from '../../src/api/aiRun';
@@ -124,6 +124,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
 
   const { data: review, isLoading, isError } = useReviewDetail(reviewId);
   const diagnosticId = review?.diagnostic?.diagnosticId ?? 0;
+  const { data: diagnosticDetail } = useDiagnosticDetail(diagnosticId);
   const { data: aiResult } = useAiResult(diagnosticId);
   const { data: history } = useDiagnosticHistory(diagnosticId);
   const submitReview = useSubmitReview();
@@ -170,7 +171,6 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
     setShowConfirmApproveModal(false);
     submitReview.mutate(
       { id: reviewId, data: { decision: 'APPROVED' } },
-      { onSuccess: () => navigate(listPath) }
     );
   };
 
@@ -188,7 +188,6 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
       {
         onSuccess: () => {
           setShowApproveModal(false);
-          navigate(listPath);
         },
       }
     );
@@ -352,7 +351,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
           {/* 기안 정보 */}
           <div className="bg-white rounded-[16px] border border-[#dee2e6] p-[24px] mb-[24px]">
             <h2 className="font-title-medium text-[#212529] mb-[16px]">기안 정보</h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-[16px]">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-[16px]">
               <div>
                 <p className="font-body-small text-[#868e96] mb-[4px]">기안명</p>
                 <p className="font-title-small text-[#212529]">{review.diagnostic?.title || '-'}</p>
@@ -368,6 +367,14 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
               <div>
                 <p className="font-body-small text-[#868e96] mb-[4px]">상태</p>
                 <p className="font-title-small text-[#212529]">{review.statusLabel || review.status}</p>
+              </div>
+              <div>
+                <p className="font-body-small text-[#868e96] mb-[4px]">기안자명</p>
+                <p className="font-title-small text-[#212529]">{diagnosticDetail?.createdBy?.maskedName || '-'}</p>
+              </div>
+              <div>
+                <p className="font-body-small text-[#868e96] mb-[4px]">기안자 이메일</p>
+                <p className="font-title-small text-[#212529]">{diagnosticDetail?.createdBy?.email || '-'}</p>
               </div>
             </div>
           </div>
@@ -583,7 +590,7 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                   disabled={isMutating || isCompleted}
                   className="px-[32px] py-[14px] bg-[#00ad1d] text-white rounded-[8px] font-title-small hover:bg-[#008a18] transition-colors disabled:opacity-50"
                 >
-                  승인 (Approve)
+                  완료 (Complete)
                 </button>
               </>
             )}

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -32,7 +32,7 @@ export interface DiagnosticDetail {
   qualitativeProgress: number;
   quantitativeProgress: number;
   overallProgress: number;
-  createdBy: { userId: number; name: string; maskedName: string };
+  createdBy: { userId: number; name: string; maskedName: string; email?: string };
   createdAt: string;
   updatedAt: string;
   submittedAt?: string;

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -39,6 +39,7 @@ export const useSubmitReview = () => {
     onSuccess: () => {
       toast.success('심사 처리가 완료되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['reviews'] });
+      queryClient.invalidateQueries({ queryKey: ['diagnostics'] });
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       handleApiError(error);


### PR DESCRIPTION
## 변경 요약
- **기안자 정보 표시**: 제출결과 조회 페이지 "기안 정보" 섹션에 기안자명(마스킹)과 이메일 필드 추가 (grid-cols-4 → grid-cols-3, 2행 6개 항목)
- **수신자 버튼 변경**: "승인 (Approve)" → "완료 (Complete)"로 역할에 맞게 변경
- **심사 후 페이지 유지**: 완료/승인 처리 후 목록 이동 대신 현재 페이지에서 데이터 자동 갱신
- **이력 즉시 반영**: `useSubmitReview`의 `onSuccess`에 `diagnostics` 쿼리 invalidate 추가로 이력 타임라인 캐시 갱신
- **타입 확장**: `DiagnosticDetail.createdBy`에 `email?: string` 필드 추가 (백엔드 응답 대비)

## 관련 이슈
- Closes #402

## 테스트 방법
1. 수신자 로그인 → `/dashboard/safety/review/:id` 접속
2. "기안 정보" 섹션에서 **기안자명**(마스킹) 표시 확인
3. **기안자 이메일** 필드: 백엔드 응답에 있으면 표시, 없으면 `-` 표시 확인
4. "완료 (Complete)" 버튼 클릭 → 페이지 이동 없이 상태/이력 갱신 확인
5. ESG 도메인: 승인 모달 → 카테고리 의견 입력 후 승인 → 모달 닫힘 + 데이터 갱신 확인
6. COMPLIANCE 도메인에서도 동일 동작 확인

## 명세 준수 체크
- [x] `useDiagnosticDetail(diagnosticId)` 훅으로 기안자 정보 조회
- [x] `diagnostic.createdBy.maskedName`으로 기안자명 표시
- [x] `diagnostic.createdBy.email`이 없으면 `-`으로 fallback
- [x] 기안 정보 그리드 `grid-cols-3` 2행 레이아웃 (6개 항목)
- [x] `useSubmitReview` onSuccess에서 `['diagnostics']` 쿼리 invalidate
- [x] 심사 처리 후 navigate 제거, 페이지 유지

## 리뷰 포인트
- `diagnostics` 쿼리 전체 invalidate 범위가 넓은데 (`['diagnostics']` prefix match), 성능 이슈 가능성 확인 필요
- 수신자 "완료" 처리 후 페이지 유지 시, 버튼 disabled 상태가 `isCompleted` 체크로 정상 전환되는지 확인

## TODO / 질문
- [ ] **백엔드**: `GET /v1/diagnostics/:id` 응답의 `createdBy`에 `email` 필드 추가 필요
- [ ] **백엔드**: 수신자 완료 처리 시 diagnostic history에 `COMPLETED` 이력 레코드 생성 여부 확인
- [ ] 결재자(approver) 역할에서도 승인 후 페이지 유지가 적절한지 UX 확인 필요