### PR TITLE
fix: 헤더 시스템 제목 텍스트 오버플로우 수정

### DIFF
--- a/shared/layout/Header.tsx
+++ b/shared/layout/Header.tsx
@@ -145,7 +145,7 @@ export default function Header({ userName, userRole, onToggleSidebar, showMenuBu
   return (
     <div className="bg-[#002554] h-[60px] md:h-[85px] w-full flex items-center justify-between px-[16px] md:px-[30px] shadow-md z-50 relative">
       {/* Left Side */}
-      <div className="flex items-center gap-[12px] md:gap-[24px]">
+      <div className="flex items-center gap-[12px] md:gap-[24px] min-w-0">
         {/* Hamburger Menu (mobile) */}
         {showMenuButton && (
           <button
@@ -169,16 +169,16 @@ export default function Header({ userName, userRole, onToggleSidebar, showMenuBu
         </Link>
 
         {/* Divider */}
-        <div className="hidden md:block h-[24px] w-px bg-white/30" />
+        <div className="hidden md:block h-[24px] w-px bg-white/30 shrink-0" />
 
         {/* System Title */}
-        <p className="hidden md:block font-title-medium text-white whitespace-nowrap">
+        <p className="hidden md:block font-title-medium text-white truncate min-w-0">
           현대중공업 협력사 통합관리시스템
         </p>
       </div>
 
       {/* Right Side */}
-      <div className="flex items-center gap-[12px] md:gap-[24px]">
+      <div className="flex items-center gap-[12px] md:gap-[24px] shrink-0">
         {/* User Info */}
         <div className="flex items-center gap-[8px]">
           <p className="font-body-medium text-white">


### PR DESCRIPTION
## 변경 요약
- 헤더 좌측 영역에 `min-w-0` 추가로 flex child 축소 허용
- 시스템 제목(`현대중공업 협력사 통합관리시스템`)에 `truncate` 적용하여 오버플로우 시 말줄임 처리
- 구분선에 `shrink-0`, 우측 영역에 `shrink-0` 추가하여 아이콘/사용자 정보가 밀리지 않도록 보호

## 관련 이슈
- Closes #406

## 테스트 방법
1. 브라우저 창을 1024px 이하로 줄여서 헤더 확인
2. 시스템 제목이 잘리지 않고 말줄임(...)으로 표시되는지 확인
3. 우측 알림 아이콘/사용자 정보가 밀리거나 줄바꿈 되지 않는지 확인
4. 모바일(md 이하)에서 시스템 제목이 숨겨져 있는지 확인

## 명세 준수 체크
- [x] 기존 헤더 높이/색상/패딩 유지
- [x] md breakpoint 이하에서 시스템 제목 `hidden` 유지
- [x] Tailwind 유틸리티 클래스만 사용

## 리뷰 포인트
- `truncate`는 `overflow-hidden text-ellipsis whitespace-nowrap`의 단축 — 기존 `whitespace-nowrap` 대체

## TODO / 질문
- [ ] 시스템 제목이 잘리는 것이 아닌 반응형 폰트 사이즈 조절이 더 나은지 디자인 확인