### PR TITLE
feat: AI 분석 결과에 교차검증(Cross Validation) 결과 표시

### DIFF
--- a/features/approvals/ApprovalDetailPage.tsx
+++ b/features/approvals/ApprovalDetailPage.tsx
@@ -9,7 +9,7 @@ import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.typ
 import { handleApiError } from '../../src/utils/errorHandler';
 import type { AxiosError } from 'axios';
 import type { ErrorResponse } from '../../src/types/api.types';
-import type { AiAnalysisResultResponse, SlotResultDetail } from '../../src/api/aiRun';
+import type { AiAnalysisResultResponse, SlotResultDetail, CrossValidationResult } from '../../src/api/aiRun';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 import { REASON_LABELS } from '../../src/constants/reasonLabels';
 
@@ -434,6 +434,20 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
           </div>
         )}
 
+        {/* 교차검증 결과 */}
+        {details?.crossValidations && details.crossValidations.length > 0 && (
+          <div>
+            <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[12px]">
+              교차검증 결과
+            </p>
+            <div className="space-y-[12px]">
+              {details.crossValidations.map((cv, index) => (
+                <CrossValidationCard key={index} result={cv} />
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* 분석 정보 */}
         <div className="grid grid-cols-2 gap-[16px] pt-[16px] border-t border-[var(--color-border-default)]">
           <div>
@@ -450,6 +464,59 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function CrossValidationCard({ result }: { result: CrossValidationResult }) {
+  const verdict = result.verdict as Verdict;
+  const title = result.displayNames.join(' × ');
+  const hasReasons = result.reasons && result.reasons.length > 0;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="rounded-[12px] border overflow-hidden" style={VERDICT_CARD_BG[verdict]}>
+      <div
+        className={`flex items-center px-[20px] py-[16px] ${hasReasons ? 'cursor-pointer' : ''}`}
+        onClick={() => hasReasons && setOpen(prev => !prev)}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-[8px]">
+            <svg className="w-[16px] h-[16px] text-[var(--color-text-tertiary)] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+            <span className="font-title-medium text-[var(--color-text-primary)]">
+              {title}
+            </span>
+          </div>
+        </div>
+        <span
+          className="px-[20px] py-[8px] rounded-[8px] font-title-medium flex-shrink-0 ml-[16px]"
+          style={VERDICT_BADGE[verdict]}
+        >
+          {VERDICT_LABELS[verdict]}
+        </span>
+        {hasReasons && (
+          <svg
+            className={`w-[20px] h-[20px] ml-[8px] flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+      {hasReasons && open && (
+        <div className="px-[20px] pb-[16px]">
+          <ul className="space-y-[6px]">
+            {result.reasons.map((reason, index) => (
+              <li key={index} className="flex items-start gap-[8px] font-body-small text-[var(--color-text-secondary)]">
+                <span className="w-[4px] h-[4px] bg-gray-500 rounded-full mt-[8px] flex-shrink-0" />
+                {REASON_LABELS[reason] || reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -9,7 +9,7 @@ import {
 import { useAiResult } from '../../src/hooks/useAiRun';
 import type { DiagnosticStatus, DomainCode, RiskLevel } from '../../src/types/api.types';
 import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.types';
-import type { AiAnalysisResultResponse, SlotResultDetail } from '../../src/api/aiRun';
+import type { AiAnalysisResultResponse, SlotResultDetail, CrossValidationResult } from '../../src/api/aiRun';
 import DashboardLayout from '../../shared/layout/DashboardLayout';
 import { REASON_LABELS } from '../../src/constants/reasonLabels';
 
@@ -508,6 +508,20 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
           </div>
         )}
 
+        {/* 교차검증 결과 */}
+        {details?.crossValidations && details.crossValidations.length > 0 && (
+          <div>
+            <p className="font-title-xsmall text-[var(--color-text-tertiary)] mb-[12px]">
+              교차검증 결과
+            </p>
+            <div className="space-y-[12px]">
+              {details.crossValidations.map((cv, index) => (
+                <CrossValidationCard key={index} result={cv} />
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* 분석 정보 */}
         <div className="grid grid-cols-2 gap-[16px] pt-[16px] border-t border-[var(--color-border-default)]">
           <div>
@@ -524,6 +538,59 @@ function AiResultSection({ result }: { result: AiAnalysisResultResponse }) {
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function CrossValidationCard({ result }: { result: CrossValidationResult }) {
+  const verdict = result.verdict as Verdict;
+  const title = result.displayNames.join(' × ');
+  const hasReasons = result.reasons && result.reasons.length > 0;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="rounded-[12px] border overflow-hidden" style={VERDICT_CARD_BG[verdict]}>
+      <div
+        className={`flex items-center px-[20px] py-[16px] ${hasReasons ? 'cursor-pointer' : ''}`}
+        onClick={() => hasReasons && setOpen(prev => !prev)}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-[8px]">
+            <svg className="w-[16px] h-[16px] text-[var(--color-text-tertiary)] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+            <span className="font-title-medium text-[var(--color-text-primary)]">
+              {title}
+            </span>
+          </div>
+        </div>
+        <span
+          className="px-[20px] py-[8px] rounded-[8px] font-title-medium flex-shrink-0 ml-[16px]"
+          style={VERDICT_BADGE[verdict]}
+        >
+          {VERDICT_LABELS[verdict]}
+        </span>
+        {hasReasons && (
+          <svg
+            className={`w-[20px] h-[20px] ml-[8px] flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+      {hasReasons && open && (
+        <div className="px-[20px] pb-[16px]">
+          <ul className="space-y-[6px]">
+            {result.reasons.map((reason, index) => (
+              <li key={index} className="flex items-start gap-[8px] font-body-small text-[var(--color-text-secondary)]">
+                <span className="w-[4px] h-[4px] bg-gray-500 rounded-full mt-[8px] flex-shrink-0" />
+                {REASON_LABELS[reason] || reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/features/documents/DocumentReviewPage.tsx
+++ b/features/documents/DocumentReviewPage.tsx
@@ -8,7 +8,7 @@ import { useAiResult } from '../../src/hooks/useAiRun';
 import { useDiagnosticDetail, useDiagnosticHistory, useSubmitDiagnostic } from '../../src/hooks/useDiagnostics';
 import type { DomainCode, DiagnosticStatus } from '../../src/types/api.types';
 import { DOMAIN_LABELS, DIAGNOSTIC_STATUS_LABELS } from '../../src/types/api.types';
-import type { SlotResultDetail } from '../../src/api/aiRun';
+import type { SlotResultDetail, CrossValidationResult } from '../../src/api/aiRun';
 import { REASON_LABELS } from '../../src/constants/reasonLabels';
 import { getDownloadUrl, fetchFileBlob } from '../../src/api/files';
 import type { DownloadUrlResponse } from '../../src/api/files';
@@ -395,6 +395,17 @@ export default function DocumentReviewPage({ userRole }: DocumentReviewPageProps
                   <div className="space-y-[12px]">
                     {aiResult.details.slot_results.map((slotResult: SlotResultDetail, index: number) => (
                       <SlotResultCard key={index} result={slotResult} onFileClick={(fid, fname, pc) => setViewerFile({ fileId: fid, fileName: fname, personCount: pc })} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {aiResult.details?.crossValidations && aiResult.details.crossValidations.length > 0 && (
+                <div>
+                  <p className="font-body-small text-[#868e96] mb-[12px]">교차검증 결과</p>
+                  <div className="space-y-[12px]">
+                    {aiResult.details.crossValidations.map((cv: CrossValidationResult, index: number) => (
+                      <CrossValidationCard key={index} result={cv} />
                     ))}
                   </div>
                 </div>
@@ -887,6 +898,57 @@ function FileViewerModal({ fileId, fileName, personCount, onClose }: { fileId: n
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function CrossValidationCard({ result }: { result: CrossValidationResult }) {
+  const verdict = result.verdict as Verdict;
+  const title = result.displayNames.join(' × ');
+  const hasReasons = result.reasons && result.reasons.length > 0;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="rounded-[12px] border overflow-hidden" style={VERDICT_CARD_BG[verdict]}>
+      <div
+        className={`flex items-center px-[20px] py-[16px] ${hasReasons ? 'cursor-pointer' : ''}`}
+        onClick={() => hasReasons && setOpen(prev => !prev)}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-[8px]">
+            <svg className="w-[16px] h-[16px] text-[#868e96] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+            <span className="font-title-medium text-[#212529]">{title}</span>
+          </div>
+        </div>
+        <span
+          className="px-[20px] py-[8px] rounded-[8px] font-title-medium flex-shrink-0 ml-[16px]"
+          style={VERDICT_BADGE[verdict]}
+        >
+          {VERDICT_LABELS[verdict]}
+        </span>
+        {hasReasons && (
+          <svg
+            className={`w-[20px] h-[20px] ml-[8px] flex-shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+      {hasReasons && open && (
+        <div className="px-[20px] pb-[16px]">
+          <ul className="space-y-[6px]">
+            {result.reasons.map((reason, index) => (
+              <li key={index} className="flex items-start gap-[8px] font-body-small text-[#868e96]">
+                <span className="w-[4px] h-[4px] bg-[#adb5bd] rounded-full mt-[8px] flex-shrink-0" />
+                {REASON_LABELS[reason] || reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/api/aiRun.ts
+++ b/src/api/aiRun.ts
@@ -46,9 +46,18 @@ export interface ClarificationDetail {
   file_ids: string[];
 }
 
+export interface CrossValidationResult {
+  slots: string[];
+  displayNames: string[];
+  verdict: 'PASS' | 'WARN' | 'NEED_CLARIFY' | 'NEED_FIX';
+  reasons: string[];
+  extras?: Record<string, unknown>;
+}
+
 export interface AiAnalysisDetails {
   slot_results: SlotResultDetail[];
   clarifications: ClarificationDetail[];
+  crossValidations?: CrossValidationResult[];
   extras?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## 변경 요약
- `CrossValidationResult` 타입 정의 및 `AiAnalysisDetails.crossValidations` 필드 추가 (`src/api/aiRun.ts`)
- 진단 상세(`DiagnosticDetailPage`), 결재 상세(`ApprovalDetailPage`), 문서 리뷰(`DocumentReviewPage`) 페이지에 교차검증 결과 카드 섹션 추가
- 슬롯 간 교차 비교 결과를 verdict별 색상 배지(PASS/WARN/NEED_CLARIFY/NEED_FIX)로 표시
- 사유 목록 아코디언 토글 지원

## 관련 이슈
- Closes #404

## 테스트 방법
1. AI 분석이 완료된 진단 건의 상세 페이지 진입
2. AI 분석 결과 영역에 "교차검증 결과" 섹션이 노출되는지 확인
3. 교차검증 카드 클릭 시 사유 목록이 토글되는지 확인
4. 결재 상세, 문서 리뷰 페이지에서도 동일하게 동작하는지 확인
5. `crossValidations`가 빈 배열이거나 없는 경우 섹션이 숨겨지는지 확인

## 명세 준수 체크
- [x] `CrossValidationResult` 타입이 백엔드 응답 스키마와 일치
- [x] verdict 값에 따른 색상 매핑이 기존 SlotResultCard와 동일한 스타일 상수 사용
- [x] REASON_LABELS 상수를 통한 사유 코드 → 한글 변환

## 리뷰 포인트
- 3개 페이지에 `CrossValidationCard` 컴포넌트가 각각 정의되어 있음 (공통 컴포넌트 추출 여부 검토)
- DocumentReviewPage는 하드코딩된 색상값(`#868e96` 등) 사용 중 — 기존 코드 스타일 유지

## TODO / 질문
- [ ] 교차검증 결과가 많을 경우 접기/펼치기 또는 페이지네이션 필요 여부
- [ ] `CrossValidationCard`를 공통 컴포넌트로 추출할지 추후 논의