### PR TITLE
fix: 진단 상세 제출 버튼 비활성 상태 UX 개선

### DIFF
--- a/features/diagnostics/DiagnosticDetailPage.tsx
+++ b/features/diagnostics/DiagnosticDetailPage.tsx
@@ -360,18 +360,26 @@ export default function DiagnosticDetailPage() {
             >
               파일 관리 및 AI 분석
             </button>
-            {isSubmittableStatus && !aiResult && (
-              <span className="font-body-small text-[var(--color-text-tertiary)] self-center">
-                AI 분석을 완료해야 제출할 수 있습니다
-              </span>
-            )}
-            {canSubmit && (
-              <button
-                onClick={() => setShowSubmitModal(true)}
-                className="px-[24px] py-[12px] rounded-[8px] bg-[var(--color-primary-main)] text-white font-title-small hover:opacity-90 transition-colors"
-              >
-                {hasApprovalWorkflow ? '결재자에게 제출' : '수신자에게 제출'}
-              </button>
+            {isSubmittableStatus && (
+              <div className="relative group">
+                <button
+                  onClick={canSubmit ? () => setShowSubmitModal(true) : undefined}
+                  disabled={!canSubmit}
+                  className={`px-[24px] py-[12px] rounded-[8px] font-title-small transition-colors ${
+                    canSubmit
+                      ? 'bg-[var(--color-primary-main)] text-white hover:opacity-90 cursor-pointer'
+                      : 'bg-[var(--color-primary-main)]/40 text-white cursor-not-allowed'
+                  }`}
+                >
+                  {hasApprovalWorkflow ? '결재자에게 제출' : '수신자에게 제출'}
+                </button>
+                {!canSubmit && (
+                  <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-[8px] px-[12px] py-[8px] bg-[var(--color-text-primary)] text-white font-body-small rounded-[8px] whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity">
+                    AI 분석을 완료해야 제출할 수 있습니다
+                    <div className="absolute top-full left-1/2 -translate-x-1/2 border-[6px] border-transparent border-t-[var(--color-text-primary)]" />
+                  </div>
+                )}
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## 변경 요약
- AI 분석 미완료 시 제출 버튼을 숨기는 대신 **disabled 상태**로 항상 표시
- hover 시 **툴팁**으로 "AI 분석을 완료해야 제출할 수 있습니다" 안내
- disabled 상태: `opacity 40%` + `cursor-not-allowed`

## 관련 이슈
- Closes #405

## 테스트 방법
1. 기안자로 로그인 후 진단 상세 페이지 진입 (제출 가능 상태: CREATED/RETURNED/AI_COMPLETED)
2. AI 분석 미완료 상태에서 제출 버튼이 비활성(반투명)으로 표시되는지 확인
3. 비활성 버튼에 마우스 hover 시 툴팁이 나타나는지 확인
4. 비활성 버튼 클릭 시 아무 동작 없는지 확인
5. AI 분석 완료 후 버튼이 활성화되어 정상 제출 가능한지 확인

## 명세 준수 체크
- [x] `isSubmittableStatus` 조건 내에서 `canSubmit` 분기로 활성/비활성 처리
- [x] 기존 제출 모달 동작 유지 (canSubmit=true 시)
- [x] 색상/폰트 등 디자인 시스템 변수 사용

## 리뷰 포인트
- 툴팁이 CSS-only(`group-hover:opacity-100`)로 구현됨 — 접근성(aria) 고려 필요 여부
- `bg-[var(--color-primary-main)]/40` Tailwind opacity modifier 사용

## TODO / 질문
- [ ] 결재 상세 페이지에도 동일 패턴 적용 필요 여부 확인
- [ ] 모바일에서 hover 동작이 안 되므로 터치 시 툴팁 처리 검토