### PR TITLE
fix: 기안 생성 시 기간 자동 설정 타임존 버그 수정 (#418)

### DIFF
--- a/features/diagnostics/DiagnosticCreatePage.tsx
+++ b/features/diagnostics/DiagnosticCreatePage.tsx
@@ -54,18 +54,10 @@ export default function DiagnosticCreatePage() {
       setValue('domainCode', selectedCampaign.domainCode, { shouldValidate: true, shouldDirty: true });
     }
 
-    // 기간 자동 설정
+    // 기간 자동 설정 (캠페인 날짜를 그대로 사용)
     if (selectedCampaign.startDate && selectedCampaign.endDate) {
-      const startDate = new Date(selectedCampaign.startDate);
-      const endDate = new Date(selectedCampaign.endDate);
-
-      const periodStart = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
-      const periodEnd = new Date(endDate.getFullYear(), endDate.getMonth() + 1, 0);
-
-      const formatDate = (d: Date) => d.toISOString().split('T')[0];
-
-      setValue('periodStartDate', formatDate(periodStart), { shouldValidate: true, shouldDirty: true });
-      setValue('periodEndDate', formatDate(periodEnd), { shouldValidate: true, shouldDirty: true });
+      setValue('periodStartDate', selectedCampaign.startDate, { shouldValidate: true, shouldDirty: true });
+      setValue('periodEndDate', selectedCampaign.endDate, { shouldValidate: true, shouldDirty: true });
     }
   }, [selectedCampaignId, campaigns, setValue]);
 


### PR DESCRIPTION
## 변경 요약
캠페인 선택 시 기안 기간(`periodStartDate`/`periodEndDate`)이 하루 밀려 설정되는 버그를 수정합니다.

**Before:** 캠페인 startDate `2025-09-30` → `new Date()` 변환 → 월 첫째 날 계산 → `toISOString()`(UTC) → `2025-08-31`
**After:** 캠페인 startDate `2025-09-30` → 그대로 `2025-09-30` 사용

## 관련 이슈
- Closes #418

## 테스트 방법
1. 기안 생성 페이지(`/diagnostics/new`) 접속
2. 안전보건 캠페인 선택 → 기간이 `2025-09-30` ~ 해당 캠페인 endDate로 표시되는지 확인
3. 컴플라이언스 캠페인 선택 → 기간이 `2025-09-30` ~ 해당 캠페인 endDate로 표시되는지 확인
4. 백엔드 Swagger에서 Campaign API 응답의 startDate/endDate와 프론트 표시값 일치 확인

## 명세 준수 체크
- [x] periodStartDate가 캠페인 startDate와 일치
- [x] periodEndDate가 캠페인 endDate와 일치
- [x] 타임존(KST/UTC) 무관하게 정확한 날짜 표시

## 리뷰 포인트
- `Date` 객체 생성 및 `toISOString()` 로직 전부 제거 → 문자열 그대로 사용으로 타임존 이슈 근본 차단
- 캠페인 API 응답이 `YYYY-MM-DD` 형식임을 전제 (validation schema에서 검증됨)

## TODO / 질문
- 없음