### PR TITLE
fix: 대시보드 외부 리스크 패널 문구 수정 (#415)

### DIFF
--- a/features/dashboard/HomePage.tsx
+++ b/features/dashboard/HomePage.tsx
@@ -260,7 +260,7 @@ function ExternalRiskPanel() {
       {/* Header */}
       <div className="flex items-center justify-between mb-[24px]">
         <p className="font-title-large text-[#212529]">
-          외부 리스크 감지 현황
+          AI 협력사 외부 리스크 감지
         </p>
         <button
           onClick={handleDetectAll}
@@ -273,7 +273,7 @@ function ExternalRiskPanel() {
               분석중...
             </>
           ) : (
-            '전체 재분석'
+            '업데이트'
           )}
         </button>
       </div>


### PR DESCRIPTION
## 변경 요약
대시보드 외부 리스크 패널의 제목과 버튼 텍스트를 기획 명세에 맞게 수정합니다.
- 패널 제목: "외부 리스크 감지 현황" → "AI 협력사 외부 리스크 감지"
- 버튼 텍스트: "전체 재분석" → "업데이트"

## 관련 이슈
- Closes #415

## 테스트 방법
1. 대시보드 접속 (REVIEWER 권한)
2. 우측 "AI 협력사 외부 리스크 감지" 패널 제목 확인
3. "업데이트" 버튼 텍스트 확인

## 명세 준수 체크
- [x] 패널 제목 문구 일치
- [x] 버튼 텍스트 문구 일치

## 리뷰 포인트
- 단순 문구 변경이므로 기능 영향 없음

## TODO / 질문
- 없음