### PR TITLE
feat: 진단 파일 페이지 preview 증분 전송 및 상태 관리 개선 (#410)

### DIFF
--- a/src/api/aiRun.ts
+++ b/src/api/aiRun.ts
@@ -29,6 +29,20 @@ export interface SlotResult {
   extractedData?: Record<string, unknown>;
 }
 
+// 슬롯별 extras 타입
+export interface SlotExtras {
+  analysis_message?: string;
+  analysis_detail?: string;
+  reason_descriptions?: string;
+  success_points?: string;
+  issue_points?: string;
+  person_count?: string;
+  person_count_yolo?: string;
+  person_count_llm?: string;
+  person_count_gap?: string;
+  [key: string]: unknown;
+}
+
 // 새 API 응답 타입
 export interface SlotResultDetail {
   slot_name: string;
@@ -37,7 +51,7 @@ export interface SlotResultDetail {
   reasons: string[];
   file_ids: string[];
   file_names: string[];
-  extras?: Record<string, unknown>;
+  extras?: SlotExtras;
 }
 
 export interface ClarificationDetail {
@@ -46,10 +60,16 @@ export interface ClarificationDetail {
   file_ids: string[];
 }
 
+// 최상위 extras 타입
+export interface AnalysisExtras {
+  service_why?: string;
+  [key: string]: unknown;
+}
+
 export interface AiAnalysisDetails {
   slot_results: SlotResultDetail[];
   clarifications: ClarificationDetail[];
-  extras?: Record<string, unknown>;
+  extras?: AnalysisExtras;
 }
 
 export interface AiAnalysisResultResponse {
@@ -71,11 +91,17 @@ export interface AiResultDetailResponse extends AiAnalysisResultResponse {
 
 export const previewAiRun = async (
   diagnosticId: number,
-  fileIds: number[]
+  fileIds: number[],
+  removedFileIds?: string[],
+  packageId?: string
 ): Promise<RunPreviewResponse> => {
   const response = await apiClient.post<BaseResponse<RunPreviewResponse>>(
     `/v1/ai/run/diagnostics/${diagnosticId}/preview`,
-    { fileIds },
+    {
+      fileIds,
+      ...(removedFileIds?.length ? { removedFileIds } : {}),
+      ...(packageId ? { packageId } : {}),
+    },
     { timeout: 35000 }
   );
   return response.data.data;

--- a/src/hooks/useAiRun.ts
+++ b/src/hooks/useAiRun.ts
@@ -7,8 +7,8 @@ import type { ErrorResponse } from '../types/api.types';
 
 export const useAiPreview = () => {
   return useMutation({
-    mutationFn: ({ diagnosticId, fileIds }: { diagnosticId: number; fileIds: number[] }) =>
-      aiRunApi.previewAiRun(diagnosticId, fileIds),
+    mutationFn: ({ diagnosticId, fileIds, removedFileIds, packageId }: { diagnosticId: number; fileIds: number[]; removedFileIds?: string[]; packageId?: string }) =>
+      aiRunApi.previewAiRun(diagnosticId, fileIds, removedFileIds, packageId),
     onError: (error: AxiosError<ErrorResponse>) => {
       handleApiError(error);
     },


### PR DESCRIPTION
## Summary
- previewAiRun 시그니처에 removedFileIds, packageId 파라미터 추가
- Add 버튼 증분 전송, 삭제 시 removedFileIds 방식으로 변경
- sessionStorage로 addedFileIds 저장/복원하여 재진입 시 상태 유지
- 초기 preview 호출 시 addedFileIds에 있는 파일만 전송
- 이번 세션 업로드 파일 auto-add 방지
- SlotExtras, AnalysisExtras 타입 정의 추가

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)